### PR TITLE
chore(astro-uxds): meta version bump

### DIFF
--- a/packages/astro-uxds/_content/_data/meta.js
+++ b/packages/astro-uxds/_content/_data/meta.js
@@ -1,5 +1,5 @@
 module.exports = {
-  version: "5.3",
+  version: "6.0",
   copyright: new Date().getFullYear(),
   repo: process.env.REPOSITORY_URL,
   branch: process.env.BRANCH,


### PR DESCRIPTION
Bumps the meta version to 6.0 to align with release
