### PR TITLE
fix(astro-uxds): commented out failing widget

### DIFF
--- a/packages/astro-uxds/_includes/_footer.njk
+++ b/packages/astro-uxds/_includes/_footer.njk
@@ -41,14 +41,9 @@
 
 
 </footer>
-
-	{# <script 
-    data-jsd-embedded 
-    data-key="6b1e2081-b6c2-4a91-a844-fe72d7d91248" 
-    data-base-url="https://jsd-widget.atlassian.com" 
-    src="https://jsd-widget.atlassian.com/assets/embed.js"></script> #}
 	<script src="/js/site.js"></script>
-	<script data-jsd-embedded data-key="6b1e2081-b6c2-4a91-a844-fe72d7d91248" data-base-url="https://jsd-widget.atlassian.com" src="https://jsd-widget.atlassian.com/assets/embed.js"></script>
+	<!-- The below script is causing the site to not be interactable on mobile - data-key is probably expired -->
+	{# <script data-jsd-embedded data-key="6b1e2081-b6c2-4a91-a844-fe72d7d91248" data-base-url="https://jsd-widget.atlassian.com" src="https://jsd-widget.atlassian.com/assets/embed.js"></script> #}
 	<script 
 		async 
 		src="https://www.googletagmanager.com/gtag/js?id=UA-114182957-1"></script>


### PR DESCRIPTION
## Brief Description

Comments out the failing widget in footer.js, line 51
This was causing the site to not be interactive without a refresh.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2352
## Related Issue

## General Notes

Pretty sure that the data-id token has expired, thus the failing widget 
## Motivation and Context

Fixes broken links on mobile.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
