### PR TITLE
chore(web-components): bump storybook docs addon

### DIFF
--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@astrouxds/astro-web-components",
-            "version": "6.0.2",
+            "version": "6.0.3",
             "license": "MIT",
             "dependencies": {
                 "@stencil/core": "~2.5.2",
@@ -15,7 +15,7 @@
             },
             "devDependencies": {
                 "@astrouxds/astro-figma-export": "~1.0.1",
-                "@astrouxds/storybook-addon-docs-stencil": "~1.0.7",
+                "@astrouxds/storybook-addon-docs-stencil": "~1.0.8",
                 "@babel/core": "~7.13.16",
                 "@stencil/angular-output-target": "~0.2.0",
                 "@stencil/eslint-plugin": "~0.4.0",
@@ -76,9 +76,9 @@
             }
         },
         "node_modules/@astrouxds/storybook-addon-docs-stencil": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@astrouxds/storybook-addon-docs-stencil/-/storybook-addon-docs-stencil-1.0.7.tgz",
-            "integrity": "sha512-BDfX4A7Y4cSCyemca2spquVc5FLNnTAhkV6vLF0oqg8d3VDEqk8PoMOkLedBdXn8md5Ne2NXoAtoJu1eCe4lOw==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@astrouxds/storybook-addon-docs-stencil/-/storybook-addon-docs-stencil-1.0.8.tgz",
+            "integrity": "sha512-y1pXg03/x9FxnTdXn0S8/pKW7s2rJ1XPIjrfLCVzZEWaf4DEWWhC2dAEW7BPYyDgQIL0JZs2C+gbG3yxJEl0nA==",
             "dev": true,
             "dependencies": {
                 "@storybook/api": "^6.1.0",
@@ -25642,9 +25642,9 @@
             }
         },
         "@astrouxds/storybook-addon-docs-stencil": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@astrouxds/storybook-addon-docs-stencil/-/storybook-addon-docs-stencil-1.0.7.tgz",
-            "integrity": "sha512-BDfX4A7Y4cSCyemca2spquVc5FLNnTAhkV6vLF0oqg8d3VDEqk8PoMOkLedBdXn8md5Ne2NXoAtoJu1eCe4lOw==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@astrouxds/storybook-addon-docs-stencil/-/storybook-addon-docs-stencil-1.0.8.tgz",
+            "integrity": "sha512-y1pXg03/x9FxnTdXn0S8/pKW7s2rJ1XPIjrfLCVzZEWaf4DEWWhC2dAEW7BPYyDgQIL0JZs2C+gbG3yxJEl0nA==",
             "dev": true,
             "requires": {
                 "@storybook/api": "^6.1.0",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -44,7 +44,7 @@
     "license": "MIT",
     "devDependencies": {
         "@astrouxds/astro-figma-export": "~1.0.1",
-        "@astrouxds/storybook-addon-docs-stencil": "~1.0.7",
+        "@astrouxds/storybook-addon-docs-stencil": "~1.0.8",
         "@babel/core": "~7.13.16",
         "@stencil/angular-output-target": "~0.2.0",
         "@stencil/eslint-plugin": "~0.4.0",


### PR DESCRIPTION
## Brief Description

just bumps the storybook docs addon that fixes a minor deprecation in the new storybook 

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
