### PR TITLE
feat(starter-kits): vue3 npx cmd

### DIFF
--- a/packages/starter-kits/vue3-starter/init.js
+++ b/packages/starter-kits/vue3-starter/init.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+const process = require("process");
+const fs = require("fs");
+const http = require("https");
+const readline = require("readline");
+
+let inSrc = false;
+let inAssets = false;
+
+function writeFile(fileName) {
+  console.log(`Creating ${fileName} ...`);
+  let url;
+  if (!inSrc && !inAssets) {
+    url =
+      "https://raw.githubusercontent.com/RocketCommunicationsInc/astro/main/packages/starter-kits/vue3-starter/" +
+      fileName;
+  } else if (inSrc && !inAssets) {
+    url =
+      "https://raw.githubusercontent.com/RocketCommunicationsInc/astro/main/packages/starter-kits/vue3-starter/src/" +
+      fileName;
+  } else {
+    url =
+      "https://raw.githubusercontent.com/RocketCommunicationsInc/astro/main/packages/starter-kits/vue3-starter/src/assets" +
+      fileName;
+  }
+
+  const file = fs.createWriteStream(`${fileName}`);
+  const request = http.get(url, (res) => {
+    res.on("error", (err) => {
+      console.log(err);
+      process.exit(1);
+    });
+    res.pipe(file);
+  });
+}
+
+function changeDir(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir);
+    process.chdir(dir);
+  } else {
+    process.chdir(dir);
+  }
+  console.log(`Now working in ${process.cwd()}`);
+}
+
+function getAppName(query) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) =>
+    rl.question(query, (ans) => {
+      rl.close();
+      resolve(ans);
+    })
+  );
+}
+
+async function init() {
+  let appName = process.argv[2];
+  if (!appName) {
+    appName = await getAppName("Please enter a root directory name: ");
+  }
+  console.log("***** Instializing Astro Vue 3 starter kit *****");
+
+  changeDir(`./${appName}`);
+  console.log(`Root directory ${appName} created!`);
+  writeFile("package.json");
+  writeFile("vite.config.js");
+  writeFile("index.html");
+  //   writeFile("README.md");
+  //   writeFile(".gitignore");
+
+  //create src dir, or change into it if it exists
+  changeDir("./src");
+  inSrc = true;
+  writeFile("App.vue");
+  writeFile("main.js");
+  console.log(`/src directory created in ${process.cwd()}`);
+
+  //assets folder
+  changeDir("./assets");
+  inAssets = true;
+  writeFile("logo.png");
+  console.log(`/assets directory created in ${process.cwd()}`);
+
+  console.log(`Finished!`);
+  console.log(`******************`);
+  console.log(`Please run: `);
+  console.log(`cd ${appName}`);
+  console.log(`npm install`);
+  console.log(`npm run dev`);
+  console.log(`Thanks for using AstroUXDS!`);
+  console.log(`******************`);
+}
+
+init();

--- a/packages/starter-kits/vue3-starter/package.json
+++ b/packages/starter-kits/vue3-starter/package.json
@@ -1,13 +1,14 @@
 {
-  "name": "vue3-test",
-  "version": "0.0.0",
+  "name": "astro-vue-3",
+  "version": "0.1.0",
+  "bin": "init.js",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "serve": "vite preview"
   },
   "dependencies": {
-    "@astrouxds/astro-web-components": "0.0.18",
+    "@astrouxds/astro-web-components": "^0.0.18",
     "vue": "^3.2.16"
   },
   "devDependencies": {


### PR DESCRIPTION
## Brief Description

Creates a vue3 npx command that builds the scaffolding of a vue3 app with astro dependencies. 

To test, run `npx astro-vue-3` anywhere you'd want to create a new vue app. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2174

## Related Issue

## General Notes

## Motivation and Context

Adds a quick way for devs to get set up using vue3 and astro-components 

## Issues and Limitations

There is a vite warning when running the app: 
```
4:37:59 PM [vite] warning:
/Users/micahjones/Documents/Vue/from-web/node_modules/.vite/@astrouxds_astro-web-components_dist_custom-elements.js
1808|      return module[exportName];
1809|    }
1810|    return import(
   |                  ^
1811|      /* webpackInclude: /\.entry\.js$/ */
1812|      /* webpackExclude: /\.system\.entry\.js$/ */
The above dynamic import cannot be analyzed by vite.
```
This may be just a vite warning, and we can suppress it if necessary.

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
