### PR TITLE
docs(astro-uxds): fix class markings caption

### DIFF
--- a/packages/astro-uxds/_content/components/classification-markings.md
+++ b/packages/astro-uxds/_content/components/classification-markings.md
@@ -119,7 +119,7 @@ The colors used in the tag components are the same as those in the overall banne
 
 ![Do: Place portion markings at the top-left of classified or controlled information ](/img/components/portion-marking-do-2.png "Do: Place portion markings at the top-left of classified or controlled information ")
 
-![Blank placeholder image](/img/components/blank.png)
+![](/img/components/blank.png)
 
 ![Do: Use colored tags for general section markings and text portion marking in portions lower in the visual hierarchy  ](/img/components/portion-marking-do-3.png "Do: Use colored tags for general section markings and text portion marking in portions lower in the visual hierarchy")
 


### PR DESCRIPTION
## Brief Description

Forgot in my last pr that the alt text for images is used for captions.
Removed the blank placeholder alt text to get rid of the unnecessary caption.

## JIRA Link

(none - quick fix)

## Related Issue

## General Notes

## Motivation and Context

Resolves an error I caused in my last PR

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
