### PR TITLE
build: bump node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 12.x
+      - name: Setup Node.js 16.x
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 16.x
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
## Brief Description

bumps the version of node to 16 on the changeset action. when it goes to update the PR, it triggers the git hook to run our tests and that fails because stencil requires node 16