### PR TITLE
build: rm npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
## Brief Description

removes .npmrc as we are no longer using it and it is causing errors in the changeset action