### PR TITLE
fix(table): light theme text color

### DIFF
--- a/packages/web-components/src/components/rux-table/rux-table.scss
+++ b/packages/web-components/src/components/rux-table/rux-table.scss
@@ -29,7 +29,7 @@
     /**
       * @prop --table-header-text-color: Table header text color
       */
-    --table-header-text-color: var(--default-text);
+    --table-header-text-color: var(--gsb-default-text);
 
     /**
       * @prop --table-header-box-shadow: Table header box shadow


### PR DESCRIPTION
## Brief Description

fixes light theme table header

## JIRA Link

[ASTRO-1922](https://rocketcom.atlassian.net/browse/ASTRO-1922)

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations
noticed that our storybook docs pages still look weird in light mode and need to be tweaked 

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
