### PR TITLE
Astro 2476 hotfix notification closing

### DIFF
--- a/packages/web-components/src/components/rux-notification/rux-notification.tsx
+++ b/packages/web-components/src/components/rux-notification/rux-notification.tsx
@@ -1,3 +1,4 @@
+/* eslint react/jsx-no-bind: 0 */ // --> OFF
 import { Component, Host, h, Prop, Watch } from '@stencil/core'
 import { Status } from '../../common/commonTypes.module'
 
@@ -73,7 +74,7 @@ export class RuxNotification {
                 <rux-icon
                     role="button"
                     label="Close notification"
-                    onClick={this._onClick}
+                    onClick={() => this._onClick()}
                     icon="close"
                     size="36px"
                 ></rux-icon>

--- a/packages/web-components/src/components/rux-notification/test/index.html
+++ b/packages/web-components/src/components/rux-notification/test/index.html
@@ -19,6 +19,28 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
     <body>
-        <rux-notification open>Hello world</rux-notification>
+        <section>
+            <h2>Default</h2>
+            <div style="position: relative; overflow: hidden; height: 200px">
+                <rux-notification
+                    open
+                    data-test-id="default"
+                    message="testing time"
+                ></rux-notification>
+            </div>
+        </section>
+
+        <section>
+            <h2>With Autoclose</h2>
+            <div style="position: relative; overflow: hidden; height: 200px">
+                <rux-notification
+                    data-test-id="autoclose"
+                    open
+                    close-after="100"
+                    status="caution"
+                    message="testing time"
+                ></rux-notification>
+            </div>
+        </section>
     </body>
 </html>

--- a/packages/web-components/src/components/rux-notification/test/rux-notification.e2e.js
+++ b/packages/web-components/src/components/rux-notification/test/rux-notification.e2e.js
@@ -6,22 +6,15 @@ describe('Notification', () => {
         cy.get('rux-notification').should('have.class', 'hydrated')
     })
 
-    //   it('closes after time is up', async () => {
-    //     const page = await newE2EPage()
-    //     await page.setContent(
-    //         '<rux-notification open close-after="3000" status="caution" message="testing time"></rux-notification>'
-    //     )
-    //     const el = await page.find('rux-notification')
-    //     //Wait for notification time limit to be up before checking open attr
-    //     setTimeout(() => expect(el).not.toHaveAttribute('open'), 3001)
-    // })
-    // it('does not close before time is up', async () => {
-    //     const page = await newE2EPage()
-    //     await page.setContent(
-    //         '<rux-notification open close-after="3000" status="caution" message="testing time"></rux-notification>'
-    //     )
-    //     const el = await page.find('rux-notification')
-    //     //Checking open attr right before time is up to make sure it doesn't close a ms too early
-    //     setTimeout(() => expect(el).toHaveAttribute('open'), 2999)
-    // })
+    it('closes when close icon is clicked', () => {
+        const notification = cy.get('rux-notification[data-test-id="default"]')
+        notification.should('have.attr', 'open')
+        const icon = cy
+            .get('rux-notification')
+            .first()
+            .shadow()
+            .find('rux-icon')
+        icon.click()
+        notification.should('not.have.attr', 'open')
+    })
 })

--- a/packages/web-components/src/components/rux-notification/test/rux-notification.e2e.js
+++ b/packages/web-components/src/components/rux-notification/test/rux-notification.e2e.js
@@ -17,4 +17,23 @@ describe('Notification', () => {
         icon.click()
         notification.should('not.have.attr', 'open')
     })
+
+    //   it('closes after time is up', async () => {
+    //     const page = await newE2EPage()
+    //     await page.setContent(
+    //         '<rux-notification open close-after="3000" status="caution" message="testing time"></rux-notification>'
+    //     )
+    //     const el = await page.find('rux-notification')
+    //     //Wait for notification time limit to be up before checking open attr
+    //     setTimeout(() => expect(el).not.toHaveAttribute('open'), 3001)
+    // })
+    // it('does not close before time is up', async () => {
+    //     const page = await newE2EPage()
+    //     await page.setContent(
+    //         '<rux-notification open close-after="3000" status="caution" message="testing time"></rux-notification>'
+    //     )
+    //     const el = await page.find('rux-notification')
+    //     //Checking open attr right before time is up to make sure it doesn't close a ms too early
+    //     setTimeout(() => expect(el).toHaveAttribute('open'), 2999)
+    // })
 })

--- a/packages/web-components/src/components/rux-tree-node/rux-tree-node.tsx
+++ b/packages/web-components/src/components/rux-tree-node/rux-tree-node.tsx
@@ -1,3 +1,4 @@
+/* eslint react/jsx-no-bind: 0 */ // --> OFF
 import {
     Prop,
     Event,
@@ -218,7 +219,9 @@ export class RuxTreeNode {
                 role="treeitem"
                 aria-expanded={this.expanded ? 'true' : 'false'}
                 aria-selected={this.selected ? 'true' : 'false'}
-                onClick={this._handleTreeNodeClick}
+                onClick={(event: MouseEvent) =>
+                    this._handleTreeNodeClick(event)
+                }
             >
                 <div
                     id={this.componentId}
@@ -232,7 +235,7 @@ export class RuxTreeNode {
                     <div class="parent" tabindex="0">
                         {this._hasChildren && (
                             <i
-                                onClick={this._handleArrowClick}
+                                onClick={(e) => this._handleArrowClick(e)}
                                 class="arrow"
                             ></i>
                         )}


### PR DESCRIPTION
## Brief Description

fixes issue where close icon was not properly closing Notification

## JIRA Link

[ASTRO-2476](https://rocketcom.atlassian.net/browse/ASTRO-2476)

## Motivation and Context

a recent change removed arrow functions from a lot of components due to this eslint rule https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md
this ended up breaking notification, which was intentionally relying on that rerender.

added some test coverage

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
