### PR TITLE
fix(astro-uxds): sign in now points to the correct SB example, enabled scrolling

### DIFF
--- a/packages/astro-uxds/_content/components/sign-in.md
+++ b/packages/astro-uxds/_content/components/sign-in.md
@@ -4,11 +4,12 @@ path: /components/sign-in
 date: Last Modified
 layout: components.template.njk
 title: Sign In
-demo: components-sign-in--sign-in
-storybook: components-sign-in--sign-in
+demo: astro-uxds-patterns-sign-in--page
+storybook: astro-uxds-patterns-sign-in--page
 git: rux-sign-in
 height: 400px
 theme: true
+scrolling: yes
 ---
 
 # Sign In


### PR DESCRIPTION
## Brief Description

Points to the correct SB demo in astrouxds for sign-in 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2307

## Related Issue

## General Notes

Changed the dmeo and storybook front matter on sign-in.md, added scrolling: yes to enable scrolling

## Motivation and Context

Sign in pattern now shows correctly on UXDS

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
