### PR TITLE
Astro 2640 modal parts

### DIFF
--- a/.changeset/chatty-crabs-rescue.md
+++ b/.changeset/chatty-crabs-rescue.md
@@ -1,0 +1,9 @@
+---
+"@astrouxds/astro-web-components": minor
+"@astrouxds/ag-grid-theme": minor
+"@astrouxds/angular": minor
+"astro-website": minor
+"@astrouxds/react": minor
+---
+
+Added container and content parts to modal. Added deprecation notice for wrapper part.

--- a/packages/web-components/src/components/rux-modal/rux-modal.tsx
+++ b/packages/web-components/src/components/rux-modal/rux-modal.tsx
@@ -11,8 +11,9 @@ import {
 } from '@stencil/core'
 
 /**
- * @part wrapper - the modal wrapper overlay
- *
+ * @part wrapper - the modal wrapper overlay ! DEPRECATED IN FAVOR OF CONTAINER !
+ * @part container - the modal container
+ * @part content - the content container of the modal
  */
 @Component({
     tag: 'rux-modal',
@@ -143,14 +144,21 @@ export class RuxModal {
         return (
             open && (
                 <Host>
-                    <div part="wrapper" class="rux-modal__wrapper">
-                        <dialog class="rux-modal__dialog" role="dialog">
+                    <div part="wrapper container" class="rux-modal__wrapper">
+                        <dialog
+                            class="rux-modal__dialog"
+                            role="dialog"
+                            part="dialog"
+                        >
                             {modalTitle && (
-                                <header class="rux-modal__titlebar">
+                                <header
+                                    class="rux-modal__titlebar"
+                                    part="header"
+                                >
                                     <div>{modalTitle}</div>
                                 </header>
                             )}
-                            <div class="rux-modal__content">
+                            <div class="rux-modal__content" part="content">
                                 <div class="rux-modal__message">
                                     {modalMessage}
                                 </div>

--- a/packages/web-components/src/components/rux-modal/rux-modal.tsx
+++ b/packages/web-components/src/components/rux-modal/rux-modal.tsx
@@ -13,6 +13,7 @@ import {
 /**
  * @part wrapper - the modal wrapper overlay ! DEPRECATED IN FAVOR OF CONTAINER !
  * @part container - the modal container
+ * @part header - the modal's header container
  * @part content - the content container of the modal
  */
 @Component({


### PR DESCRIPTION
## Brief Description

Adds a container, header and content part for modal. Adds deprecation notice for wrapper part in favor of container to keep things consistent. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2640

## Related Issue

## General Notes

Found something interesting with modal and rux-button - rux-button has a container part on it's shadow button element, and that works for styling. But using that same part does not update the styling for the rux-modal buttons. In testing I added a part to the host of rux-button, and that would style the modal buttons but not a regular button.
This probably isn't a big deal since modal is going to be slots in the future, but thought I'd catalogue it just in case.

## Motivation and Context

Shadow part effort

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
