### PR TITLE
Astro 2608 shadow parts

### DIFF
--- a/.changeset/silly-pans-pull.md
+++ b/.changeset/silly-pans-pull.md
@@ -1,0 +1,11 @@
+---
+"@astrouxds/angular": minor
+"@astrouxds/astro-web-components": minor
+"@astrouxds/ag-grid-theme": minor
+"astro-website": minor
+"@astrouxds/react": minor
+---
+
+Adds new CSS Shadow Parts for `monitoring-badge`, `monitoring-label`, `monitoring-sublabel`, `container`, `icon-group`, `progress-display`, `radial-progress`, `status-icon`.
+
+Adds new CSS Shadow Parts for `monitoring-badge`, `monitoring-label`, `monitoring-sublabel`.

--- a/.changeset/silly-pans-pull.md
+++ b/.changeset/silly-pans-pull.md
@@ -6,6 +6,7 @@
 "@astrouxds/react": minor
 ---
 
-Adds new CSS Shadow Parts for `monitoring-badge`, `monitoring-label`, `monitoring-sublabel`, `container`, `icon-group`, `progress-display`, `radial-progress`, `status-icon`.
-
-Adds new CSS Shadow Parts for `monitoring-badge`, `monitoring-label`, `monitoring-sublabel`.
+- Monitoring Progress Icon
+  - Adds new CSS Shadow Parts for `monitoring-badge`, `monitoring-label`, `monitoring-sublabel`, `container`, `icon-group`, `progress-display`, `radial-progress`, `status-icon`.
+- Monitoring Icon
+  - Adds new CSS Shadow Parts for `monitoring-badge`, `monitoring-label`, `monitoring-sublabel`.

--- a/packages/angular/src/directives/proxies.ts
+++ b/packages/angular/src/directives/proxies.ts
@@ -19848,6 +19848,7 @@ export class RuxIconZoomOutMap {
 export declare interface RuxInput extends Components.RuxInput {}
 @ProxyCmp({
   inputs: [
+    "autocomplete",
     "disabled",
     "errorText",
     "helpText",
@@ -19857,8 +19858,10 @@ export declare interface RuxInput extends Components.RuxInput {}
     "min",
     "name",
     "placeholder",
+    "readonly",
     "required",
     "size",
+    "spellcheck",
     "step",
     "type",
     "value",
@@ -19869,6 +19872,7 @@ export declare interface RuxInput extends Components.RuxInput {}
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: "<ng-content></ng-content>",
   inputs: [
+    "autocomplete",
     "disabled",
     "errorText",
     "helpText",
@@ -19878,8 +19882,10 @@ export declare interface RuxInput extends Components.RuxInput {}
     "min",
     "name",
     "placeholder",
+    "readonly",
     "required",
     "size",
+    "spellcheck",
     "step",
     "type",
     "value",

--- a/packages/web-components/src/common/functional-components/MonitoringBadge/MonitoringBadge.tsx
+++ b/packages/web-components/src/common/functional-components/MonitoringBadge/MonitoringBadge.tsx
@@ -39,6 +39,7 @@ const MonitoringBadge: FunctionalComponent<MonitoringBadgeProps> = ({
         class={`rux-advanced-status__badge ${
             !notifications ? 'rux-advanced-status__hidden' : ''
         }`}
+        part="monitoring-badge"
     >
         {notifications && collapseNotifications(notifications)}
     </div>

--- a/packages/web-components/src/common/functional-components/MonitoringLabel.tsx
+++ b/packages/web-components/src/common/functional-components/MonitoringLabel.tsx
@@ -10,11 +10,12 @@ const MonitoringLabel: FunctionalComponent<MonitoringLabelProps> = ({
     sublabel,
 }) => (
     <div class="rux-advanced-status__label">
-        {label}
+        <span part="monitoring-label">{label}</span>
         <span
             class={`rux-advanced-status__sublabel ${
                 !sublabel ? 'rux-advanced-status__hidden' : ''
             }`}
+            part="monitoring-sublabel"
         >
             {sublabel}
         </span>

--- a/packages/web-components/src/components/rux-monitoring-icon/readme.md
+++ b/packages/web-components/src/components/rux-monitoring-icon/readme.md
@@ -114,6 +114,15 @@ Pass properties as attributes of the Astro Monitoring Progress Icon custom eleme
 | `sublabel`           | `sublabel`      | Displays a smaller label underneath the icon label                                                                                                                                                                                                                                      | `string \| undefined`                                                    | `undefined` |
 
 
+## Shadow Parts
+
+| Part                    | Description                        |
+| ----------------------- | ---------------------------------- |
+| `"monitoring-badge"`    | The component's notification badge |
+| `"monitoring-label"`    | The component's label              |
+| `"monitoring-sublabel"` | The component's sublabel           |
+
+
 ## Dependencies
 
 ### Depends on
@@ -132,3 +141,4 @@ graph TD;
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*
+````

--- a/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.tsx
+++ b/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.tsx
@@ -3,6 +3,11 @@ import { Status, StatusTypes } from '../../common/commonTypes.module'
 import MonitoringBadge from '../../common/functional-components/MonitoringBadge/MonitoringBadge'
 import MonitoringLabel from '../../common/functional-components/MonitoringLabel'
 
+/**
+ * @part monitoring-badge - The component's notification badge
+ * @part monitoring-label - The component's label
+ * @part monitoring-sublabel - The component's sublabel
+ */
 @Component({
     tag: 'rux-monitoring-icon',
     styleUrl: 'rux-monitoring-icon.scss',

--- a/packages/web-components/src/components/rux-monitoring-icon/test/rux-monitoring-icon.spec.tsx
+++ b/packages/web-components/src/components/rux-monitoring-icon/test/rux-monitoring-icon.spec.tsx
@@ -22,13 +22,15 @@ describe('rux-monitoring-icon', () => {
              <rux-status status="standby"></rux-status>
              </div>
              <rux-icon class="rux-status--standby" icon="altitude" size="2.5rem"></rux-icon>
-             <div class="rux-advanced-status__badge">
+             <div class="rux-advanced-status__badge" part="monitoring-badge">
                10K
              </div>
            </div>
            <div class="rux-advanced-status__label">
+            <span part="monitoring-label">
              Altitude for satellite X
-             <span class="rux-advanced-status__sublabel">
+             </span>
+             <span class="rux-advanced-status__sublabel" part="monitoring-sublabel">
                100000m
              </span>
            </div>

--- a/packages/web-components/src/components/rux-monitoring-progress-icon/readme.md
+++ b/packages/web-components/src/components/rux-monitoring-progress-icon/readme.md
@@ -95,7 +95,6 @@ A sample of a `range` Array. This sample is also the default value for `range`. 
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property             | Attribute       | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Type                  | Default     |
@@ -108,20 +107,33 @@ A sample of a `range` Array. This sample is also the default value for `range`. 
 | `range` _(required)_ | --              | Items in this Array define thresholds for changing the status style of the progress icon. For each item in the Array, the icon will be styled with the given status while the progress value is less than or equal to the Array item’s threshold and greater than the next smallest item‘s threshold. Both progress and the Array items’ threshold values can be positive or negative. If no min is specified, the component assumes the Array's first status threshold begins at 0.                                               | `RangeItem[]`         | `undefined` |
 | `sublabel`           | `sublabel`      | Displays a smaller label underneath the icon label                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `string \| undefined` | `undefined` |
 
+## Shadow Parts
+
+| Part                    | Description                                                                               |
+| ----------------------- | ----------------------------------------------------------------------------------------- |
+| `"container"`           | The component's container element                                                         |
+| `"icon-group"`          | A wrapper element containing the status icon, radial progress, and notification elements. |
+| `"monitoring-badge"`    | The component's notification badge                                                        |
+| `"monitoring-label"`    | The component's label                                                                     |
+| `"monitoring-sublabel"` | The component's sublabel                                                                  |
+| `"progress-display"`    | The component's progress value                                                            |
+| `"radial-progress"`     | The "donut"-style progress meter                                                          |
+| `"status-icon"`         | The component's status symbol                                                             |
 
 ## Dependencies
 
 ### Depends on
 
-- [rux-status](../rux-status)
+-   [rux-status](../rux-status)
 
 ### Graph
+
 ```mermaid
 graph TD;
   rux-monitoring-progress-icon --> rux-status
   style rux-monitoring-progress-icon fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.tsx
+++ b/packages/web-components/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.tsx
@@ -8,6 +8,16 @@ export interface RangeItem {
     status: Status
 }
 
+/**
+ * @part container - The component's container element
+ * @part radial-progress - The "donut"-style progress meter
+ * @part icon-group - A wrapper element containing the status icon, radial progress, and notification elements.
+ * @part status-icon - The component's status symbol
+ * @part progress-display - The component's progress value
+ * @part monitoring-badge - The component's notification badge
+ * @part monitoring-label - The component's label
+ * @part monitoring-sublabel - The component's sublabel
+ */
 @Component({
     tag: 'rux-monitoring-progress-icon',
     styleUrl: 'rux-monitoring-progress-icon.scss',
@@ -154,14 +164,19 @@ export class RuxMonitoringProgressIcon {
                 id="rux-advanced-status__icon"
                 class="rux-advanced-status"
                 title={`${this.notifications} ${this.label} ${this.sublabel}`}
+                part="container"
             >
-                <div class="rux-advanced-status__icon-group">
-                    <rux-status status={this._status}></rux-status>
+                <div class="rux-advanced-status__icon-group" part="icon-group">
+                    <rux-status
+                        status={this._status}
+                        part="status-icon"
+                    ></rux-status>
 
                     <svg
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 128 128"
                         class={`rux-status--${this._status}`}
+                        part="radial-progress"
                     >
                         <g id="progress">
                             <circle
@@ -187,7 +202,10 @@ export class RuxMonitoringProgressIcon {
                             />
                         </g>
                     </svg>
-                    <div class="rux-advanced-status__progress">
+                    <div
+                        class="rux-advanced-status__progress"
+                        part="progress-display"
+                    >
                         {Math.ceil(
                             ((this.progress - this.min) /
                                 (this.max - this.min)) *

--- a/packages/web-components/src/components/rux-monitoring-progress-icon/test/rux-monitoring-progress-icon.spec.tsx
+++ b/packages/web-components/src/components/rux-monitoring-progress-icon/test/rux-monitoring-progress-icon.spec.tsx
@@ -17,25 +17,27 @@ describe('rux-monitoring-progress-icon', () => {
         expect(page.root).toEqualHtml(`
       <rux-monitoring-progress-icon label="Label" max="100" notifications="345678" progress="70" sublabel="sublabel">
         <mock:shadow-root>
-          <div class="rux-advanced-status" id="rux-advanced-status__icon" title="345678 Label sublabel">
-            <div class="rux-advanced-status__icon-group">
-              <rux-status status="serious"></rux-status>
-              <svg class="rux-status--serious" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+          <div class="rux-advanced-status" id="rux-advanced-status__icon" title="345678 Label sublabel" part="container">
+            <div class="rux-advanced-status__icon-group" part="icon-group">
+              <rux-status status="serious" part="status-icon"></rux-status>
+              <svg class="rux-status--serious" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" part="radial-progress">
                 <g id="progress">
                   <circle cx="60" cy="60" fill="transparent" r="56" stroke="rgba(40, 63, 88, 1)" stroke-width="10" transform="rotate(-90 61 60)"></circle>
                   <circle class="progress-ring__circle" cx="60" cy="60" fill="transparent" r="56" stroke-dasharray="351.8583772 351.8583772" stroke-dashoffset="105.55751316061708" stroke-linecap="round" stroke-width="10" transform="rotate(-90 61 60)"></circle>
                 </g>
               </svg>
-              <div class="rux-advanced-status__progress">
+              <div class="rux-advanced-status__progress" part="progress-display">
                 70%
               </div>
-              <div class="rux-advanced-status__badge">
+              <div class="rux-advanced-status__badge" part="monitoring-badge">
                 345K
               </div>
             </div>
             <div class="rux-advanced-status__label">
-              Label
-              <span class="rux-advanced-status__sublabel">
+              <span part="monitoring-label">
+                Label
+              </span>
+              <span class="rux-advanced-status__sublabel" part="monitoring-sublabel">
                 sublabel
               </span>
             </div>


### PR DESCRIPTION
## Brief Description

Adds shadow parts for rux-monitoring-progress-icon

## JIRA Link

ASTRO-2608

## Issues and Limitations

rux-monitoring-icon also needed to be updated because it uses the same functional components for badge and label. 

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
