### PR TITLE
fix(notification): can now be closed properly in react

### DIFF
--- a/packages/web-components/src/components/rux-notification/rux-notification.scss
+++ b/packages/web-components/src/components/rux-notification/rux-notification.scss
@@ -35,7 +35,7 @@
     display: none;
 }
 
-:host([open]) {
+:host(.rux-notification-banner-0ba5409c--open) {
     top: 0;
 }
 

--- a/packages/web-components/src/components/rux-notification/rux-notification.tsx
+++ b/packages/web-components/src/components/rux-notification/rux-notification.tsx
@@ -89,7 +89,21 @@ export class RuxNotification {
     }
     render() {
         return (
-            <Host>
+            /**
+             * Add a randomly generated class name when the banner is open
+             * so that we can achieve backwards compatibility if anybody is
+             * styling the host element.
+             *
+             * We shouldn't be changing the component's class because the developer
+             * has full control of it and can easily override it. But by using
+             * a random string, we reduce the chances of that happening unknowingly.
+             */
+
+            <Host
+                class={{
+                    'rux-notification-banner-0ba5409c--open': this.open,
+                }}
+            >
                 <div class="rux-notification__message">{`${this.message}`}</div>
                 <rux-icon
                     role="button"

--- a/packages/web-components/src/components/rux-notification/test/rux-notification.spec.tsx
+++ b/packages/web-components/src/components/rux-notification/test/rux-notification.spec.tsx
@@ -11,7 +11,7 @@ describe('rux-notification', () => {
             html: `<rux-notification open message="hello there"></rux-notification>`,
         })
         expect(page.root).toEqualHtml(`
-         <rux-notification message="hello there" open="" status="standby">
+         <rux-notification class="rux-notification-banner-0ba5409c--open" message="hello there" open="" status="standby">
            <mock:shadow-root>
              <div class="rux-notification__message">
                hello there


### PR DESCRIPTION
## Brief Description

notification - replaces open attribute styling with a class

## JIRA Link

[ASTRO-2476](https://rocketcom.atlassian.net/browse/ASTRO-2476)

## Issues and Limitations

Because we were styling [open], the banner could never be closed in React or if the developer was passing in false `<rux-notification open="false">` because open would still exist. 

But notification is also weird in that we're applying a lot of styling to the host, which means the developer could be override that with `rux-notification { position: relative; }` and this is probably more common because that's currently the only way to control the positioning. 

So for backwards compatibility, we need to apply a class instead. But applying a class to the host element is an anti pattern--the developer could override that. To make sure that doesnt happen unknowingly, I made the class name somewhat random. 

* alternatively we could have probably done something with the css *^~3#$%@#$ selectors and check for open=false or something. but styling an attribute is still not a good idea.

My intention is that this will removed in the next release as a breaking change and developers who are overriding the host, can use a shadow part instead. 

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
