### PR TITLE
Fix importing docs

### DIFF
--- a/packages/starter-kits/svelte-starter/index.js
+++ b/packages/starter-kits/svelte-starter/index.js
@@ -2,9 +2,16 @@ import App from "./App.svelte";
 
 // Import Astro's base styles
 import "../node_modules/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css";
+
 // Define the Astro Components
-import { defineCustomElements } from "@astrouxds/astro-web-components/dist/custom-elements";
-defineCustomElements();
+import {
+  applyPolyfills,
+  defineCustomElements,
+} from "@astrouxds/astro-web-components/loader";
+
+applyPolyfills().then(() => {
+  defineCustomElements();
+});
 
 const app = new App({
   target: document.body,

--- a/packages/starter-kits/vue3-starter/src/main.js
+++ b/packages/starter-kits/vue3-starter/src/main.js
@@ -1,7 +1,14 @@
 import { createApp } from "vue";
 import App from "./App.vue";
 import "@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css";
-import { defineCustomElements } from "@astrouxds/astro-web-components/dist/custom-elements";
 
-defineCustomElements();
+import {
+  applyPolyfills,
+  defineCustomElements,
+} from "@astrouxds/astro-web-components/loader";
+
+applyPolyfills().then(() => {
+  defineCustomElements();
+});
+
 createApp(App).mount("#app");

--- a/packages/web-components/src/stories/astro-uxds/welcome/svelte.stories.mdx
+++ b/packages/web-components/src/stories/astro-uxds/welcome/svelte.stories.mdx
@@ -21,10 +21,17 @@ Astro Web Components make use of Stencil's automatic lazy loader which only load
 import App from './App.svelte'
 
 // Import Astro's base styles
-import '@astrouxds/astro-web-components/build/astro-web-components.css'
+import '@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css'
+
 // Define the Astro Components
-import { defineCustomElements } from '@astrouxds/astro-web-components/dist/custom-elements'
-defineCustomElements()
+import {
+    applyPolyfills,
+    defineCustomElements,
+} from '@astrouxds/astro-web-components/loader'
+
+applyPolyfills().then(() => {
+    defineCustomElements()
+})
 
 const app = new App({
     target: document.body,

--- a/packages/web-components/src/stories/astro-uxds/welcome/vue2.stories.mdx
+++ b/packages/web-components/src/stories/astro-uxds/welcome/vue2.stories.mdx
@@ -24,10 +24,16 @@ import App from './App.vue'
 Vue.config.productionTip = false
 
 // Import Astro's base styles
-import '@astrouxds/astro-web-components/build/astro-web-components.css'
+import '@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css'
 
-import { defineCustomElements } from '@astrouxds/astro-web-components/dist/custom-elements'
-defineCustomElements()
+import {
+    applyPolyfills,
+    defineCustomElements,
+} from '@astrouxds/astro-web-components/loader'
+
+applyPolyfills().then(() => {
+    defineCustomElements()
+})
 
 // Tell Vue to ignore all components defined in the astro-web-components package
 Vue.config.ignoredElements = [/rux-\w*/]

--- a/packages/web-components/src/stories/astro-uxds/welcome/vue3.stories.mdx
+++ b/packages/web-components/src/stories/astro-uxds/welcome/vue3.stories.mdx
@@ -21,9 +21,16 @@ Astro Web Components make use of Stencil's automatic lazy loader which only load
 import { createApp } from 'vue'
 import App from './App.vue'
 import '@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css'
-import { defineCustomElements } from '@astrouxds/astro-web-components/dist/custom-elements'
 
-defineCustomElements()
+import {
+    applyPolyfills,
+    defineCustomElements,
+} from '@astrouxds/astro-web-components/loader'
+
+applyPolyfills().then(() => {
+    defineCustomElements()
+})
+
 createApp(App).mount('#app')
 ```
 


### PR DESCRIPTION
## Brief Description

svelte/vue docs/starter kits were using the custom-elements build that we'll be deprecating soon. there were also some rando typos using /build 