### PR TITLE
Astro 2500 rux clock bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
     "build.tests": "lerna run --scope '{@astrouxds/astro-web-components,@astrouxds/react}' build",
-    "test": "lerna run --parallel --ignore @astrouxds/angular test"
+    "test": "lerna run --ignore @astrouxds/angular test"
   }
 }

--- a/packages/web-components/cypress/support/index.js
+++ b/packages/web-components/cypress/support/index.js
@@ -20,3 +20,22 @@ import './commands'
 // require('./commands')
 
 import 'cypress-real-events/support'
+
+/**
+ * Make Cypress fail if it finds any console.errors
+ */
+Cypress.on('window:before:load', (win) => {
+    cy.stub(win.console, 'error', (msg) => {
+        // Whitelist errors should we so ever desire to
+        // if (msg.includes("This is an error")) {
+        //   return null;
+        // }
+
+        cy.now('task', 'error', msg)
+        throw new Error(msg)
+    })
+
+    cy.stub(win.console, 'warn', (msg) => {
+        cy.now('task', 'warn', msg)
+    })
+})

--- a/packages/web-components/src/components/rux-clock/rux-clock.tsx
+++ b/packages/web-components/src/components/rux-clock/rux-clock.tsx
@@ -72,11 +72,8 @@ export class RuxClock {
     @Watch('timezone')
     timezoneChanged() {
         this._convertTimezone(this.timezone)
-        this._updateTime()
-    }
-
-    constructor() {
-        this._timezone = this.timezone
+        if (this.aos) this.convertedAos = this._formatLosAos(this.aos)
+        if (this.los) this.convertedLos = this._formatLosAos(this.los)
         this._updateTime()
     }
 
@@ -96,6 +93,12 @@ export class RuxClock {
 
     disconnectedCallback() {
         clearTimeout(this._timer)
+    }
+
+    componentWillLoad() {
+        this._timezone = this.timezone
+        this._convertTimezone(this.timezone)
+        this._updateTime()
     }
 
     private _formatTime(time: Date, timezone: string): string {

--- a/packages/web-components/src/components/rux-clock/test/__snapshots__/rux-clock.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-clock/test/__snapshots__/rux-clock.spec.tsx.snap
@@ -1,0 +1,925 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rux-clock converts all military timezones 1`] = `
+<rux-clock timezone="A">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        06:02:03 GMT+1
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 2`] = `
+<rux-clock timezone="B">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        07:02:03 GMT+2
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 3`] = `
+<rux-clock timezone="C">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        08:02:03 GMT+3
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 4`] = `
+<rux-clock timezone="D">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        09:02:03 GMT+4
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 5`] = `
+<rux-clock timezone="E">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        10:02:03 GMT+5
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 6`] = `
+<rux-clock timezone="F">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        112
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        11:02:03 GMT+6
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 7`] = `
+<rux-clock timezone="G">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        112
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        12:02:03 GMT+7
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 8`] = `
+<rux-clock timezone="H">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        112
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        13:02:03 GMT+8
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 9`] = `
+<rux-clock timezone="I">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        112
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        14:02:03 GMT+9
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 10`] = `
+<rux-clock timezone="K">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        112
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        15:02:03 GMT+10
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 11`] = `
+<rux-clock timezone="L">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        112
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        16:02:03 GMT+11
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 12`] = `
+<rux-clock timezone="M">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        112
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        17:02:03 GMT+12
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 13`] = `
+<rux-clock timezone="N">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        04:02:03 GMT-1
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 14`] = `
+<rux-clock timezone="O">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        03:02:03 GMT-2
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 15`] = `
+<rux-clock timezone="P">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        02:02:03 GMT-3
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 16`] = `
+<rux-clock timezone="Q">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        01:02:03 GMT-4
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 17`] = `
+<rux-clock timezone="R">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        00:02:03 GMT-5
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 18`] = `
+<rux-clock timezone="S">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        23:02:03 GMT-6
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 19`] = `
+<rux-clock timezone="T">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        22:02:03 GMT-7
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 20`] = `
+<rux-clock timezone="U">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        21:02:03 GMT-8
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 21`] = `
+<rux-clock timezone="V">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        20:02:03 GMT-9
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 22`] = `
+<rux-clock timezone="W">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        19:02:03 GMT-10
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 23`] = `
+<rux-clock timezone="X">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        18:02:03 GMT-11
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 24`] = `
+<rux-clock timezone="Y">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        17:02:03 GMT-12
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts all military timezones 25`] = `
+<rux-clock timezone="Z">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        05:02:03 Z
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts aos/los unix timestamps when timezone is changed 1`] = `
+<rux-clock aos="1638373590145" los="1638373590145">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        05:02:03 UTC
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+    <div class="rux-clock__aos rux-clock__segment">
+      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos">
+        15:46:30
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos">
+        AOS
+      </div>
+    </div>
+    <div class="rux-clock__los rux-clock__segment">
+      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los">
+        15:46:30
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--los">
+        LOS
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts aos/los unix timestamps when timezone is changed 2`] = `
+<rux-clock aos="1638373590145" los="1638373590145" timezone="America/Los_Angeles">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        22:02:03 PDT
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+    <div class="rux-clock__aos rux-clock__segment">
+      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos">
+        07:46:30
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos">
+        AOS
+      </div>
+    </div>
+    <div class="rux-clock__los rux-clock__segment">
+      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los">
+        07:46:30
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--los">
+        LOS
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts time to timezone 1`] = `
+<rux-clock timezone="America/Los_Angeles">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        22:02:03 PDT
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts time to timezone on the fly 1`] = `
+<rux-clock>
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        05:02:03 UTC
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock converts time to timezone on the fly 2`] = `
+<rux-clock timezone="America/Los_Angeles">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        22:02:03 PDT
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock hides the date 1`] = `
+<rux-clock hide-date="">
+  <mock:shadow-root>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        05:02:03 UTC
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock hides the labels 1`] = `
+<rux-clock hide-labels="">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        05:02:03 UTC
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock hides the timezone 1`] = `
+<rux-clock hide-timezone="">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        05:02:03
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock shows and updates aos 1`] = `
+<rux-clock aos="1988-04-22 12:12:12">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        05:02:03 UTC
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+    <div class="rux-clock__aos rux-clock__segment">
+      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos">
+        12:12:12
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos">
+        AOS
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock shows and updates aos 2`] = `
+<rux-clock aos="1988-04-22 09:12:12">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        05:02:03 UTC
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+    <div class="rux-clock__aos rux-clock__segment">
+      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos">
+        09:12:12
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos">
+        AOS
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock shows and updates los 1`] = `
+<rux-clock los="1988-04-22 12:12:12">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        05:02:03 UTC
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+    <div class="rux-clock__los rux-clock__segment">
+      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los">
+        12:12:12
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--los">
+        LOS
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock shows and updates los 2`] = `
+<rux-clock los="1988-04-22 09:12:12">
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        05:02:03 UTC
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+    <div class="rux-clock__los rux-clock__segment">
+      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los">
+        09:12:12
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--los">
+        LOS
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;
+
+exports[`rux-clock shows the current time 1`] = `
+<rux-clock>
+  <mock:shadow-root>
+    <div class="rux-clock__day-of-the-year rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+        113
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+        Date
+      </div>
+    </div>
+    <div class="rux-clock__segment rux-clock__time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+        05:02:03 UTC
+      </div>
+      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+        Time
+      </div>
+    </div>
+  </mock:shadow-root>
+</rux-clock>
+`;

--- a/packages/web-components/src/components/rux-clock/test/index.html
+++ b/packages/web-components/src/components/rux-clock/test/index.html
@@ -19,6 +19,13 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
     <body>
-        <rux-clock></rux-clock>
+        <section>
+            <h2>Default</h2>
+            <rux-clock></rux-clock>
+        </section>
+        <section>
+            <h2>With Military Timezone</h2>
+            <rux-clock timezone="A"></rux-clock>
+        </section>
     </body>
 </html>


### PR DESCRIPTION
## Brief Description

This fixes a few issues with the AOS/LOS timestamps and timezones. When
changing the timezone, the AOS/LOS timestamps now update correctly to
show the selected timezone.


## JIRA Link

[ASTRO-2500](https://rocketcom.atlassian.net/browse/ASTRO-2500)

## General Notes

Clock tests now use Jest snapshots over `assertHTMLEquals` which was really annoying to maintain. We should probably move all tests to uses snapshots at some point. I feel like they might be slightly less readable though. 

## Issues and Limitations

Something really weird is going on in the tests. If I pass in strings as AOS/LOS timestamps, I get a totally unexpected output. `utcToZonedTime` returns '1988-04-22T15:12:12.000Z' in the test and returns '1988-04-22 09:12:12' in the browser. Created a separate ticket to look into this more. It behaves as expected in the browser. I suspect it has something to do with our testing config, setting TZ to UTC or the global mock we do.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
