### PR TITLE
feat(classification-markings): tag, header and footer shadow part

### DIFF
--- a/.changeset/witty-dolls-cover.md
+++ b/.changeset/witty-dolls-cover.md
@@ -1,0 +1,9 @@
+---
+"@astrouxds/angular": minor
+"@astrouxds/react": minor
+"@astrouxds/astro-web-components": minor
+"@astrouxds/ag-grid-theme": minor
+"astro-website": minor
+---
+
+Added tag and header part to classification banner/tag, added footer part and notice of deprecation of footer-banner

--- a/packages/web-components/src/components/rux-classification-marking/readme.md
+++ b/packages/web-components/src/components/rux-classification-marking/readme.md
@@ -105,9 +105,11 @@ Applying the `label` property attribute to the classification custom element add
 
 ## Shadow Parts
 
-| Part              | Description       |
-| ----------------- | ----------------- |
-| `"footer-banner"` | the footer banner |
+| Part              | Description                      |
+| ----------------- | -------------------------------- |
+| `"container"`     | the container for the tag/banner |
+| `"footer"`        | the footer banner                |
+| `"footer-banner"` | the footer banner                |
 
 ## CSS Custom Properties
 

--- a/packages/web-components/src/components/rux-classification-marking/readme.md
+++ b/packages/web-components/src/components/rux-classification-marking/readme.md
@@ -105,11 +105,12 @@ Applying the `label` property attribute to the classification custom element add
 
 ## Shadow Parts
 
-| Part              | Description                      |
-| ----------------- | -------------------------------- |
-| `"container"`     | the container for the tag/banner |
-| `"footer"`        | the footer banner                |
-| `"footer-banner"` | the footer banner                |
+| Part              | Description                                         |
+| ----------------- | --------------------------------------------------- |
+| `"footer"`        | the footer banner                                   |
+| `"footer-banner"` | the footer banner ! DEPRECATED IN FAVOR OF FOOTER ! |
+| `"header"`        | the container for the header banner                 |
+| `"tag"`           | the container for the tag                           |
 
 ## CSS Custom Properties
 

--- a/packages/web-components/src/components/rux-classification-marking/rux-classification-marking.tsx
+++ b/packages/web-components/src/components/rux-classification-marking/rux-classification-marking.tsx
@@ -3,9 +3,10 @@ import { Classification } from '../../common/commonTypes.module'
 import { hasSlot } from '../../utils/utils'
 
 /**
- * @part footer-banner - the footer banner
+ * @part footer-banner - the footer banner ! DEPRECATED IN FAVOR OF FOOTER !
  * @part footer - the footer banner
- * @part container - the container for the tag/banner
+ * @part tag - the container for the tag
+ * @part header - the container for the header banner
  *
  */
 @Component({
@@ -86,7 +87,7 @@ export class RuxClassificationMarking {
                         'rux-classification--tag': type === 'tag',
                         'rux-classification--banner': type === 'banner',
                     }}
-                    part="container"
+                    part="tag header"
                 >
                     {this._getDisplayData()}
                     {label}

--- a/packages/web-components/src/components/rux-classification-marking/rux-classification-marking.tsx
+++ b/packages/web-components/src/components/rux-classification-marking/rux-classification-marking.tsx
@@ -4,6 +4,8 @@ import { hasSlot } from '../../utils/utils'
 
 /**
  * @part footer-banner - the footer banner
+ * @part footer - the footer banner
+ * @part container - the container for the tag/banner
  *
  */
 @Component({
@@ -84,6 +86,7 @@ export class RuxClassificationMarking {
                         'rux-classification--tag': type === 'tag',
                         'rux-classification--banner': type === 'banner',
                     }}
+                    part="container"
                 >
                     {this._getDisplayData()}
                     {label}
@@ -97,7 +100,7 @@ export class RuxClassificationMarking {
                             'rux-classification--banner__footer':
                                 isWrapper === true,
                         }}
-                        part="footer-banner"
+                        part="footer-banner footer"
                     >
                         {this._getDisplayData()}
                         {label}

--- a/packages/web-components/src/components/rux-classification-marking/test/__snapshots__/rux-classification-marking.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-classification-marking/test/__snapshots__/rux-classification-marking.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`rux-classification-marking renders component with no properties set 1`] = `
 <rux-classification-marking classification="unclassified">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner" part="container">
+    <div class="rux-classification rux-classification--banner" part="tag header">
       unclassified
     </div>
     <slot></slot>
@@ -14,7 +14,7 @@ exports[`rux-classification-marking renders component with no properties set 1`]
 exports[`rux-classification-marking rux-classification-marking banners renders confidential banner 1`] = `
 <rux-classification-marking classification="confidential">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner" part="container">
+    <div class="rux-classification rux-classification--banner" part="tag header">
       confidential
     </div>
     <slot></slot>
@@ -25,7 +25,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders c
 exports[`rux-classification-marking rux-classification-marking banners renders controlled banner 1`] = `
 <rux-classification-marking classification="controlled">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner" part="container">
+    <div class="rux-classification rux-classification--banner" part="tag header">
       controlled
     </div>
     <slot></slot>
@@ -36,7 +36,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders c
 exports[`rux-classification-marking rux-classification-marking banners renders cui banner 1`] = `
 <rux-classification-marking classification="cui">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner" part="container">
+    <div class="rux-classification rux-classification--banner" part="tag header">
       cui
     </div>
     <slot></slot>
@@ -47,7 +47,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders c
 exports[`rux-classification-marking rux-classification-marking banners renders secret banner 1`] = `
 <rux-classification-marking classification="secret">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner" part="container">
+    <div class="rux-classification rux-classification--banner" part="tag header">
       secret
     </div>
     <slot></slot>
@@ -58,7 +58,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders s
 exports[`rux-classification-marking rux-classification-marking banners renders tincorrect option banner 1`] = `
 <rux-classification-marking classification="notapprovedoption">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner" part="container"></div>
+    <div class="rux-classification rux-classification--banner" part="tag header"></div>
     <slot></slot>
   </mock:shadow-root>
 </rux-classification-marking>
@@ -67,7 +67,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders t
 exports[`rux-classification-marking rux-classification-marking banners renders top secret banner 1`] = `
 <rux-classification-marking classification="top-secret">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner" part="container">
+    <div class="rux-classification rux-classification--banner" part="tag header">
       top secret
     </div>
     <slot></slot>
@@ -78,7 +78,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders t
 exports[`rux-classification-marking rux-classification-marking banners renders top secret sci banner 1`] = `
 <rux-classification-marking classification="top-secret-sci">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner" part="container">
+    <div class="rux-classification rux-classification--banner" part="tag header">
       top secret//sci
     </div>
     <slot></slot>
@@ -89,7 +89,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders t
 exports[`rux-classification-marking rux-classification-marking banners renders unclassified banner 1`] = `
 <rux-classification-marking classification="unclassified">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner" part="container">
+    <div class="rux-classification rux-classification--banner" part="tag header">
       unclassified
     </div>
     <slot></slot>
@@ -100,7 +100,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders u
 exports[`rux-classification-marking rux-classification-marking label renders footer banner 1`] = `
 <rux-classification-marking classification="secret">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner" part="container">
+    <div class="rux-classification rux-classification--banner" part="tag header">
       secret
     </div>
     <slot></slot>
@@ -114,7 +114,7 @@ exports[`rux-classification-marking rux-classification-marking label renders foo
 exports[`rux-classification-marking rux-classification-marking label renders unclassified banner label 1`] = `
 <rux-classification-marking classification="unclassified" label="-hello world-">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner" part="container">
+    <div class="rux-classification rux-classification--banner" part="tag header">
       unclassified-hello world-
     </div>
     <slot></slot>
@@ -125,7 +125,7 @@ exports[`rux-classification-marking rux-classification-marking label renders unc
 exports[`rux-classification-marking rux-classification-marking label renders unclassified tag label 1`] = `
 <rux-classification-marking classification="unclassified" label="-hello world-" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag" part="container">
+    <div class="rux-classification rux-classification--tag" part="tag header">
       u-hello world-
     </div>
     <slot></slot>
@@ -136,7 +136,7 @@ exports[`rux-classification-marking rux-classification-marking label renders unc
 exports[`rux-classification-marking rux-classification-marking tags renders confidential tag 1`] = `
 <rux-classification-marking classification="confidential" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag" part="container">
+    <div class="rux-classification rux-classification--tag" part="tag header">
       c
     </div>
     <slot></slot>
@@ -147,7 +147,7 @@ exports[`rux-classification-marking rux-classification-marking tags renders conf
 exports[`rux-classification-marking rux-classification-marking tags renders controlled tag 1`] = `
 <rux-classification-marking classification="controlled" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag" part="container">
+    <div class="rux-classification rux-classification--tag" part="tag header">
       cui
     </div>
     <slot></slot>
@@ -158,7 +158,7 @@ exports[`rux-classification-marking rux-classification-marking tags renders cont
 exports[`rux-classification-marking rux-classification-marking tags renders incorrect option tag 1`] = `
 <rux-classification-marking classification="notapprovedoption" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag" part="container"></div>
+    <div class="rux-classification rux-classification--tag" part="tag header"></div>
     <slot></slot>
   </mock:shadow-root>
 </rux-classification-marking>
@@ -167,7 +167,7 @@ exports[`rux-classification-marking rux-classification-marking tags renders inco
 exports[`rux-classification-marking rux-classification-marking tags renders secret tag 1`] = `
 <rux-classification-marking classification="secret" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag" part="container">
+    <div class="rux-classification rux-classification--tag" part="tag header">
       s
     </div>
     <slot></slot>
@@ -178,7 +178,7 @@ exports[`rux-classification-marking rux-classification-marking tags renders secr
 exports[`rux-classification-marking rux-classification-marking tags renders top secret sci tag 1`] = `
 <rux-classification-marking classification="top-secret-sci" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag" part="container">
+    <div class="rux-classification rux-classification--tag" part="tag header">
       TS//SCI
     </div>
     <slot></slot>
@@ -189,7 +189,7 @@ exports[`rux-classification-marking rux-classification-marking tags renders top 
 exports[`rux-classification-marking rux-classification-marking tags renders top secret tag 1`] = `
 <rux-classification-marking classification="top-secret" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag" part="container">
+    <div class="rux-classification rux-classification--tag" part="tag header">
       ts
     </div>
     <slot></slot>
@@ -200,7 +200,7 @@ exports[`rux-classification-marking rux-classification-marking tags renders top 
 exports[`rux-classification-marking rux-classification-marking tags renders unclassified tag 1`] = `
 <rux-classification-marking classification="unclassified" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag" part="container">
+    <div class="rux-classification rux-classification--tag" part="tag header">
       u
     </div>
     <slot></slot>

--- a/packages/web-components/src/components/rux-classification-marking/test/__snapshots__/rux-classification-marking.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-classification-marking/test/__snapshots__/rux-classification-marking.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`rux-classification-marking renders component with no properties set 1`] = `
 <rux-classification-marking classification="unclassified">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner">
+    <div class="rux-classification rux-classification--banner" part="container">
       unclassified
     </div>
     <slot></slot>
@@ -14,7 +14,7 @@ exports[`rux-classification-marking renders component with no properties set 1`]
 exports[`rux-classification-marking rux-classification-marking banners renders confidential banner 1`] = `
 <rux-classification-marking classification="confidential">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner">
+    <div class="rux-classification rux-classification--banner" part="container">
       confidential
     </div>
     <slot></slot>
@@ -25,7 +25,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders c
 exports[`rux-classification-marking rux-classification-marking banners renders controlled banner 1`] = `
 <rux-classification-marking classification="controlled">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner">
+    <div class="rux-classification rux-classification--banner" part="container">
       controlled
     </div>
     <slot></slot>
@@ -36,7 +36,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders c
 exports[`rux-classification-marking rux-classification-marking banners renders cui banner 1`] = `
 <rux-classification-marking classification="cui">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner">
+    <div class="rux-classification rux-classification--banner" part="container">
       cui
     </div>
     <slot></slot>
@@ -47,7 +47,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders c
 exports[`rux-classification-marking rux-classification-marking banners renders secret banner 1`] = `
 <rux-classification-marking classification="secret">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner">
+    <div class="rux-classification rux-classification--banner" part="container">
       secret
     </div>
     <slot></slot>
@@ -58,7 +58,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders s
 exports[`rux-classification-marking rux-classification-marking banners renders tincorrect option banner 1`] = `
 <rux-classification-marking classification="notapprovedoption">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner"></div>
+    <div class="rux-classification rux-classification--banner" part="container"></div>
     <slot></slot>
   </mock:shadow-root>
 </rux-classification-marking>
@@ -67,7 +67,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders t
 exports[`rux-classification-marking rux-classification-marking banners renders top secret banner 1`] = `
 <rux-classification-marking classification="top-secret">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner">
+    <div class="rux-classification rux-classification--banner" part="container">
       top secret
     </div>
     <slot></slot>
@@ -78,7 +78,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders t
 exports[`rux-classification-marking rux-classification-marking banners renders top secret sci banner 1`] = `
 <rux-classification-marking classification="top-secret-sci">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner">
+    <div class="rux-classification rux-classification--banner" part="container">
       top secret//sci
     </div>
     <slot></slot>
@@ -89,7 +89,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders t
 exports[`rux-classification-marking rux-classification-marking banners renders unclassified banner 1`] = `
 <rux-classification-marking classification="unclassified">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner">
+    <div class="rux-classification rux-classification--banner" part="container">
       unclassified
     </div>
     <slot></slot>
@@ -100,7 +100,7 @@ exports[`rux-classification-marking rux-classification-marking banners renders u
 exports[`rux-classification-marking rux-classification-marking label renders footer banner 1`] = `
 <rux-classification-marking classification="secret">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner">
+    <div class="rux-classification rux-classification--banner" part="container">
       secret
     </div>
     <slot></slot>
@@ -114,7 +114,7 @@ exports[`rux-classification-marking rux-classification-marking label renders foo
 exports[`rux-classification-marking rux-classification-marking label renders unclassified banner label 1`] = `
 <rux-classification-marking classification="unclassified" label="-hello world-">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--banner">
+    <div class="rux-classification rux-classification--banner" part="container">
       unclassified-hello world-
     </div>
     <slot></slot>
@@ -125,7 +125,7 @@ exports[`rux-classification-marking rux-classification-marking label renders unc
 exports[`rux-classification-marking rux-classification-marking label renders unclassified tag label 1`] = `
 <rux-classification-marking classification="unclassified" label="-hello world-" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag">
+    <div class="rux-classification rux-classification--tag" part="container">
       u-hello world-
     </div>
     <slot></slot>
@@ -136,7 +136,7 @@ exports[`rux-classification-marking rux-classification-marking label renders unc
 exports[`rux-classification-marking rux-classification-marking tags renders confidential tag 1`] = `
 <rux-classification-marking classification="confidential" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag">
+    <div class="rux-classification rux-classification--tag" part="container">
       c
     </div>
     <slot></slot>
@@ -147,7 +147,7 @@ exports[`rux-classification-marking rux-classification-marking tags renders conf
 exports[`rux-classification-marking rux-classification-marking tags renders controlled tag 1`] = `
 <rux-classification-marking classification="controlled" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag">
+    <div class="rux-classification rux-classification--tag" part="container">
       cui
     </div>
     <slot></slot>
@@ -158,7 +158,7 @@ exports[`rux-classification-marking rux-classification-marking tags renders cont
 exports[`rux-classification-marking rux-classification-marking tags renders incorrect option tag 1`] = `
 <rux-classification-marking classification="notapprovedoption" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag"></div>
+    <div class="rux-classification rux-classification--tag" part="container"></div>
     <slot></slot>
   </mock:shadow-root>
 </rux-classification-marking>
@@ -167,7 +167,7 @@ exports[`rux-classification-marking rux-classification-marking tags renders inco
 exports[`rux-classification-marking rux-classification-marking tags renders secret tag 1`] = `
 <rux-classification-marking classification="secret" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag">
+    <div class="rux-classification rux-classification--tag" part="container">
       s
     </div>
     <slot></slot>
@@ -178,7 +178,7 @@ exports[`rux-classification-marking rux-classification-marking tags renders secr
 exports[`rux-classification-marking rux-classification-marking tags renders top secret sci tag 1`] = `
 <rux-classification-marking classification="top-secret-sci" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag">
+    <div class="rux-classification rux-classification--tag" part="container">
       TS//SCI
     </div>
     <slot></slot>
@@ -189,7 +189,7 @@ exports[`rux-classification-marking rux-classification-marking tags renders top 
 exports[`rux-classification-marking rux-classification-marking tags renders top secret tag 1`] = `
 <rux-classification-marking classification="top-secret" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag">
+    <div class="rux-classification rux-classification--tag" part="container">
       ts
     </div>
     <slot></slot>
@@ -200,7 +200,7 @@ exports[`rux-classification-marking rux-classification-marking tags renders top 
 exports[`rux-classification-marking rux-classification-marking tags renders unclassified tag 1`] = `
 <rux-classification-marking classification="unclassified" tag="">
   <mock:shadow-root>
-    <div class="rux-classification rux-classification--tag">
+    <div class="rux-classification rux-classification--tag" part="container">
       u
     </div>
     <slot></slot>


### PR DESCRIPTION
## Brief Description

Adds a tag, header and footer shadow part to rux-classification-marking

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2635

## Related Issue

## General Notes

Classification markings contains two main divs, the normal banner/tag and the footer banner (which cannot be a tag). The footer already has a shadow part named footer-banner

## Motivation and Context

shadow part effort

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
