### PR TITLE
ci: added lifecycle scripts for publishing

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/RocketCommunicationsInc/astro/tree/main/packages/angular"
   },
   "scripts": {
+    "prepack": "npm run build",
     "build": "npm run build.ng",
     "build.fesm": "rollup --config ./scripts/rollup.config.js",
     "build.ng": "npm run build.es2015 && npm run build.es5",

--- a/packages/astro-uxds/package.json
+++ b/packages/astro-uxds/package.json
@@ -1,6 +1,7 @@
 {
   "name": "astro-website",
   "version": "6.0.1",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/RocketCommunicationsInc/astro-uxds"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/RocketCommunicationsInc/astro/tree/main/packages/react"
   },
   "scripts": {
+    "prepack": "npm run build",
     "build": "npm run clean && npm run compile",
     "clean": "rm -rf dist",
     "compile": "npm run tsc",


### PR DESCRIPTION
## Brief Description

Added prepack scripts to the angular and react packages, to make sure they build before getting published.
Marked UXDS website as private, which makes Lerna skip it during the publish process.

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

Without this, `Lerna Publish` will try to publish wrappers without building them first, and also to publish UXDS to npm.
## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
