### PR TITLE
docs(stories): added documentation for react and angular npx

### DIFF
--- a/packages/web-components/src/stories/astro-uxds/welcome/angular.stories.mdx
+++ b/packages/web-components/src/stories/astro-uxds/welcome/angular.stories.mdx
@@ -15,6 +15,12 @@ Our wrapper library builds on top of that and adds:
 
 ### Via NPM
 
+To get started quickly with all boilerplate and dependencies included, run:
+
+`npx @astrouxds/angular-starter my-app`
+
+Otherwise, use:
+
 `npm i @astrouxds/angular`
 
 ## Integration

--- a/packages/web-components/src/stories/astro-uxds/welcome/react.stories.mdx
+++ b/packages/web-components/src/stories/astro-uxds/welcome/react.stories.mdx
@@ -8,6 +8,12 @@ import { Meta } from '@storybook/addon-docs/blocks'
 
 ### Via NPM
 
+To get started quickly with all boilerplate and dependencies included, run:
+
+`npx @astrouxds/react-starter my-app`
+
+Otherwise, use:
+
 `npm i @astrouxds/react`
 
 #### Lazy Loading


### PR DESCRIPTION
## Brief Description

Adds npx command documentation to react and angular storybook.
This should probably not be merged until we publish the `@astrouxds/react-starter` and `@astrouxds/angular-starter` packages.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2256

## Related Issue

## General Notes

## Motivation and Context

Adds docs and awareness of npx commands for react and angular starter kits

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
