### PR TITLE
Astro 2400 pop up uxds

### DIFF
--- a/packages/astro-uxds/_content/components/pop-up.md
+++ b/packages/astro-uxds/_content/components/pop-up.md
@@ -7,7 +7,7 @@ title: Pop Up
 demo: components-pop-up-menu--default-story
 storybook: components-pop-up-menu--default-story
 git: rux-pop-up-menu
-height: 200px
+height: 250px
 theme: true
 ---
 

--- a/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
+++ b/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
@@ -171,7 +171,7 @@ export class RuxPopUpMenu {
         this.menuBounds = this.el.getBoundingClientRect()
     }
 
-    private async _setMenuPosition() {
+    private _setMenuPosition() {
         if (this.anchorEl && this.anchorBounds && this.menuBounds) {
             let { anchorBounds, menuBounds } = this
             anchorBounds = this.anchorEl.getBoundingClientRect()

--- a/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
+++ b/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
@@ -81,7 +81,7 @@ export class RuxPopUpMenu {
         if (this.open) {
             setTimeout(() => {
                 this._setMenuPosition()
-            }, 50)
+            }, 100)
         }
     }
 

--- a/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
+++ b/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
@@ -79,9 +79,7 @@ export class RuxPopUpMenu {
 
     componentDidRender() {
         if (this.open) {
-            setTimeout(() => {
-                this._setMenuPosition()
-            }, 400)
+            this._setMenuPosition()
         }
     }
 

--- a/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
+++ b/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
@@ -81,7 +81,7 @@ export class RuxPopUpMenu {
         if (this.open) {
             setTimeout(() => {
                 this._setMenuPosition()
-            }, 100)
+            }, 400)
         }
     }
 

--- a/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
+++ b/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
@@ -78,7 +78,11 @@ export class RuxPopUpMenu {
     ruxMenuDidClose!: EventEmitter<void>
 
     componentDidRender() {
-        if (this.open) this._setMenuPosition()
+        if (this.open) {
+            setTimeout(() => {
+                this._setMenuPosition()
+            }, 50)
+        }
     }
 
     connectedCallback() {
@@ -167,7 +171,7 @@ export class RuxPopUpMenu {
         this.menuBounds = this.el.getBoundingClientRect()
     }
 
-    private _setMenuPosition() {
+    private async _setMenuPosition() {
         if (this.anchorEl && this.anchorBounds && this.menuBounds) {
             let { anchorBounds, menuBounds } = this
             anchorBounds = this.anchorEl.getBoundingClientRect()

--- a/packages/web-components/src/stories/popup.stories.mdx
+++ b/packages/web-components/src/stories/popup.stories.mdx
@@ -32,7 +32,10 @@ A Pop-Up Menu provides users with a quick way to access common actions for a hig
 
 export const Default = (args) => {
     return html`
-        <rux-icon icon="apps" aria-controls="popup-menu-1"></rux-icon>
+        <div style="display: flex; align-items: center;">
+            <rux-icon icon="apps" aria-controls="popup-menu-1"></rux-icon>
+            <span style="margin-left: 10px;">Click icon to see pop up</span>
+        </div>
         <rux-pop-up-menu id="popup-menu-1" .open="${args.open}">
             <rux-menu-item>Item 1</rux-menu-item>
             <rux-menu-item-divider></rux-menu-item-divider>
@@ -55,7 +58,7 @@ export const Default = (args) => {
     <Story
         height="400px"
         args={{
-            open: true,
+            open: false,
         }}
         name="Default"
     >


### PR DESCRIPTION
## Brief Description

Changed the pop-up default SB to be closed by default. Added a span that notifies user to click icon to see pop-up.

Bumped the demo SB size on the pop-up section of astrouxds 50px to prevent the pop-up from rendering above the icon and out of view.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2400

## Related Issue

## General Notes

The issue with pop-up appearing in the wrong place when set to open by default remains, but now it won't be a problem in our SB

## Motivation and Context

Pop-up was open by default on SB, and that made it appear in the wrong location 

## Issues and Limitations

Does not fix core issue with incorrect loading when open by default, but does fix our SB.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
