### PR TITLE
Astro 2232 missing value accessors

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astrouxds/angular",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "Astro Web Components Angular Wrapper",
   "license": "MIT",
   "repository": {

--- a/packages/angular/src/directives/text-value-accessor.ts
+++ b/packages/angular/src/directives/text-value-accessor.ts
@@ -5,11 +5,10 @@ import { ValueAccessor } from './value-accessor';
 
 @Directive({
   /* tslint:disable-next-line:directive-selector */
-  selector: 'rux-input, rux-textarea, rux-radio-group, rux-radio',
+  selector: 'rux-input, rux-textarea, rux-slider, rux-radio-group, rux-select',
   host: {
     '(ruxinput)': 'handleChangeEvent($event.target.value)',
-    '(ruxchange)': 'handleChangeEvent($event.target.value)',
-    '(ruxblur)': 'handleChangeEvent($event.target.value)'
+    '(ruxchange)': 'handleChangeEvent($event.target.value)'
   },
   providers: [
     {

--- a/packages/web-components/wrapper-bindings/angular.bindings.ts
+++ b/packages/web-components/wrapper-bindings/angular.bindings.ts
@@ -2,7 +2,7 @@ import { ValueAccessorConfig } from '@stencil/angular-output-target'
 
 export const angularValueAccessorBindings: ValueAccessorConfig[] = [
     {
-        elementSelectors: ['rux-input', 'rux-textarea'],
+        elementSelectors: ['rux-input', 'rux-textarea', 'rux-slider'],
         event: 'ruxinput',
         targetAttr: 'value',
         type: 'text',
@@ -14,15 +14,9 @@ export const angularValueAccessorBindings: ValueAccessorConfig[] = [
         type: 'boolean',
     },
     {
-        elementSelectors: ['rux-radio-group'],
+        elementSelectors: ['rux-radio-group', 'rux-select'],
         event: 'ruxchange',
         targetAttr: 'value',
         type: 'text',
-    },
-    {
-        elementSelectors: ['rux-radio'],
-        event: 'ruxblur',
-        targetAttr: 'value',
-        type: 'text',
-    },
+    }
 ]


### PR DESCRIPTION
## Brief Description

adds missing value accessors for select and slider so they can be used in forms
removes single radio accessor since its not supposed to be used outside a radio group and also blur was not the right event

## JIRA Link

[ASTRO-2232](https://rocketcom.atlassian.net/browse/ASTRO-2232)

## Motivation and Context

so we can use these components in forms

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
