### PR TITLE
Astro 1826 classification default

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -96,7 +96,7 @@ export namespace Components {
          */
         classification: Classification
         /**
-         * Allows additional text labels to be added to the a marking
+         * Allows additional text labels to be added to the marking
          */
         label?: string
         /**
@@ -15981,7 +15981,7 @@ declare namespace LocalJSX {
          */
         classification?: Classification
         /**
-         * Allows additional text labels to be added to the a marking
+         * Allows additional text labels to be added to the marking
          */
         label?: string
         /**

--- a/packages/web-components/src/components/rux-classification-marking/rux-classification-marking.tsx
+++ b/packages/web-components/src/components/rux-classification-marking/rux-classification-marking.tsx
@@ -69,9 +69,6 @@ export class RuxClassificationMarking {
         }
 
         const text = markings[this.type][this.classification]
-        if (!text) {
-            return 'Select a Classification Marking'
-        }
         return text
     }
 

--- a/packages/web-components/src/components/rux-classification-marking/rux-classification-marking.tsx
+++ b/packages/web-components/src/components/rux-classification-marking/rux-classification-marking.tsx
@@ -18,7 +18,7 @@ export class RuxClassificationMarking {
      */
     @Prop({ reflect: true }) classification: Classification = 'unclassified'
     /**
-     * Allows additional text labels to be added to the a marking
+     * Allows additional text labels to be added to the marking
      */
     @Prop() label?: string
     /**
@@ -69,9 +69,6 @@ export class RuxClassificationMarking {
         }
 
         const text = markings[this.type][this.classification]
-        if (!text) {
-            return 'Select a Classification Marking'
-        }
         return text
     }
 

--- a/packages/web-components/src/components/rux-classification-marking/rux-classification-marking.tsx
+++ b/packages/web-components/src/components/rux-classification-marking/rux-classification-marking.tsx
@@ -69,6 +69,9 @@ export class RuxClassificationMarking {
         }
 
         const text = markings[this.type][this.classification]
+        if (!text) {
+            return 'Select a Classification Marking'
+        }
         return text
     }
 

--- a/packages/web-components/src/components/rux-classification-marking/test/rux-classification-marking.spec.tsx
+++ b/packages/web-components/src/components/rux-classification-marking/test/rux-classification-marking.spec.tsx
@@ -130,7 +130,7 @@ describe('rux-classification-marking banners', () => {
         expect(page.root).toEqualHtml(`
       <rux-classification-marking classification="notapprovedoption">
         <mock:shadow-root>
-          <div class="rux-classification rux-classification--banner">Select a Classification Marking</div>
+          <div class="rux-classification rux-classification--banner"></div>
           <slot></slot>
         </mock:shadow-root>
       </rux-classification-marking>
@@ -237,7 +237,7 @@ describe('rux-classification-marking tags', () => {
         expect(page.root).toEqualHtml(`
       <rux-classification-marking classification="notapprovedoption" tag>
         <mock:shadow-root>
-          <div class="rux-classification rux-classification--tag">Select a Classification Marking</div>
+          <div class="rux-classification rux-classification--tag"></div>
           <slot></slot>
         </mock:shadow-root>
       </rux-classification-marking>

--- a/packages/web-components/src/stories/classification-marking.stories.mdx
+++ b/packages/web-components/src/stories/classification-marking.stories.mdx
@@ -67,7 +67,8 @@ export const WithLabel = (args) => {
 <Canvas>
     <Story
         args={{
-            label: 'customlabel',
+            classification: 'unclassified',
+            label: ' customlabel',
         }}
         name="With Label"
     >

--- a/packages/web-components/src/stories/classification-marking.stories.mdx
+++ b/packages/web-components/src/stories/classification-marking.stories.mdx
@@ -23,13 +23,20 @@ export const Default = (args) => {
         <div
             style="display: flex; flex-flow: column; justify-content: center; margin-bottom:50px; position: relative;"
         >
-            <rux-classification-marking> </rux-classification-marking>
+            <rux-classification-marking
+                classification="${args.classification}"
+                .label="${args.label}"
+                ?tag="${args.tag}"
+            >
+            </rux-classification-marking>
         </div>
     `
 }
 
 <Canvas>
-    <Story name="Default">{Default.bind()}</Story>
+    <Story args={{ classification: 'unclassified' }} name="Default">
+        {Default.bind()}
+    </Story>
 </Canvas>
 
 ## API

--- a/packages/web-components/src/stories/classification-marking.stories.mdx
+++ b/packages/web-components/src/stories/classification-marking.stories.mdx
@@ -23,12 +23,7 @@ export const Default = (args) => {
         <div
             style="display: flex; flex-flow: column; justify-content: center; margin-bottom:50px; position: relative;"
         >
-            <rux-classification-marking
-                classification="${args.classification}"
-                .label="${args.label}"
-                ?tag="${args.tag}"
-            >
-            </rux-classification-marking>
+            <rux-classification-marking> </rux-classification-marking>
         </div>
     `
 }


### PR DESCRIPTION
## Brief Description

In SB, default classification marking read `Select a classification marking`. This changes the SB so that it defaults to `unclassfied` correctly.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-1826

## Related Issue

## General Notes

Removed the args declarations in SB. Because `args.classification` was undefined it was hitting the text fallback in rux-classification-banner. 
The text fallback (line 71 in .tsx) simply changes the label to be `Select a classification marking` if the classification passed in isn't valid.

## Motivation and Context

Makes the default banner in SB correct.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
