### PR TITLE
ci(release): added github workflow to manage releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish Actions
+on:
+  workflow_dispatch:
+jobs:
+  publish:
+    name: Publish All Packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+      - name: Install modules
+        run: npm i
+      - name: Bootstrap packages
+        run: npx lerna bootstrap
+      - name: Ensure access
+        run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      - name: Configure Git
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+      - name: Bump and Publish
+        run: |
+          npx lerna version --yes --conventional-commits --create-release github --message 'chore(release): publish'
+          npx lerna publish from-package --yes

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,18 +6,18 @@ on:
     branches: [main]
   workflow_dispatch:
 jobs:
-  #lint:
-  #  name: Lint commit messages
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - uses: actions/checkout@v2.3.1
-  #      with:
-  #        fetch-depth: 0
-  #    - uses: actions/setup-node@v2.3.0
-  #   - name: Install Dependencies
-  #     run: npm ci
-  #    - name: Run CommitLint
-  #      run: npx commitlint --from HEAD~${{ github.event.pull_request.commits }}
+  lint:
+    name: Lint commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v2.3.0
+      - name: Install Dependencies
+        run: npm ci
+      - name: Run CommitLint
+        run: npx commitlint --from HEAD~${{ github.event.pull_request.commits }}
   unit-test:
     name: Unit and Integration Tests
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -12,3 +12,35 @@ Astro Web Components use [`Stencil`](https://stenciljs.com) in order to provide 
 | **React**                | [`@astrouxds/react`](https://www.npmjs.com/package/@astrouxds/react) - Astro Web Components wrapped for React use                          |                                     [`README.md`](packages/react/README.md)                                      |
 | **AG-Grid Theme**        | Astro UXDS theming for AG-Grid                                                                                                             |                                 [`README.md`](packages/ag-grid-theme/README.md)                                  |
 | **Starter Kits**         | Starter kits for getting Astro web-components running in React, Svelte, Angular and HTML/JS                                                | [React](packages/starter-kits/react-starter/README.md), [Svelte](packages/starter-kits/svelte-starter/README.md) |
+
+## Release Notes
+
+:tada: _NEW_
+
+- Can be used without NPM dependencies
+- Form elements as Web Components https://astro-stencil.netlify.app/?path=/story/astro-uxds-patterns-forms-html--page(https://astro-stencil.netlify.app/?path=/story/astro-uxds-patterns-forms-html--page)
+- Form patterns/gudiance for HTML, React, Vue and Svelte
+- Unit and Integration tests
+- Visual regression tests
+- TypeScript support
+- Single package import with tree shaking
+- Integrations with Libraries/Frameworks
+- Svelte https://astro-stencil.netlify.app/?path=/story/astro-uxds-welcome-svelte--page(https://astro-stencil.netlify.app/?path=/story/astro-uxds-welcome-svelte--page)
+- Vue3 https://astro-stencil.netlify.app/?path=/story/astro-uxds-welcome-vue-3--page(https://astro-stencil.netlify.app/?path=/story/astro-uxds-welcome-vue-3--page)
+- React Wrapper https://github.com/RocketCommunicationsInc/astro/blob/main/packages/react/README.md(https://github.com/RocketCommunicationsInc/astro/blob/main/packages/react/README.md)
+- Starter kits \* Svelte https://github.com/RocketCommunicationsInc/astro/blob/main/packages/starter-kits/svelte-starter/README.md(https://github.com/RocketCommunicationsInc/astro/blob/main/packages/starter-kits/svelte-starter/README.md)
+
+:pencil: _IMPROVED_
+
+- Storybook documentation https://astro-stencil.netlify.app/?path=/story/astro-uxds-welcome-start-here--page(https://astro-stencil.netlify.app/?path=/story/astro-uxds-welcome-start-here--page)
+- CSS Custom Property documentation for developer overrides
+- Framework integrations
+- HTML/Javascript https://astro-stencil.netlify.app/?path=/story/astro-uxds-welcome-javascript--page(https://astro-stencil.netlify.app/?path=/story/astro-uxds-welcome-javascript--page)
+- React https://astro-stencil.netlify.app/?path=/story/astro-uxds-welcome-react--page(https://astro-stencil.netlify.app/?path=/story/astro-uxds-welcome-react--page)
+- Vue2 https://astro-stencil.netlify.app/?path=/story/astro-uxds-welcome-vue-2--page(https://astro-stencil.netlify.app/?path=/story/astro-uxds-welcome-vue-2--page)
+- Starter kits
+- React https://github.com/RocketCommunicationsInc/astro/blob/main/packages/starter-kits/react-starter/README.md(https://github.com/RocketCommunicationsInc/astro/blob/main/packages/starter-kits/react-starter/README.md)
+  ​
+
+:warning: Deprecation notification
+The existing Lit/CSS libraries are moving to maintenance mode and only receive bug fixes starting January 1, 2022. We encourage all new projects to start with the new Stencil based components https://github.com/RocketCommunicationsInc/astro/tree/main/packages/web-components(https://github.com/RocketCommunicationsInc/astro/tree/main/packages/web-components)


### PR DESCRIPTION
## Brief Description

Added a workflow to allow packages to be published concurrently with the push of a button through the workflow interface.

## JIRA Link

## Related Issue

## General Notes

## Motivation and Context

With this workflow we'll be able to publish the current state of the repo with a single button push. 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
