### PR TITLE
Astro 2047 clock style update

### DIFF
--- a/packages/web-components/src/components/rux-clock/rux-clock.scss
+++ b/packages/web-components/src/components/rux-clock/rux-clock.scss
@@ -27,6 +27,7 @@
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
+    height: 3.938rem; //63px
 }
 
 :host([hidden]) {
@@ -44,12 +45,8 @@
     align-items: center;
     font-family: var(--font-family-mono);
     font-weight: 700;
-
     border: 1px solid var(--clock-border-color);
-
     background-color: var(--clock-background-color);
-    // margin-bottom: 0.25rem;
-
     white-space: nowrap;
     overflow-y: hidden;
     text-overflow: ellipsis;
@@ -85,8 +82,4 @@
 
 .rux-clock__aos {
     margin-left: 1em;
-}
-
-.rux-clock__los {
-    margin-left: 0.5em;
 }

--- a/packages/web-components/src/components/rux-clock/rux-clock.scss
+++ b/packages/web-components/src/components/rux-clock/rux-clock.scss
@@ -48,7 +48,7 @@
     border: 1px solid var(--clock-border-color);
 
     background-color: var(--clock-background-color);
-    margin-bottom: 0.25rem;
+    // margin-bottom: 0.25rem;
 
     white-space: nowrap;
     overflow-y: hidden;
@@ -71,10 +71,12 @@
 .rux-clock__segment__label {
     font-size: 0.875rem;
     color: var(--clock-label-color);
-}
-
-.rux-clock__day-of-the-year .rux-clock__segment__value {
-    border-right: none;
+    background: var(--clock-border-color);
+    border: 1px solid var(--clock-border-color);
+    width: -moz-available;
+    width: -webkit-fill-available;
+    width: fill-available;
+    text-align: center;
 }
 
 .rux-clock__segment--secondary .rux-clock__segment__value {


### PR DESCRIPTION
## Brief Description

Clock got a design update in Figma: https://www.figma.com/file/ZtHeSWpISd8hJjN46uY9pm/Astro-UX-Design-System?node-id=5314%3A130533
This updates clock styles.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2047

## Related Issue

## General Notes

Removes the `border-right: none` on  date, adds background to sublabel, removes margin on date/time so sublabel is now flush with it. Removes the margin-left on aos so that aos/los are flush as well. Adds a 3.938rem (63px) height for clock component. 

## Motivation and Context

Updates clock styles to match Figma.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
