### PR TITLE
docs(sb): added codesandboxes dir, copied sandboxes

### DIFF
--- a/packages/web-components/src/stories/astro-sandboxes/forms/html/index.html
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/html/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+        <title>Astro</title>
+        <link rel="preconnect" href="https://fonts.gstatic.com" />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400&family=Roboto:wght@200;300;400;500;600;800&display=swap"
+            rel="stylesheet"
+        />
+        <link
+            rel="stylesheet"
+            href="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
+        />
+        <script
+            type="module"
+            src="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
+        ></script>
+        <style>
+            form > div {
+                margin-bottom: 1rem;
+            }
+        </style>
+    </head>
+    <body>
+        <div style="width: 60%; margin: auto">
+            <form style="padding: 1rem" method="POST" action="/">
+                <div>
+                    <rux-input name="firstName" label="First Name"></rux-input>
+                </div>
+                <div>
+                    <rux-input name="lastName" label="Last Name"></rux-input>
+                </div>
+                <div>
+                    <rux-input
+                        name="email"
+                        type="email"
+                        label="Email"
+                    ></rux-input>
+                </div>
+                <div>
+                    <rux-select name="country" label="Country / Region">
+                        <option value="USA">United States</option>
+                        <option value="Canada">Canada</option>
+                    </rux-select>
+                </div>
+                <div>
+                    <rux-checkbox-group label="Things">
+                        <rux-checkbox name="things" value="comments">
+                            Comments
+                        </rux-checkbox>
+                        <rux-checkbox name="things" value="offers">
+                            Offers
+                        </rux-checkbox>
+                        <rux-checkbox name="things" value="events">
+                            Events
+                        </rux-checkbox>
+                    </rux-checkbox-group>
+                </div>
+                <div>
+                    <rux-radio-group label="Options">
+                        <rux-radio name="options" value="everything">
+                            Everything
+                        </rux-radio>
+                        <rux-radio name="options" value="same">
+                            Same
+                        </rux-radio>
+                        <rux-radio name="options" value="none">
+                            None
+                        </rux-radio>
+                    </rux-radio-group>
+                </div>
+                <div>
+                    <rux-slider name="range" label="A Range"> </rux-slider>
+                </div>
+                <div class="col-span-6 ml-auto">
+                    <rux-button type="submit">Submit</rux-button>
+                </div>
+            </form>
+        </div>
+    </body>
+</html>

--- a/packages/web-components/src/stories/astro-sandboxes/forms/html/package.json
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/html/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "astro-html-basic-form-pattern",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.html",
+    "scripts": {
+        "start": "serve",
+        "build": "echo This is a static template, there is no bundler or bundling involved!"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/codesandbox-app/static-template.git"
+    },
+    "keywords": [],
+    "author": "Ives van Hoorne",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/codesandbox-app/static-template/issues"
+    },
+    "homepage": "https://github.com/codesandbox-app/static-template#readme",
+    "devDependencies": {
+        "serve": "^11.2.0"
+    }
+}

--- a/packages/web-components/src/stories/astro-sandboxes/forms/react/.codesandbox/workspace.json
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/react/.codesandbox/workspace.json
@@ -1,0 +1,8 @@
+{
+    "responsive-preview": {
+        "Mobile": [320, 675],
+        "Tablet": [1024, 765],
+        "Desktop": [1400, 800],
+        "Desktop  HD": [1920, 1080]
+    }
+}

--- a/packages/web-components/src/stories/astro-sandboxes/forms/react/package.json
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/react/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "astro-react-form",
+    "version": "1.0.0",
+    "description": "",
+    "keywords": [],
+    "main": "src/index.js",
+    "dependencies": {
+        "@astrouxds/astro-web-components": "0.0.15",
+        "@astrouxds/react": "0.0.6",
+        "react": "17.0.2",
+        "react-dom": "17.0.2",
+        "react-scripts": "4.0.0"
+    },
+    "devDependencies": {
+        "@babel/runtime": "7.13.8",
+        "typescript": "4.1.3"
+    },
+    "scripts": {
+        "start": "react-scripts start",
+        "build": "react-scripts build",
+        "test": "react-scripts test --env=jsdom",
+        "eject": "react-scripts eject"
+    },
+    "browserslist": [
+        ">0.2%",
+        "not dead",
+        "not ie <= 11",
+        "not op_mini all"
+    ]
+}

--- a/packages/web-components/src/stories/astro-sandboxes/forms/react/public/index.html
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/react/public/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, shrink-to-fit=no"
+        />
+        <meta name="theme-color" content="#000000" />
+        <!--
+      manifest.json provides metadata used when your web app is added to the
+      homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
+    -->
+        <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+        <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+        <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+        <title>React App</title>
+    </head>
+
+    <body>
+        <noscript> You need to enable JavaScript to run this app. </noscript>
+        <div id="root"></div>
+        <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    --></body>
+</html>

--- a/packages/web-components/src/stories/astro-sandboxes/forms/react/src/App.js
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/react/src/App.js
@@ -1,0 +1,120 @@
+import './styles.css'
+import { React, useState } from 'react'
+import {
+    RuxInput,
+    RuxSelect,
+    RuxCheckbox,
+    RuxCheckboxGroup,
+    RuxRadio,
+    RuxRadioGroup,
+    RuxSlider,
+    RuxButton,
+} from '@astrouxds/react'
+export default function App() {
+    const [firstName, setFirstName] = useState('')
+    const [lastName, setLastName] = useState('')
+    const [email, setEmail] = useState('')
+    const [countryRegion, setCountryRegion] = useState('United States')
+    const [options, setOptions] = useState('')
+    const [range, setRange] = useState(50)
+    const [things, setThings] = useState([])
+
+    const handleSubmit = (e) => {
+        e.preventDefault()
+        alert(`
+     First Name: ${firstName} \n
+     Last Name: ${lastName} \n
+     Email: ${email} \n
+     Country/Region: ${countryRegion} \n
+     Options: ${options} \n
+     Things: ${things} \n
+     Range: ${range} \n
+    `)
+    }
+    const handleThings = (e) => {
+        let arr = things
+        arr.push(e.target.value)
+        let unique = [...new Set(arr)]
+        setThings(unique)
+    }
+    return (
+        <div className="container">
+            <form onSubmit={(e) => handleSubmit(e)}>
+                <div>
+                    <RuxInput
+                        label="First Name"
+                        value={firstName}
+                        onRux-input={(e) => setFirstName(e.target.value)}
+                    />
+                </div>
+                <div>
+                    <RuxInput
+                        label="Last Name"
+                        value={lastName}
+                        onRux-input={(e) => setLastName(e.target.value)}
+                    />
+                </div>
+                <div>
+                    <RuxInput
+                        label="Email"
+                        value={email}
+                        onRux-input={(e) => setEmail(e.target.value)}
+                    />
+                </div>
+                <div>
+                    <RuxSelect
+                        label="Country/Region"
+                        onRux-change={(e) => setCountryRegion(e.target.value)}
+                    >
+                        <option value="Canada">Canada</option>
+                        <option value="United States">United States</option>
+                    </RuxSelect>
+                </div>
+                <div>
+                    <RuxCheckboxGroup label="Things">
+                        <RuxCheckbox
+                            value="comments"
+                            onRux-change={(e) => handleThings(e)}
+                        >
+                            Comments
+                        </RuxCheckbox>
+                        <RuxCheckbox
+                            value="offers"
+                            onRux-change={(e) => handleThings(e)}
+                        >
+                            Offers
+                        </RuxCheckbox>
+                        <RuxCheckbox
+                            value="events"
+                            onRux-change={(e) => handleThings(e)}
+                        >
+                            Events
+                        </RuxCheckbox>
+                    </RuxCheckboxGroup>
+                </div>
+                <div>
+                    <RuxRadioGroup
+                        label="Options"
+                        onRux-change={(e) => setOptions(e.target.value)}
+                    >
+                        <RuxRadio label="Everything" value="everything" />
+                        <RuxRadio label="Same" value="same" />
+                        <RuxRadio label="None" value="none" />
+                    </RuxRadioGroup>
+                </div>
+                <div>
+                    <RuxSlider
+                        label="A Range"
+                        value={range}
+                        onRux-input={(e) => setRange(e.target.value)}
+                    />
+                </div>
+                <div>
+                    <RuxButton type="submit" size="large">
+                        Submit
+                    </RuxButton>
+                </div>
+            </form>
+        </div>
+    )
+}

--- a/packages/web-components/src/stories/astro-sandboxes/forms/react/src/index.js
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/react/src/index.js
@@ -1,0 +1,13 @@
+import { StrictMode } from 'react'
+import ReactDOM from 'react-dom'
+import '@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css'
+
+import App from './App'
+
+const rootElement = document.getElementById('root')
+ReactDOM.render(
+    <StrictMode>
+        <App />
+    </StrictMode>,
+    rootElement
+)

--- a/packages/web-components/src/stories/astro-sandboxes/forms/react/src/styles.css
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/react/src/styles.css
@@ -1,0 +1,11 @@
+.container {
+    /* text-align: center; */
+    width: 60%;
+    margin: auto;
+}
+form {
+    padding: 1rem;
+}
+div {
+    margin-bottom: 20px;
+}

--- a/packages/web-components/src/stories/astro-sandboxes/forms/svelte/App.svelte
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/svelte/App.svelte
@@ -1,0 +1,14 @@
+<script>
+	import Form from "./Form.svelte";
+</script>
+
+<style>
+  main {
+    font-family: sans-serif;
+    text-align: center;
+  }
+</style>
+
+<main>
+	<Form />
+</main>

--- a/packages/web-components/src/stories/astro-sandboxes/forms/svelte/Form.svelte
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/svelte/Form.svelte
@@ -1,0 +1,74 @@
+<script>
+  let count = 0;
+
+  function handleClick() {
+    count += 1;
+  }
+</script>
+
+<div style="width: 60%; margin: auto;">
+  <form style="padding: 1rem;" method="POST" action="/">
+    <div>
+      <rux-input
+        name="firstName"
+        label="First Name"
+      ></rux-input>
+    </div>
+    <div>
+      <rux-input name="lastName" label="Last Name"></rux-input>
+    </div>
+    <div>
+      <rux-input
+        name="email"
+        type="email"
+        label="Email"
+      ></rux-input>
+    </div>
+    <div>
+      <rux-select name="country" label="Country / Region">
+        <option value="USA">United States</option>
+        <option value="Canada">Canada</option>
+      </rux-select>
+    </div>
+    <div>
+      <rux-checkbox-group label="Things">
+        <rux-checkbox name="things" value="comments">
+          Comments
+        </rux-checkbox>
+        <rux-checkbox name="things" value="offers">
+          Offers
+        </rux-checkbox>
+        <rux-checkbox name="things" value="events">
+          Events
+        </rux-checkbox>
+      </rux-checkbox-group>
+    </div>
+    <div>
+      <rux-radio-group label="Options">
+        <rux-radio name="options" value="everything">
+          Everything
+        </rux-radio>
+        <rux-radio name="options" value="same">
+          Same
+        </rux-radio>
+        <rux-radio name="options" value="none">
+          None
+        </rux-radio>
+      </rux-radio-group>
+    </div>
+    <div>
+      <rux-slider name="range" label="A Range"> </rux-slider>
+    </div>
+    <div>
+      <rux-button type="submit">Submit</rux-button>
+    </div>
+  </form>
+</div>
+
+
+<style>
+  div {
+    margin-bottom: 20px;
+  }
+</style>
+

--- a/packages/web-components/src/stories/astro-sandboxes/forms/svelte/index.js
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/svelte/index.js
@@ -1,0 +1,7 @@
+import App from './App.svelte'
+
+const app = new App({
+    target: document.body,
+})
+
+export default app

--- a/packages/web-components/src/stories/astro-sandboxes/forms/svelte/package.json
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/svelte/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "astro-form-in-svelte",
+    "version": "1.0.0",
+    "devDependencies": {
+        "npm-run-all": "^4.1.5",
+        "rollup": "^1.10.1",
+        "rollup-plugin-commonjs": "^9.3.4",
+        "rollup-plugin-node-resolve": "^4.2.3",
+        "rollup-plugin-svelte": "^6.1.1",
+        "rollup-plugin-terser": "^4.0.4",
+        "sirv-cli": "^0.3.1"
+    },
+    "dependencies": {
+        "@astrouxds/astro-web-components": "0.0.16",
+        "svelte": "^3.32.3"
+    },
+    "scripts": {
+        "build": "rollup -c",
+        "autobuild": "rollup -c -w",
+        "dev": "run-p start:dev autobuild",
+        "start": "sirv public",
+        "start:dev": "sirv public --dev"
+    },
+    "keywords": [],
+    "description": "Form Example using Astro Component Library"
+}

--- a/packages/web-components/src/stories/astro-sandboxes/forms/svelte/public/index.html
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/svelte/public/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf8" />
+        <meta name="viewport" content="width=device-width" />
+
+        <title>Svelte Astro Form Example</title>
+
+        <link
+            href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400&family=Roboto:wght@200;300;400;500;600;800&display=swap"
+            rel="stylesheet"
+        />
+        <link
+            rel="stylesheet"
+            href="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
+        />
+        <script
+            type="module"
+            src="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
+        ></script>
+    </head>
+
+    <body>
+        <script src="bundle.js"></script>
+    </body>
+</html>

--- a/packages/web-components/src/stories/astro-sandboxes/forms/svelte/rollup.config.js
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/svelte/rollup.config.js
@@ -1,0 +1,42 @@
+// this file will not afect the sandbox but will
+// afect the deployment and dowload
+
+import svelte from 'rollup-plugin-svelte'
+import resolve from 'rollup-plugin-node-resolve'
+import commonjs from 'rollup-plugin-commonjs'
+import { terser } from 'rollup-plugin-terser'
+
+const production = !process.env.ROLLUP_WATCH
+
+export default {
+    input: 'index.js',
+    output: {
+        sourcemap: true,
+        format: 'iife',
+        name: 'app',
+        file: 'public/bundle.js',
+    },
+    plugins: [
+        svelte({
+            // enable run-time checks when not in production
+            dev: !production,
+            // we'll extract any component CSS out into
+            // a separate file — better for performance
+            css: (css) => {
+                css.write('public/bundle.css')
+            },
+        }),
+
+        // If you have external dependencies installed from
+        // npm, you'll most likely need these plugins. In
+        // some cases you'll need additional configuration —
+        // consult the documentation for details:
+        // https://github.com/rollup/rollup-plugin-commonjs
+        resolve(),
+        commonjs(),
+
+        // If we're building for production (npm run build
+        // instead of npm run dev), minify
+        production && terser(),
+    ],
+}

--- a/packages/web-components/src/stories/astro-sandboxes/forms/vue/.codesandbox/workspace.json
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/vue/.codesandbox/workspace.json
@@ -1,0 +1,8 @@
+{
+    "responsive-preview": {
+        "Mobile": [320, 675],
+        "Tablet": [1024, 765],
+        "Desktop": [1400, 800],
+        "Desktop  HD": [1920, 1080]
+    }
+}

--- a/packages/web-components/src/stories/astro-sandboxes/forms/vue/package.json
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/vue/package.json
@@ -1,0 +1,49 @@
+{
+    "name": "astro-vue-basic-form-pattern",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "serve": "vue-cli-service serve",
+        "build": "vue-cli-service build",
+        "lint": "vue-cli-service lint"
+    },
+    "dependencies": {
+        "@astrouxds/astro-web-components": "0.0.16",
+        "@vue/cli-plugin-babel": "4.1.1",
+        "vue": "2.6.14"
+    },
+    "devDependencies": {
+        "@vue/cli-plugin-eslint": "4.1.1",
+        "@vue/cli-service": "4.1.1",
+        "babel-eslint": "^10.0.3",
+        "eslint": "^6.7.2",
+        "eslint-plugin-vue": "^6.0.1",
+        "vue-template-compiler": "^2.6.11"
+    },
+    "eslintConfig": {
+        "root": true,
+        "env": {
+            "node": true
+        },
+        "extends": [
+            "plugin:vue/essential",
+            "eslint:recommended"
+        ],
+        "rules": {},
+        "parserOptions": {
+            "parser": "babel-eslint"
+        }
+    },
+    "postcss": {
+        "plugins": {
+            "autoprefixer": {}
+        }
+    },
+    "browserslist": [
+        "> 1%",
+        "last 2 versions",
+        "not ie <= 8"
+    ],
+    "keywords": [],
+    "description": ""
+}

--- a/packages/web-components/src/stories/astro-sandboxes/forms/vue/public/index.html
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/vue/public/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+        <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
+        <title>codesandbox</title>
+    </head>
+    <body>
+        <noscript>
+            <strong
+                >We're sorry but codesandbox doesn't work properly without
+                JavaScript enabled. Please enable it to continue.</strong
+            >
+        </noscript>
+        <div id="app"></div>
+        <!-- built files will be auto injected -->
+    </body>
+</html>

--- a/packages/web-components/src/stories/astro-sandboxes/forms/vue/src/App.vue
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/vue/src/App.vue
@@ -1,0 +1,160 @@
+<template>
+    <div style="width: 60%; margin: auto">
+        <form style="padding: 1rem" @submit.prevent="submit()">
+            <div>
+                <rux-input
+                    :value="form.firstName"
+                    @rux-input="form.firstName = $event.target.value"
+                    label="First Name"
+                ></rux-input>
+            </div>
+
+            <div>
+                <rux-input
+                    :value="form.lastName"
+                    @rux-input="form.lastName = $event.target.value"
+                    label="Last Name"
+                ></rux-input>
+            </div>
+
+            <div>
+                <rux-input
+                    :value="form.email"
+                    @rux-input="form.email = $event.target.value"
+                    type="email"
+                    label="Email"
+                ></rux-input>
+            </div>
+
+            <div>
+                <rux-select
+                    label="Country / Region"
+                    :value="form.country"
+                    @rux-change="form.country = $event.target.value"
+                >
+                    <option value="USA">United States</option>
+                    <option value="Canada">Canada</option>
+                </rux-select>
+            </div>
+
+            <div>
+                <rux-checkbox-group label="Things">
+                    <rux-checkbox
+                        value="comments"
+                        :checked="form.things.includes('comments')"
+                        @rux-change="
+                            updateThings('comments', $event.target.checked)
+                        "
+                    >
+                        Comments
+                    </rux-checkbox>
+                    <rux-checkbox
+                        value="offers"
+                        :checked="form.things.includes('offers')"
+                        @rux-change="
+                            updateThings('offers', $event.target.checked)
+                        "
+                    >
+                        Offers
+                    </rux-checkbox>
+                    <rux-checkbox
+                        value="events"
+                        :checked="form.things.includes('events')"
+                        @rux-change="
+                            updateThings('events', $event.target.checked)
+                        "
+                    >
+                        Events
+                    </rux-checkbox>
+                </rux-checkbox-group>
+            </div>
+
+            <div>
+                <rux-radio-group
+                    :value="form.options"
+                    @rux-change="form.options = $event.target.value"
+                    label="Options"
+                >
+                    <rux-radio
+                        value="everything"
+                        :checked="form.options === 'everything'"
+                    >
+                        Everything
+                    </rux-radio>
+                    <rux-radio value="same" :checked="form.options === 'same'">
+                        Same
+                    </rux-radio>
+                    <rux-radio value="none" :checked="form.options === 'none'">
+                        None
+                    </rux-radio>
+                </rux-radio-group>
+            </div>
+
+            <div>
+                <rux-slider
+                    :value="form.range"
+                    @rux-input="form.range = $event.target.value"
+                    label="A Range"
+                >
+                </rux-slider>
+            </div>
+
+            <div class="col-span-6 ml-auto">
+                <rux-button :disabled="loading" type="submit"
+                    >Submit</rux-button
+                >
+            </div>
+        </form>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'App',
+    data() {
+        return {
+            loading: false,
+            form: {
+                firstName: '',
+                lastName: '',
+                email: '',
+                country: 'USA',
+                options: 'none',
+                things: [],
+                range: '',
+            },
+        }
+    },
+    methods: {
+        submit() {
+            this.loading = true
+
+            // Mock HTTP request
+            setTimeout(() => {
+                this.loading = false
+                alert(JSON.stringify(this.form))
+            }, 100)
+        },
+        /**
+         * Manually handle checkbox form binding
+         */
+        updateThings(value, checked) {
+            if (checked) {
+                this.form.things = this.form.things.concat(value)
+            } else {
+                console.log('not checked')
+
+                this.form.things = this.form.things.filter(
+                    (item) => item !== value
+                )
+            }
+        },
+    },
+}
+</script>
+
+<style scoped>
+form > div {
+    margin-bottom: 1rem;
+}
+</style>

--- a/packages/web-components/src/stories/astro-sandboxes/forms/vue/src/main.js
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/vue/src/main.js
@@ -1,0 +1,19 @@
+import Vue from 'vue'
+import App from './App.vue'
+import '@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css'
+import {
+    applyPolyfills,
+    defineCustomElements,
+} from '@astrouxds/astro-web-components/loader'
+
+Vue.config.productionTip = false
+Vue.config.ignoredElements = [/rux-\w*/]
+
+// // Bind the custom elements to the window object
+applyPolyfills().then(() => {
+    defineCustomElements()
+})
+
+new Vue({
+    render: (h) => h(App),
+}).$mount('#app')

--- a/packages/web-components/src/stories/astro-sandboxes/sign-in/index.css
+++ b/packages/web-components/src/stories/astro-sandboxes/sign-in/index.css
@@ -1,0 +1,23 @@
+form {
+    margin: 0 auto;
+    max-width: 330px;
+    display: block;
+}
+.group {
+    margin-bottom: 2.25rem;
+}
+.field {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: flex-start;
+}
+.checkbox {
+    margin: 0.5rem 0 1rem 0 !important;
+    line-height: 1.2;
+}
+rux-input {
+    width: 100%;
+}
+.sign-in-btn {
+    margin-left: auto;
+}

--- a/packages/web-components/src/stories/astro-sandboxes/sign-in/index.html
+++ b/packages/web-components/src/stories/astro-sandboxes/sign-in/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+
+        <link rel="stylesheet" href="index.css" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400&family=Roboto:wght@200;300;400;500;600;800&display=swap"
+            rel="stylesheet"
+        />
+        <link
+            rel="stylesheet"
+            href="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
+        />
+        <script
+            type="module"
+            src="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
+        ></script>
+        <noscript>
+            <style type="text/css">
+                #show {
+                    display: none;
+                }
+            </style>
+        </noscript>
+        <title>Static Template</title>
+    </head>
+    <body>
+        <form id="rux-form">
+            <div class="group">
+                <div class="field">
+                    <rux-input
+                        id="email"
+                        placeholder="Email@astro.com"
+                        label="Email"
+                        type="email"
+                        rux-blur="{handleValidation()}"
+                    ></rux-input>
+                </div>
+            </div>
+            <div class="group">
+                <div class="field">
+                    <rux-input
+                        id="pw"
+                        label="Password"
+                        type="password"
+                    ></rux-input>
+                </div>
+                <div class="field">
+                    <rux-checkbox class="checkbox">Remember me</rux-checkbox>
+                </div>
+            </div>
+            <div class="field">
+                <rux-button id="sign-in-btn" class="sign-in-btn" type="submit"
+                    >Sign in</rux-button
+                >
+            </div>
+        </form>
+        <script>
+            const emailField = document.getElementById('email')
+            const pwField = document.getElementById('pw')
+            const form = document.getElementById('rux-form')
+            let pwValid = false
+            let emailValid = false
+
+            function validateEmail(email) {
+                const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+                return re.test(String(email).toLowerCase())
+            }
+            emailField.addEventListener('rux-blur', () => {
+                if (validateEmail(emailField.value)) {
+                    emailField.setAttribute('error-text', '')
+                    emailValid = true
+                } else {
+                    emailField.setAttribute(
+                        'error-text',
+                        'That email is not valid.'
+                    )
+                    emailValid = false
+                }
+            })
+            pwField.addEventListener('rux-blur', () => {
+                if (pwField.value !== '') {
+                    pwField.setAttribute('error-text', '')
+                    pwValid = true
+                } else {
+                    pwField.setAttribute(
+                        'error-text',
+                        'Please enter your password.'
+                    )
+                    pwValid = false
+                }
+            })
+            form.addEventListener('submit', (e) => {
+                e.preventDefault()
+                if (!pwValid || !emailValid) {
+                    alert('Please enter a valid email and password.')
+                }
+            })
+        </script>
+    </body>
+</html>

--- a/packages/web-components/src/stories/astro-sandboxes/sign-in/package.json
+++ b/packages/web-components/src/stories/astro-sandboxes/sign-in/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "rux-sign-in-template",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.html",
+    "scripts": {
+        "start": "serve",
+        "build": "echo This is a static template, there is no bundler or bundling involved!"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/codesandbox-app/static-template.git"
+    },
+    "keywords": [],
+    "author": "Ives van Hoorne",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/codesandbox-app/static-template/issues"
+    },
+    "homepage": "https://github.com/codesandbox-app/static-template#readme",
+    "devDependencies": {
+        "serve": "^11.2.0"
+    }
+}


### PR DESCRIPTION
## Brief Description

Moves the code currently used in codesandbox to a new dir in web-components /src/stories/astro-sandboxes
This way we can manage the codesandbox examples in our repo making it much easier to maintain. 
After this is merged, I will create another PR that imports the relevant directory's into code sandbox and update the iframes on the stories. 

I copied the code and project structure from the existing codesandbox's, so some of it may not actually be neeeded.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2181

## Related Issue

## General Notes

The reason this ticket needs two PR's is one to create the directory with the codesandbox code, and two to link the newly created directory to codesandbox and update the iframes. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
