### PR TITLE
Astro 2637 gsb parts

### DIFF
--- a/.changeset/little-poems-stare.md
+++ b/.changeset/little-poems-stare.md
@@ -1,0 +1,9 @@
+---
+"@astrouxds/angular": minor
+"@astrouxds/react": minor
+"@astrouxds/astro-web-components": minor
+"@astrouxds/ag-grid-theme": minor
+"astro-website": minor
+---
+
+Adds a container shadow part to rux-global-status-bar

--- a/.changeset/short-items-joke.md
+++ b/.changeset/short-items-joke.md
@@ -1,0 +1,9 @@
+---
+"@astrouxds/angular": minor
+"@astrouxds/react": minor
+"@astrouxds/astro-web-components": minor
+"@astrouxds/ag-grid-theme": minor
+"astro-website": minor
+---
+
+Added username and app-state shadow parts to rux-global-status-bar

--- a/packages/web-components/src/components/rux-global-status-bar/readme.md
+++ b/packages/web-components/src/components/rux-global-status-bar/readme.md
@@ -129,14 +129,15 @@ There is one unnamed slot in the Global Status Bar. This slot is intended for an
 | `"app-meta"`   | Used to display the Application's metadata (Domain, Name, State, Version, etc.) |
 | `"left-side"`  | Used to prepend a RuxIcon or similar element                                    |
 | `"right-side"` | Used to append optional content                                                 |
+| `"username"`   | Used to display the username                                                    |
 
 ## Shadow Parts
 
-| Part          | Description                         |
-| ------------- | ----------------------------------- |
-| `"app-state"` |                                     |
-| `"container"` | the container for global-status-bar |
-| `"username"`  |                                     |
+| Part          | Description                              |
+| ------------- | ---------------------------------------- |
+| `"app-state"` | The container for the applications state |
+| `"container"` | The container for global-status-bar      |
+| `"username"`  | The container for the username           |
 
 ## Dependencies
 

--- a/packages/web-components/src/components/rux-global-status-bar/readme.md
+++ b/packages/web-components/src/components/rux-global-status-bar/readme.md
@@ -108,7 +108,6 @@ There is one unnamed slot in the Global Status Bar. This slot is intended for an
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property        | Attribute         | Description                                                                                           | Type                                                | Default     |
@@ -122,7 +121,6 @@ There is one unnamed slot in the Global Status Bar. This slot is intended for an
 | `menuIcon`      | `menu-icon`       | Sets the icon to be displayed in the default rux-icon component                                       | `string`                                            | `'apps'`    |
 | `username`      | `username`        | Declares what text will render and whether the username component will be shown in the app-meta slot  | `string \| undefined`                               | `''`        |
 
-
 ## Slots
 
 | Slot           | Description                                                                     |
@@ -132,20 +130,28 @@ There is one unnamed slot in the Global Status Bar. This slot is intended for an
 | `"left-side"`  | Used to prepend a RuxIcon or similar element                                    |
 | `"right-side"` | Used to append optional content                                                 |
 
+## Shadow Parts
+
+| Part          | Description                         |
+| ------------- | ----------------------------------- |
+| `"app-state"` |                                     |
+| `"container"` | the container for global-status-bar |
+| `"username"`  |                                     |
 
 ## Dependencies
 
 ### Depends on
 
-- [rux-icon](../rux-icon)
+-   [rux-icon](../rux-icon)
 
 ### Graph
+
 ```mermaid
 graph TD;
   rux-global-status-bar --> rux-icon
   style rux-global-status-bar fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.tsx
+++ b/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.tsx
@@ -6,8 +6,11 @@ import { AppMeta } from './appMeta/appMeta'
  * @slot left-side - Used to prepend a RuxIcon or similar element
  * @slot app-meta - Used to display the Application's metadata (Domain, Name, State, Version, etc.)
  * @slot right-side - Used to append optional content
+ * @slot username - Used to display the username
  *
- * @part container - the container for global-status-bar
+ * @part app-state - The container for the applications state
+ * @part container - The container for global-status-bar
+ * @part username - The container for the username
  */
 @Component({
     tag: 'rux-global-status-bar',

--- a/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.tsx
+++ b/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.tsx
@@ -6,6 +6,8 @@ import { AppMeta } from './appMeta/appMeta'
  * @slot left-side - Used to prepend a RuxIcon or similar element
  * @slot app-meta - Used to display the Application's metadata (Domain, Name, State, Version, etc.)
  * @slot right-side - Used to append optional content
+ *
+ * @part container - the container for global-status-bar
  */
 @Component({
     tag: 'rux-global-status-bar',
@@ -78,7 +80,7 @@ export class RuxGlobalStatusBar {
 
         return (
             <Host>
-                <header>
+                <header part="container">
                     <slot name="left-side">
                         {this.includeIcon && (
                             <rux-icon
@@ -106,6 +108,7 @@ export class RuxGlobalStatusBar {
                                     {this.appState && (
                                         <div
                                             class="app-state"
+                                            part="app-state"
                                             style={{
                                                 backgroundColor: `${
                                                     TagColor[
@@ -118,7 +121,7 @@ export class RuxGlobalStatusBar {
                                         </div>
                                     )}
                                     {this.username && (
-                                        <div class="username">
+                                        <div class="username" part="username">
                                             {this.username}
                                         </div>
                                     )}

--- a/packages/web-components/src/components/rux-global-status-bar/test/__snapshots__/rux-global-status-bar.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-global-status-bar/test/__snapshots__/rux-global-status-bar.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`rux-global-status-bar renders 1`] = `
 <rux-global-status-bar menu-icon="apps">
   <mock:shadow-root>
-    <header>
+    <header part="container">
       <slot name="left-side"></slot>
       <slot name="app-meta"></slot>
       <div class="slotted-content">
@@ -18,7 +18,7 @@ exports[`rux-global-status-bar renders 1`] = `
 exports[`rux-global-status-bar renders with icon and app meta 1`] = `
 <rux-global-status-bar app-domain="ASTRO" app-name="Test App Name" app-state="App State" app-version="test v1.0" include-icon="" menu-icon="apps" username="Username">
   <mock:shadow-root>
-    <header>
+    <header part="container">
       <slot name="left-side">
         <rux-icon class="shifted-up" icon="apps" size="small"></rux-icon>
       </slot>
@@ -36,10 +36,10 @@ exports[`rux-global-status-bar renders with icon and app meta 1`] = `
             </span>
           </div>
           <div class="app-state-wrapper">
-            <div class="app-state" style="background-color: var(--color-global-tag-tag1-600);">
+            <div class="app-state" part="app-state" style="background-color: var(--color-global-tag-tag1-600);">
               App State
             </div>
-            <div class="username">
+            <div class="username" part="username">
               Username
             </div>
           </div>
@@ -57,7 +57,7 @@ exports[`rux-global-status-bar renders with icon and app meta 1`] = `
 exports[`rux-global-status-bar renders with icon, app meta and slotted content 1`] = `
 <rux-global-status-bar app-domain="ASTRO" app-name="Test App Name" app-state="App State" app-version="test v1.0" include-icon="" menu-icon="apps" username="Username">
   <mock:shadow-root>
-    <header>
+    <header part="container">
       <slot name="left-side">
         <rux-icon class="shifted-up" icon="apps" size="small"></rux-icon>
       </slot>
@@ -75,10 +75,10 @@ exports[`rux-global-status-bar renders with icon, app meta and slotted content 1
             </span>
           </div>
           <div class="app-state-wrapper">
-            <div class="app-state" style="background-color: var(--color-global-tag-tag1-600);">
+            <div class="app-state" part="app-state" style="background-color: var(--color-global-tag-tag1-600);">
               App State
             </div>
-            <div class="username">
+            <div class="username" part="username">
               Username
             </div>
           </div>


### PR DESCRIPTION
## Brief Description

Adds a `container` part to global status bar. 
It's added to header, because adding it to host had no effect when attempting to style with it. The rest of GSB is basically slots, which are customizable already.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2637

## Related Issue

## General Notes

## Motivation and Context

shadow parts boi

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
