### PR TITLE
chore(web-components): move output targets to devDeps

### DIFF
--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -6,12 +6,10 @@
     "packages": {
         "": {
             "name": "@astrouxds/astro-web-components",
-            "version": "6.0.1",
+            "version": "6.0.2",
             "license": "MIT",
             "dependencies": {
-                "@stencil/angular-output-target": "~0.2.0",
                 "@stencil/core": "~2.5.2",
-                "@stencil/react-output-target": "~0.1.0",
                 "date-fns": "~2.21.1",
                 "date-fns-tz": "~1.1.4"
             },
@@ -19,7 +17,9 @@
                 "@astrouxds/astro-figma-export": "~1.0.1",
                 "@astrouxds/storybook-addon-docs-stencil": "~1.0.7",
                 "@babel/core": "~7.13.16",
+                "@stencil/angular-output-target": "~0.2.0",
                 "@stencil/eslint-plugin": "~0.4.0",
+                "@stencil/react-output-target": "~0.1.0",
                 "@stencil/sass": "~1.4.1",
                 "@storybook/addon-a11y": "~6.3.7",
                 "@storybook/addon-actions": "~6.3.7",
@@ -3063,7 +3063,8 @@
         "node_modules/@stencil/angular-output-target": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.2.0.tgz",
-            "integrity": "sha512-Ptr5vigf8v+EnF9Y9LXTKimcVPfB9arC5FnSuKt5ZdNQ8IATWGLx4fhoD2/LThhkPwG9QtjDj9A4GPidu0Fomg=="
+            "integrity": "sha512-Ptr5vigf8v+EnF9Y9LXTKimcVPfB9arC5FnSuKt5ZdNQ8IATWGLx4fhoD2/LThhkPwG9QtjDj9A4GPidu0Fomg==",
+            "dev": true
         },
         "node_modules/@stencil/core": {
             "version": "2.5.2",
@@ -3140,6 +3141,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.1.0.tgz",
             "integrity": "sha512-NWeN2S43dwWDIousfojzGXIMkJJhfcdS1JxpwgE7IOqy4tZ+nqlDLPhM6tXvZ3eq4rJm8bkF+3/WbPJNR9xR7Q==",
+            "dev": true,
             "peerDependencies": {
                 "@stencil/core": ">=1.8.0"
             }
@@ -27826,7 +27828,8 @@
         "@stencil/angular-output-target": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.2.0.tgz",
-            "integrity": "sha512-Ptr5vigf8v+EnF9Y9LXTKimcVPfB9arC5FnSuKt5ZdNQ8IATWGLx4fhoD2/LThhkPwG9QtjDj9A4GPidu0Fomg=="
+            "integrity": "sha512-Ptr5vigf8v+EnF9Y9LXTKimcVPfB9arC5FnSuKt5ZdNQ8IATWGLx4fhoD2/LThhkPwG9QtjDj9A4GPidu0Fomg==",
+            "dev": true
         },
         "@stencil/core": {
             "version": "2.5.2",
@@ -27873,6 +27876,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.1.0.tgz",
             "integrity": "sha512-NWeN2S43dwWDIousfojzGXIMkJJhfcdS1JxpwgE7IOqy4tZ+nqlDLPhM6tXvZ3eq4rJm8bkF+3/WbPJNR9xR7Q==",
+            "dev": true,
             "requires": {}
         },
         "@stencil/sass": {

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -37,9 +37,7 @@
         "test.all": "concurrently npm:test.unit npm:test.e2e"
     },
     "dependencies": {
-        "@stencil/angular-output-target": "~0.2.0",
         "@stencil/core": "~2.5.2",
-        "@stencil/react-output-target": "~0.1.0",
         "date-fns": "~2.21.1",
         "date-fns-tz": "~1.1.4"
     },
@@ -50,6 +48,8 @@
         "@babel/core": "~7.13.16",
         "@stencil/eslint-plugin": "~0.4.0",
         "@stencil/sass": "~1.4.1",
+        "@stencil/angular-output-target": "~0.2.0",
+        "@stencil/react-output-target": "~0.1.0",
         "@storybook/addon-a11y": "~6.3.7",
         "@storybook/addon-actions": "~6.3.7",
         "@storybook/addon-docs": "~6.3.7",


### PR DESCRIPTION
## Brief Description

the output targets should be dev dependencies since they're only run on build 

https://github.com/ionic-team/stencil-ds-output-targets/blob/master/packages/example-project/component-library/package.json

## Types of changes

- [x?] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
