### PR TITLE
Rux icon part

### DIFF
--- a/.changeset/curvy-pans-develop.md
+++ b/.changeset/curvy-pans-develop.md
@@ -1,0 +1,9 @@
+---
+"@astrouxds/astro-web-components": minor
+"@astrouxds/ag-grid-theme": minor
+"@astrouxds/angular": minor
+"astro-website": minor
+"@astrouxds/react": minor
+---
+
+Added a icon shadow part to rux-icon.

--- a/packages/web-components/src/components/rux-icon/readme.md
+++ b/packages/web-components/src/components/rux-icon/readme.md
@@ -123,9 +123,9 @@ In Astro 4.0, these groups have been flattened, and each icon is now imported di
 
 ## Shadow Parts
 
-| Part     | Description |
-| -------- | ----------- |
-| `"icon"` |             |
+| Part     | Description                    |
+| -------- | ------------------------------ |
+| `"icon"` | the icon container in rux-icon |
 
 ## CSS Custom Properties
 

--- a/packages/web-components/src/components/rux-icon/readme.md
+++ b/packages/web-components/src/components/rux-icon/readme.md
@@ -113,7 +113,6 @@ In Astro 4.0, these groups have been flattened, and each icon is now imported di
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property            | Attribute | Description                                                                                                                    | Type                  | Default     |
@@ -122,6 +121,11 @@ In Astro 4.0, these groups have been flattened, and each icon is now imported di
 | `label`             | `label`   | The icon SVG's title attribute. Used for accessibility. If none is provided, the icon name will be used.                       | `string \| undefined` | `undefined` |
 | `size`              | `size`    | The size of the icon. Can be 'extra-small', 'small', 'normal', 'large', 'auto' or any custom value ('30px', '1rem', '3.321em') | `string`              | `'normal'`  |
 
+## Shadow Parts
+
+| Part     | Description |
+| -------- | ----------- |
+| `"icon"` |             |
 
 ## CSS Custom Properties
 
@@ -129,19 +133,19 @@ In Astro 4.0, these groups have been flattened, and each icon is now imported di
 | ---------------------- | ----------------------------- |
 | `--icon-default-color` | the default color of the icon |
 
-
 ## Dependencies
 
 ### Used by
 
- - [rux-button](../rux-button)
- - [rux-global-status-bar](../rux-global-status-bar)
- - [rux-input](../rux-input)
- - [rux-monitoring-icon](../rux-monitoring-icon)
- - [rux-notification](../rux-notification)
- - [rux-push-button](../rux-push-button)
+-   [rux-button](../rux-button)
+-   [rux-global-status-bar](../rux-global-status-bar)
+-   [rux-input](../rux-input)
+-   [rux-monitoring-icon](../rux-monitoring-icon)
+-   [rux-notification](../rux-notification)
+-   [rux-push-button](../rux-push-button)
 
 ### Graph
+
 ```mermaid
 graph TD;
   rux-button --> rux-icon
@@ -153,6 +157,6 @@ graph TD;
   style rux-icon fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-icon/rux-icon.tsx
+++ b/packages/web-components/src/components/rux-icon/rux-icon.tsx
@@ -1,5 +1,8 @@
 import { Component, Host, Prop, h } from '@stencil/core'
 
+/**
+ * @part icon - the icon container in rux-icon
+ */
 @Component({
     tag: 'rux-icon',
     styleUrl: 'rux-icon.scss',

--- a/packages/web-components/src/components/rux-icon/rux-icon.tsx
+++ b/packages/web-components/src/components/rux-icon/rux-icon.tsx
@@ -41,7 +41,7 @@ export class RuxIcon {
         const SVG = `rux-icon-${this.icon}`
 
         return (
-            <Host>
+            <Host part="icon">
                 <SVG class="icon" size={this.size} title={this.iconLabel}></SVG>
             </Host>
         )

--- a/packages/web-components/src/components/rux-icon/test/__snapshots__/rux-icon.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-icon/test/__snapshots__/rux-icon.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`rux-icon renders 1`] = `
-<rux-icon icon="360" size="normal">
+<rux-icon icon="360" part="icon" size="normal">
   <mock:shadow-root>
     <rux-icon-360 class="icon" size="normal" title="360"></rux-icon-360>
   </mock:shadow-root>


### PR DESCRIPTION
## Brief Description

Adds an `icon` shadow part to rux-icon's host. 

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

This will allow us to remove any icon shadow parts on other components that use rux icon

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
