### PR TITLE
Astro 2501 react font

### DIFF
--- a/packages/starter-kits/react-starter/README.md
+++ b/packages/starter-kits/react-starter/README.md
@@ -33,6 +33,7 @@ export default MyComp;
 ### Boilerplate
 
 - Astro UXDS stylesheet import on `index.js`.
+- Roboto font loading in `index.html`.
 
 ### Resources
 

--- a/packages/starter-kits/react-starter/public/index.html
+++ b/packages/starter-kits/react-starter/public/index.html
@@ -9,6 +9,11 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400&family=Roboto:wght@200;300;400;500;600;800&display=swap"
+      rel="stylesheet"
+    />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/packages/web-components/src/stories/astro-uxds/welcome/react.stories.mdx
+++ b/packages/web-components/src/stories/astro-uxds/welcome/react.stories.mdx
@@ -20,9 +20,19 @@ Otherwise, use:
 
 Astro Web Components make use of Stencil's automatic lazy loader which only loads components that are actually used on the page.
 
-First, import the @astrouxds/astro-web-components main CSS file into your `index.js` or `app.js` file.
+Import the `@astrouxds/astro-web-components` main CSS file into your `index.js` or `app.js` file.
 
 `import '@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css'`
+
+Import [Roboto](https://fonts.google.com/specimen/Roboto) in your index.html. We recommend using Google's CDN for ease of use but you can also install it locally.
+
+```html
+<link rel="preconnect" href="https://fonts.gstatic.com" />
+<link
+    href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400&family=Roboto:wght@200;300;400;500;600;800&display=swap"
+    rel="stylesheet"
+/>
+```
 
 Next, import any desired Astro component as you would any React component.
 


### PR DESCRIPTION
## Brief Description

Adds the roboto font info to the react getting started and adds it to the `index.html` file in react-starter. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2501

## Related Issue

## General Notes


## Motivation and Context

Roboto font info was missing in the getting started for react SB and in the react-starter.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
