### PR TITLE
Astro 2636 clock parts

### DIFF
--- a/.changeset/nine-owls-burn.md
+++ b/.changeset/nine-owls-burn.md
@@ -1,0 +1,9 @@
+---
+"@astrouxds/angular": minor
+"@astrouxds/react": minor
+"@astrouxds/astro-web-components": minor
+"@astrouxds/ag-grid-theme": minor
+"astro-website": minor
+---
+
+Added shadow parts to rux-clock

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,4 +42,4 @@ jobs:
         run: npm i
 
       - name: Commit Lint
-        run: npx commitlint --from HEAD~${{ github.event.pull_request.commits }} --to HEAD
+        run: npx commitlint --from HEAD~${{ github.event.pull_request.commits }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,4 +42,4 @@ jobs:
         run: npm i
 
       - name: Commit Lint
-        run: npx commitlint --from HEAD~${{ github.event.pull_request.commits }}
+        run: npx commitlint --from HEAD~${{ github.event.pull_request.commits }} --to HEAD

--- a/packages/web-components/src/components/rux-clock/readme.md
+++ b/packages/web-components/src/components/rux-clock/readme.md
@@ -52,7 +52,6 @@ Define AOS and LOS with valid [Unix Time Stamp](http://pubs.opengroup.org/online
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property       | Attribute       | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Type                  | Default     |
@@ -65,6 +64,18 @@ Define AOS and LOS with valid [Unix Time Stamp](http://pubs.opengroup.org/online
 | `small`        | `small`         | Applies a smaller clock style.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | `boolean`             | `false`     |
 | `timezone`     | `timezone`      | Accepts the [IANA timezone string format](https://www.iana.org/time-zones) such as `'America/Los_Angeles'` or any single-character designation for a [military timezones](https://en.wikipedia.org/wiki/List_of_military_time_zones) (`'A'` through `'Z'`, excluding `'J'`), both case-insensitive. If no value for timezone is provided, the clock will use `'UTC'`. See [`toLocaleString()` on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString#Parameters) for more details. | `string`              | `'UTC'`     |
 
+## Shadow Parts
+
+| Part           | Description                                 |
+| -------------- | ------------------------------------------- |
+| `"aos"`        | the container for the aos section of clock  |
+| `"aos-label"`  | the container for the aos label             |
+| `"date"`       | the container for the date section of clock |
+| `"date-label"` | the container for the date label            |
+| `"los"`        | the container for the los section of clock  |
+| `"los-label"`  | the container for the los label             |
+| `"time"`       | the conatiner for the time section of clock |
+| `"time-label"` | the container for the time label            |
 
 ## CSS Custom Properties
 
@@ -75,7 +86,6 @@ Define AOS and LOS with valid [Unix Time Stamp](http://pubs.opengroup.org/online
 | `--clock-label-color`      | the label color for the clock      |
 | `--clock-text-color`       | the color of the clock text        |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-clock/rux-clock.tsx
+++ b/packages/web-components/src/components/rux-clock/rux-clock.tsx
@@ -164,8 +164,8 @@ export class RuxClock {
                     <div class="rux-clock__segment">
                         <div
                             class="rux-clock__segment__value"
-                            part="date"
                             aria-labelledby="rux-clock__day-of-year-label"
+                            part="date"
                         >
                             {this.dayOfYear}
                         </div>
@@ -181,7 +181,7 @@ export class RuxClock {
                     </div>
                 )}
 
-                <div class="rux-clock__segment" part="time">
+                <div class="rux-clock__segment">
                     <div
                         class="rux-clock__segment__value"
                         aria-labelledby="rux-clock__time-label"

--- a/packages/web-components/src/components/rux-clock/rux-clock.tsx
+++ b/packages/web-components/src/components/rux-clock/rux-clock.tsx
@@ -4,6 +4,16 @@ import { format, utcToZonedTime } from 'date-fns-tz'
 import { militaryTimezones } from './military-timezones'
 import { MilitaryTimezone } from './rux-clock.model'
 
+/**
+ * @part date - the container for the date section of clock
+ * @part date-label - the container for the date label
+ * @part time - the conatiner for the time section of clock
+ * @part time-label - the container for the time label
+ * @part aos - the container for the aos section of clock
+ * @part aos-label - the container for the aos label
+ * @part los - the container for the los section of clock
+ * @part los-label - the container for the los label
+ */
 @Component({
     tag: 'rux-clock',
     styleUrl: 'rux-clock.scss',
@@ -151,9 +161,10 @@ export class RuxClock {
         return (
             <Host>
                 {!this.hideDate && (
-                    <div class="rux-clock__segment rux-clock__day-of-the-year">
+                    <div class="rux-clock__segment">
                         <div
                             class="rux-clock__segment__value"
+                            part="date"
                             aria-labelledby="rux-clock__day-of-year-label"
                         >
                             {this.dayOfYear}
@@ -162,6 +173,7 @@ export class RuxClock {
                             <div
                                 class="rux-clock__segment__label"
                                 id="rux-clock__day-of-year-label"
+                                part="date-label"
                             >
                                 Date
                             </div>
@@ -169,10 +181,11 @@ export class RuxClock {
                     </div>
                 )}
 
-                <div class="rux-clock__segment rux-clock__time">
+                <div class="rux-clock__segment" part="time">
                     <div
                         class="rux-clock__segment__value"
                         aria-labelledby="rux-clock__time-label"
+                        part="time"
                     >
                         {this.time}
                     </div>
@@ -180,6 +193,7 @@ export class RuxClock {
                         <div
                             class="rux-clock__segment__label"
                             id="rux-clock__time-label"
+                            part="time-label"
                         >
                             Time
                         </div>
@@ -192,6 +206,7 @@ export class RuxClock {
                             class="rux-clock__segment__value"
                             aria-labelledby="rux-clock__time-label--aos"
                             id="rux-clock__time--aos"
+                            part="aos"
                         >
                             {this.convertedAos}
                         </div>
@@ -199,6 +214,7 @@ export class RuxClock {
                             <div
                                 class="rux-clock__segment__label"
                                 id="rux-clock__time-label--aos"
+                                part="aos-label"
                             >
                                 AOS
                             </div>
@@ -212,6 +228,7 @@ export class RuxClock {
                             class="rux-clock__segment__value"
                             aria-labelledby="rux-clock__time-label--los"
                             id="rux-clock__time--los"
+                            part="los"
                         >
                             {this.convertedLos}
                         </div>
@@ -219,6 +236,7 @@ export class RuxClock {
                             <div
                                 class="rux-clock__segment__label"
                                 id="rux-clock__time-label--los"
+                                part="los-label"
                             >
                                 LOS
                             </div>

--- a/packages/web-components/src/components/rux-clock/test/__snapshots__/rux-clock.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-clock/test/__snapshots__/rux-clock.spec.tsx.snap
@@ -3,19 +3,19 @@
 exports[`rux-clock converts all military timezones 1`] = `
 <rux-clock timezone="A">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         02:02:03 GMT+1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -26,19 +26,19 @@ exports[`rux-clock converts all military timezones 1`] = `
 exports[`rux-clock converts all military timezones 2`] = `
 <rux-clock timezone="B">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         03:02:03 GMT+2
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -49,19 +49,19 @@ exports[`rux-clock converts all military timezones 2`] = `
 exports[`rux-clock converts all military timezones 3`] = `
 <rux-clock timezone="C">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         04:02:03 GMT+3
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -72,19 +72,19 @@ exports[`rux-clock converts all military timezones 3`] = `
 exports[`rux-clock converts all military timezones 4`] = `
 <rux-clock timezone="D">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         05:02:03 GMT+4
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -95,19 +95,19 @@ exports[`rux-clock converts all military timezones 4`] = `
 exports[`rux-clock converts all military timezones 5`] = `
 <rux-clock timezone="E">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         06:02:03 GMT+5
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -118,19 +118,19 @@ exports[`rux-clock converts all military timezones 5`] = `
 exports[`rux-clock converts all military timezones 6`] = `
 <rux-clock timezone="F">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         07:02:03 GMT+6
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -141,19 +141,19 @@ exports[`rux-clock converts all military timezones 6`] = `
 exports[`rux-clock converts all military timezones 7`] = `
 <rux-clock timezone="G">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         08:02:03 GMT+7
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -164,19 +164,19 @@ exports[`rux-clock converts all military timezones 7`] = `
 exports[`rux-clock converts all military timezones 8`] = `
 <rux-clock timezone="H">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         09:02:03 GMT+8
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -187,19 +187,19 @@ exports[`rux-clock converts all military timezones 8`] = `
 exports[`rux-clock converts all military timezones 9`] = `
 <rux-clock timezone="I">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         10:02:03 GMT+9
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -210,19 +210,19 @@ exports[`rux-clock converts all military timezones 9`] = `
 exports[`rux-clock converts all military timezones 10`] = `
 <rux-clock timezone="K">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         11:02:03 GMT+10
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -233,19 +233,19 @@ exports[`rux-clock converts all military timezones 10`] = `
 exports[`rux-clock converts all military timezones 11`] = `
 <rux-clock timezone="L">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         12:02:03 GMT+11
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -256,19 +256,19 @@ exports[`rux-clock converts all military timezones 11`] = `
 exports[`rux-clock converts all military timezones 12`] = `
 <rux-clock timezone="M">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         13:02:03 GMT+12
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -279,19 +279,19 @@ exports[`rux-clock converts all military timezones 12`] = `
 exports[`rux-clock converts all military timezones 13`] = `
 <rux-clock timezone="N">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         00:02:03 GMT-1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -302,19 +302,19 @@ exports[`rux-clock converts all military timezones 13`] = `
 exports[`rux-clock converts all military timezones 14`] = `
 <rux-clock timezone="O">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         366
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         23:02:03 GMT-2
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -325,19 +325,19 @@ exports[`rux-clock converts all military timezones 14`] = `
 exports[`rux-clock converts all military timezones 15`] = `
 <rux-clock timezone="P">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         366
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         22:02:03 GMT-3
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -348,19 +348,19 @@ exports[`rux-clock converts all military timezones 15`] = `
 exports[`rux-clock converts all military timezones 16`] = `
 <rux-clock timezone="Q">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         366
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         21:02:03 GMT-4
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -371,19 +371,19 @@ exports[`rux-clock converts all military timezones 16`] = `
 exports[`rux-clock converts all military timezones 17`] = `
 <rux-clock timezone="R">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         366
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         20:02:03 GMT-5
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -394,19 +394,19 @@ exports[`rux-clock converts all military timezones 17`] = `
 exports[`rux-clock converts all military timezones 18`] = `
 <rux-clock timezone="S">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         366
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         19:02:03 GMT-6
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -417,19 +417,19 @@ exports[`rux-clock converts all military timezones 18`] = `
 exports[`rux-clock converts all military timezones 19`] = `
 <rux-clock timezone="T">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         366
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         18:02:03 GMT-7
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -440,19 +440,19 @@ exports[`rux-clock converts all military timezones 19`] = `
 exports[`rux-clock converts all military timezones 20`] = `
 <rux-clock timezone="U">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         366
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         17:02:03 GMT-8
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -463,19 +463,19 @@ exports[`rux-clock converts all military timezones 20`] = `
 exports[`rux-clock converts all military timezones 21`] = `
 <rux-clock timezone="V">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         366
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         16:02:03 GMT-9
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -486,19 +486,19 @@ exports[`rux-clock converts all military timezones 21`] = `
 exports[`rux-clock converts all military timezones 22`] = `
 <rux-clock timezone="W">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         366
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         15:02:03 GMT-10
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -509,19 +509,19 @@ exports[`rux-clock converts all military timezones 22`] = `
 exports[`rux-clock converts all military timezones 23`] = `
 <rux-clock timezone="X">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         366
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         14:02:03 GMT-11
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -532,19 +532,19 @@ exports[`rux-clock converts all military timezones 23`] = `
 exports[`rux-clock converts all military timezones 24`] = `
 <rux-clock timezone="Y">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         366
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         13:02:03 GMT-12
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -555,19 +555,19 @@ exports[`rux-clock converts all military timezones 24`] = `
 exports[`rux-clock converts all military timezones 25`] = `
 <rux-clock timezone="Z">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 Z
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -578,35 +578,35 @@ exports[`rux-clock converts all military timezones 25`] = `
 exports[`rux-clock converts aos/los unix timestamps when timezone is changed 1`] = `
 <rux-clock aos="1638373590145" los="1638373590145">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
     <div class="rux-clock__aos rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos">
+      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos" part="aos">
         15:46:30
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos" part="aos-label">
         AOS
       </div>
     </div>
     <div class="rux-clock__los rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los">
+      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los" part="los">
         15:46:30
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--los">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--los" part="los-label">
         LOS
       </div>
     </div>
@@ -617,35 +617,35 @@ exports[`rux-clock converts aos/los unix timestamps when timezone is changed 1`]
 exports[`rux-clock converts aos/los unix timestamps when timezone is changed 2`] = `
 <rux-clock aos="1638373590145" los="1638373590145" timezone="America/Los_Angeles">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         366
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         17:02:03 PST
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
     <div class="rux-clock__aos rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos">
+      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos" part="aos">
         07:46:30
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos" part="aos-label">
         AOS
       </div>
     </div>
     <div class="rux-clock__los rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los">
+      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los" part="los">
         07:46:30
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--los">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--los" part="los-label">
         LOS
       </div>
     </div>
@@ -656,19 +656,19 @@ exports[`rux-clock converts aos/los unix timestamps when timezone is changed 2`]
 exports[`rux-clock converts time to timezone 1`] = `
 <rux-clock timezone="America/Los_Angeles">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         366
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         17:02:03 PST
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -679,19 +679,19 @@ exports[`rux-clock converts time to timezone 1`] = `
 exports[`rux-clock converts time to timezone on the fly 1`] = `
 <rux-clock>
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -702,19 +702,19 @@ exports[`rux-clock converts time to timezone on the fly 1`] = `
 exports[`rux-clock converts time to timezone on the fly 2`] = `
 <rux-clock timezone="America/Los_Angeles">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         366
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         17:02:03 PST
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -725,11 +725,11 @@ exports[`rux-clock converts time to timezone on the fly 2`] = `
 exports[`rux-clock hides the date 1`] = `
 <rux-clock hide-date="">
   <mock:shadow-root>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -740,13 +740,13 @@ exports[`rux-clock hides the date 1`] = `
 exports[`rux-clock hides the labels 1`] = `
 <rux-clock hide-labels="">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
     </div>
@@ -757,19 +757,19 @@ exports[`rux-clock hides the labels 1`] = `
 exports[`rux-clock hides the timezone 1`] = `
 <rux-clock hide-timezone="">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
@@ -780,27 +780,27 @@ exports[`rux-clock hides the timezone 1`] = `
 exports[`rux-clock shows and updates aos 1`] = `
 <rux-clock aos="1988-04-22 12:12:12">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
     <div class="rux-clock__aos rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos">
+      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos" part="aos">
         12:12:12
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos" part="aos-label">
         AOS
       </div>
     </div>
@@ -811,27 +811,27 @@ exports[`rux-clock shows and updates aos 1`] = `
 exports[`rux-clock shows and updates aos 2`] = `
 <rux-clock aos="1988-04-22 09:12:12">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
     <div class="rux-clock__aos rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos">
+      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos" part="aos">
         09:12:12
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos" part="aos-label">
         AOS
       </div>
     </div>
@@ -842,27 +842,27 @@ exports[`rux-clock shows and updates aos 2`] = `
 exports[`rux-clock shows and updates los 1`] = `
 <rux-clock los="1988-04-22 12:12:12">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
     <div class="rux-clock__los rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los">
+      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los" part="los">
         12:12:12
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--los">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--los" part="los-label">
         LOS
       </div>
     </div>
@@ -873,27 +873,27 @@ exports[`rux-clock shows and updates los 1`] = `
 exports[`rux-clock shows and updates los 2`] = `
 <rux-clock los="1988-04-22 09:12:12">
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>
     <div class="rux-clock__los rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los">
+      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los" part="los">
         09:12:12
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--los">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label--los" part="los-label">
         LOS
       </div>
     </div>
@@ -904,19 +904,19 @@ exports[`rux-clock shows and updates los 2`] = `
 exports[`rux-clock shows the current time 1`] = `
 <rux-clock>
   <mock:shadow-root>
-    <div class="rux-clock__day-of-the-year rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment">
+      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
         1
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label">
+      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
       </div>
     </div>
-    <div class="rux-clock__segment rux-clock__time">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value">
+    <div class="rux-clock__segment" part="time">
+      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label">
+      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
         Time
       </div>
     </div>

--- a/packages/web-components/src/components/rux-clock/test/__snapshots__/rux-clock.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-clock/test/__snapshots__/rux-clock.spec.tsx.snap
@@ -11,7 +11,7 @@ exports[`rux-clock converts all military timezones 1`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         02:02:03 GMT+1
       </div>
@@ -34,7 +34,7 @@ exports[`rux-clock converts all military timezones 2`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         03:02:03 GMT+2
       </div>
@@ -57,7 +57,7 @@ exports[`rux-clock converts all military timezones 3`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         04:02:03 GMT+3
       </div>
@@ -80,7 +80,7 @@ exports[`rux-clock converts all military timezones 4`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         05:02:03 GMT+4
       </div>
@@ -103,7 +103,7 @@ exports[`rux-clock converts all military timezones 5`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         06:02:03 GMT+5
       </div>
@@ -126,7 +126,7 @@ exports[`rux-clock converts all military timezones 6`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         07:02:03 GMT+6
       </div>
@@ -149,7 +149,7 @@ exports[`rux-clock converts all military timezones 7`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         08:02:03 GMT+7
       </div>
@@ -172,7 +172,7 @@ exports[`rux-clock converts all military timezones 8`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         09:02:03 GMT+8
       </div>
@@ -195,7 +195,7 @@ exports[`rux-clock converts all military timezones 9`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         10:02:03 GMT+9
       </div>
@@ -218,7 +218,7 @@ exports[`rux-clock converts all military timezones 10`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         11:02:03 GMT+10
       </div>
@@ -241,7 +241,7 @@ exports[`rux-clock converts all military timezones 11`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         12:02:03 GMT+11
       </div>
@@ -264,7 +264,7 @@ exports[`rux-clock converts all military timezones 12`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         13:02:03 GMT+12
       </div>
@@ -287,7 +287,7 @@ exports[`rux-clock converts all military timezones 13`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         00:02:03 GMT-1
       </div>
@@ -310,7 +310,7 @@ exports[`rux-clock converts all military timezones 14`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         23:02:03 GMT-2
       </div>
@@ -333,7 +333,7 @@ exports[`rux-clock converts all military timezones 15`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         22:02:03 GMT-3
       </div>
@@ -356,7 +356,7 @@ exports[`rux-clock converts all military timezones 16`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         21:02:03 GMT-4
       </div>
@@ -379,7 +379,7 @@ exports[`rux-clock converts all military timezones 17`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         20:02:03 GMT-5
       </div>
@@ -402,7 +402,7 @@ exports[`rux-clock converts all military timezones 18`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         19:02:03 GMT-6
       </div>
@@ -425,7 +425,7 @@ exports[`rux-clock converts all military timezones 19`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         18:02:03 GMT-7
       </div>
@@ -448,7 +448,7 @@ exports[`rux-clock converts all military timezones 20`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         17:02:03 GMT-8
       </div>
@@ -471,7 +471,7 @@ exports[`rux-clock converts all military timezones 21`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         16:02:03 GMT-9
       </div>
@@ -494,7 +494,7 @@ exports[`rux-clock converts all military timezones 22`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         15:02:03 GMT-10
       </div>
@@ -517,7 +517,7 @@ exports[`rux-clock converts all military timezones 23`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         14:02:03 GMT-11
       </div>
@@ -540,7 +540,7 @@ exports[`rux-clock converts all military timezones 24`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         13:02:03 GMT-12
       </div>
@@ -563,7 +563,7 @@ exports[`rux-clock converts all military timezones 25`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 Z
       </div>
@@ -586,7 +586,7 @@ exports[`rux-clock converts aos/los unix timestamps when timezone is changed 1`]
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
@@ -625,7 +625,7 @@ exports[`rux-clock converts aos/los unix timestamps when timezone is changed 2`]
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         17:02:03 PST
       </div>
@@ -664,7 +664,7 @@ exports[`rux-clock converts time to timezone 1`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         17:02:03 PST
       </div>
@@ -687,7 +687,7 @@ exports[`rux-clock converts time to timezone on the fly 1`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
@@ -710,7 +710,7 @@ exports[`rux-clock converts time to timezone on the fly 2`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         17:02:03 PST
       </div>
@@ -725,7 +725,7 @@ exports[`rux-clock converts time to timezone on the fly 2`] = `
 exports[`rux-clock hides the date 1`] = `
 <rux-clock hide-date="">
   <mock:shadow-root>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
@@ -745,7 +745,7 @@ exports[`rux-clock hides the labels 1`] = `
         1
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
@@ -765,7 +765,7 @@ exports[`rux-clock hides the timezone 1`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03
       </div>
@@ -788,7 +788,7 @@ exports[`rux-clock shows and updates aos 1`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
@@ -819,7 +819,7 @@ exports[`rux-clock shows and updates aos 2`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
@@ -850,7 +850,7 @@ exports[`rux-clock shows and updates los 1`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
@@ -881,7 +881,7 @@ exports[`rux-clock shows and updates los 2`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>
@@ -912,7 +912,7 @@ exports[`rux-clock shows the current time 1`] = `
         Date
       </div>
     </div>
-    <div class="rux-clock__segment" part="time">
+    <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
         01:02:03 UTC
       </div>


### PR DESCRIPTION
## Brief Description

Adds the shadow parts time, time-label, date, date-label, aos, aos-label, los and los-label. 
I think we'd have to move some css around to get away with having a part that encapuslates each section and the corresponding label, ie just the time part being moved up a div level. That is what I tried first, but the component styling takes place one level down from the first, thus the part wouldn't do anything to attributes that where already styled. 

I also removed two classes from clock that weren't being used: `rux-clock__day-of-the-year` and `rux-clock__time`. If i'm just blind and missed where they are being used let me know

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2636

## Related Issue

## General Notes

## Motivation and Context

Adds shadow parts to rux-clock

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
