### PR TITLE
docs(astro-uxds): update classification markings

### DIFF
--- a/packages/astro-uxds/_content/components/classification-markings.md
+++ b/packages/astro-uxds/_content/components/classification-markings.md
@@ -120,7 +120,7 @@ The colors used in the tag components are the same as those in the overall banne
 
 ![Do: Place portion markings at the top-left of classified or controlled information ](/img/components/portion-marking-do-2.png "Do: Place portion markings at the top-left of classified or controlled information ")
 
-![](/img/components/blank.png)
+![Blank placeholder image](/img/components/blank.png)
 
 ![Do: Use colored tags for general section markings and text portion marking in portions lower in the visual hierarchy  ](/img/components/portion-marking-do-3.png "Do: Use colored tags for general section markings and text portion marking in portions lower in the visual hierarchy")
 


### PR DESCRIPTION
## Brief Description

- Fixed a typo: bxe > be. 
- Rearranged color chart to be from lowest to highest classification level. 
- Added clarification statement about ISOO rules on colors.
- Added alt text to portion marking image
- Added alt text to blank placeholder image

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2323

## Related Issue

https://rocketcom.atlassian.net/browse/ASTRO-1463

## General Notes

## Motivation and Context

Answers client questions with definitive answer

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [x] New feature (new sentence in docs)
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
