### PR TITLE
feat(starter-kits): vue2 init command

### DIFF
--- a/packages/starter-kits/vue2-starter/init.js
+++ b/packages/starter-kits/vue2-starter/init.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+const process = require("process");
+const fs = require("fs");
+const http = require("https");
+const readline = require("readline");
+
+let inSrc = false;
+let inPublic = false;
+
+function writeFile(fileName) {
+  console.log(`Creating ${fileName} ...`);
+  let url;
+  if (!inSrc && !inPublic) {
+    url =
+      "https://raw.githubusercontent.com/RocketCommunicationsInc/astro/main/packages/starter-kits/vue2-starter/" +
+      fileName;
+  } else if (inSrc && !inPublic) {
+    url =
+      "https://raw.githubusercontent.com/RocketCommunicationsInc/astro/main/packages/starter-kits/vue2-starter/src/" +
+      fileName;
+  } else {
+    url =
+      "https://raw.githubusercontent.com/RocketCommunicationsInc/astro/main/packages/starter-kits/vue2-starter/public/" +
+      fileName;
+  }
+
+  const file = fs.createWriteStream(`${fileName}`);
+  const request = http.get(url, (res) => {
+    res.on("error", (err) => {
+      console.log(err);
+      process.exit(1);
+    });
+    res.pipe(file);
+  });
+}
+
+function changeDir(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir);
+    process.chdir(dir);
+  } else {
+    process.chdir(dir);
+  }
+  console.log(`Now working in ${process.cwd()}`);
+}
+
+function getAppName(query) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) =>
+    rl.question(query, (ans) => {
+      rl.close();
+      resolve(ans);
+    })
+  );
+}
+
+async function init() {
+  let appName = process.argv[2];
+  if (!appName) {
+    appName = await getAppName("Please enter a root directory name: ");
+  }
+  console.log("***** Instializing Astro Vue 2 starter kit *****");
+
+  changeDir(`./${appName}`);
+  console.log(`Root directory ${appName} created!`);
+  writeFile("package.json");
+  //   writeFile("README.md");
+  //   writeFile(".gitignore");
+
+  //create src dir, or change into it if it exists
+  changeDir("./src");
+  inSrc = true;
+  writeFile("App.vue");
+  writeFile("main.js");
+
+  console.log(`/src directory created in ${process.cwd()}`);
+
+  //create public dir or change into it if already exists
+  changeDir("../");
+  changeDir("./public");
+
+  inPublic = true;
+  writeFile("index.html");
+
+  console.log(`./public directory created in ${process.cwd()}`);
+  console.log(`Finished!`);
+  console.log(`******************`);
+  console.log(`Please run: `);
+  console.log(`cd ${appName}`);
+  console.log(`npm install`);
+  console.log(`npm run serve`);
+  console.log(`Thanks for using AstroUXDS!`);
+  console.log(`******************`);
+}
+
+init();

--- a/packages/starter-kits/vue2-starter/package.json
+++ b/packages/starter-kits/vue2-starter/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "astro-vue",
+  "name": "astro-vue-2",
   "version": "0.1.0",
   "private": true,
+  "bin": "init.js",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",


### PR DESCRIPTION
## Brief Description

Adds an `init.js` file to the vue2-starter. This file copies files from the starter kit to wherever the npx command was run, similar to the react init. 

To test, run `npx astro-vue-2` where you'd want to create the new vue project. 
This should be updated and published under astro as `@astrouxds/vue2` or something along those lines in the future.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2174

## Related Issue

## General Notes

## Motivation and Context

Adds a quick way to set up our astro components in vue.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
