### PR TITLE
Astro 2641 monitoring icon parts

### DIFF
--- a/.changeset/warm-cycles-pay.md
+++ b/.changeset/warm-cycles-pay.md
@@ -1,0 +1,9 @@
+---
+"@astrouxds/astro-web-components": minor
+"@astrouxds/ag-grid-theme": minor
+"@astrouxds/angular": minor
+"astro-website": minor
+"@astrouxds/react": minor
+---
+
+Added container shadow part to rux-monitoring-icon.

--- a/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.tsx
+++ b/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.tsx
@@ -4,6 +4,7 @@ import MonitoringBadge from '../../common/functional-components/MonitoringBadge/
 import MonitoringLabel from '../../common/functional-components/MonitoringLabel'
 
 /**
+ * @part container - The monitoring-icon's container.
  * @part monitoring-badge - The component's notification badge
  * @part monitoring-label - The component's label
  * @part monitoring-sublabel - The component's sublabel
@@ -64,6 +65,7 @@ export class RuxMonitoringIcon {
                 id="rux-advanced-status__icon"
                 class="rux-advanced-status"
                 title={`${this.notifications} ${this.label} ${this.sublabel}`}
+                part="container"
             >
                 <div class="rux-advanced-status__icon-group">
                     <div class="rux-advanced-status__status">

--- a/packages/web-components/src/components/rux-monitoring-icon/test/__snapshots__/rux-monitoring-icon.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-monitoring-icon/test/__snapshots__/rux-monitoring-icon.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`rux-monitoring-icon renders 1`] = `
 <rux-monitoring-icon icon="altitude" label="Altitude for satellite X" notifications="10210" status="standby" sublabel="100000m">
   <mock:shadow-root>
-    <div class="rux-advanced-status" id="rux-advanced-status__icon" title="10210 Altitude for satellite X 100000m">
+    <div class="rux-advanced-status" id="rux-advanced-status__icon" part="container" title="10210 Altitude for satellite X 100000m">
       <div class="rux-advanced-status__icon-group">
         <div class="rux-advanced-status__status">
           <rux-status status="standby"></rux-status>


### PR DESCRIPTION
## Brief Description

Adds a container part to rux-monitoring-icon, updates snapshots. 


## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2641

## Related Issue

## General Notes

## Motivation and Context

Shadow parts 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
