### PR TITLE
feat(web-components): Add shadow parts to relevant components

### DIFF
--- a/.changeset/tiny-rules-lie.md
+++ b/.changeset/tiny-rules-lie.md
@@ -1,0 +1,26 @@
+---
+"@astrouxds/astro-web-components": minor
+"@astrouxds/ag-grid-theme": minor
+"@astrouxds/angular": minor
+"astro-website": minor
+"@astrouxds/react": minor
+---
+
+    Moved the icon shadow part in rux-icon to be on the SVG element.
+    Added exportparts to rux-icon in rux-monitoring-icon.
+    Added label and icon shadow parts to rux-push-button.
+    Added progress and output shadow shadow parts to rux-progress.
+    Added confirm-button and deny-button to the modal's rux-buttons as shadow parts.
+    Added label shadow part to rux-segmented-button
+    Added switch shadow part to rux-switch. The pseudo selectors ::before select the track, ::after selects the button.
+    Added input, form-field shadow parts to rux-input
+    Added form-field-message shadow part to FormFieldMessage to allow styling of help/error text.
+    Added form-field and label shadow parts to rux-checkbox.
+    Added form-field and label shadow parts to rux-radio.
+    Added label and select shadow parts to rux-select.
+    Added input shadow part to rux-input.
+    Added input shadow part to rux-slider
+    Added texarea shadow part to rux-textarea
+    Added container shadow part to rux-menu-item.
+    Added container shadow part to rux-menu-item-divider
+    Added exportparts to rux-icon inside of rux-global-status-bar

--- a/packages/web-components/src/common/functional-components/FormFieldMessage/FormFieldMessage.tsx
+++ b/packages/web-components/src/common/functional-components/FormFieldMessage/FormFieldMessage.tsx
@@ -15,6 +15,7 @@ const FormFieldMessage = (props: FormFieldMessageInterface, children: any) => {
                     'rux-error-text': !!errorText,
                     'rux-help-text': !!helpText,
                 }}
+                part="form-field-message"
             >
                 {children}
 

--- a/packages/web-components/src/common/functional-components/FormFieldMessage/FormFieldMessage.tsx
+++ b/packages/web-components/src/common/functional-components/FormFieldMessage/FormFieldMessage.tsx
@@ -5,6 +5,10 @@ export interface FormFieldMessageInterface {
     errorText?: string
 }
 
+/**
+ * @part form-field-message - the container for the help or error text
+ */
+
 const FormFieldMessage = (props: FormFieldMessageInterface, children: any) => {
     const { helpText, errorText } = props
 

--- a/packages/web-components/src/components/rux-button-group/rux-button-group.tsx
+++ b/packages/web-components/src/components/rux-button-group/rux-button-group.tsx
@@ -2,7 +2,6 @@ import { Prop, Component, h } from '@stencil/core'
 
 /**
  * @slot (default) - Two or more RuxButton components to render in the group
- *
  * @part container - the components container
  */
 @Component({

--- a/packages/web-components/src/components/rux-button/readme.md
+++ b/packages/web-components/src/components/rux-button/readme.md
@@ -134,9 +134,10 @@ For more information about AstroUXDS usage outside of a Web Component environmen
 
 ## Shadow Parts
 
-| Part          | Description               |
-| ------------- | ------------------------- |
-| `"container"` | the components container. |
+| Part          | Description                           |
+| ------------- | ------------------------------------- |
+| `"container"` | the components native button element. |
+| `"icon"`      | the optional rux-icon                 |
 
 ## CSS Custom Properties
 

--- a/packages/web-components/src/components/rux-button/rux-button.tsx
+++ b/packages/web-components/src/components/rux-button/rux-button.tsx
@@ -2,7 +2,7 @@ import { Prop, Element, Component, h, Host } from '@stencil/core'
 import { hasShadowDom } from '../../utils/utils'
 
 /**
- * @part native - the components native button element.
+ * @part container - the components native button element.
  * @part icon - the optional rux-icon
  */
 @Component({

--- a/packages/web-components/src/components/rux-button/rux-button.tsx
+++ b/packages/web-components/src/components/rux-button/rux-button.tsx
@@ -3,6 +3,7 @@ import { hasShadowDom } from '../../utils/utils'
 
 /**
  * @part container - the components container.
+ * @part icon - the optional rux-icon
  */
 @Component({
     tag: 'rux-button',
@@ -94,6 +95,7 @@ export class RuxButton {
                         <rux-icon
                             size="extra-small"
                             icon={icon}
+                            exportparts="icon"
                             color={secondary ? 'primary' : 'dark'}
                         ></rux-icon>
                     ) : null}

--- a/packages/web-components/src/components/rux-button/rux-button.tsx
+++ b/packages/web-components/src/components/rux-button/rux-button.tsx
@@ -2,7 +2,7 @@ import { Prop, Element, Component, h, Host } from '@stencil/core'
 import { hasShadowDom } from '../../utils/utils'
 
 /**
- * @part container - the components container.
+ * @part native - the components native button element.
  * @part icon - the optional rux-icon
  */
 @Component({
@@ -89,7 +89,7 @@ export class RuxButton {
                     }}
                     aria-disabled={disabled ? 'true' : null}
                     disabled={disabled}
-                    part="container"
+                    part="native"
                 >
                     {icon ? (
                         <rux-icon

--- a/packages/web-components/src/components/rux-button/rux-button.tsx
+++ b/packages/web-components/src/components/rux-button/rux-button.tsx
@@ -89,7 +89,7 @@ export class RuxButton {
                     }}
                     aria-disabled={disabled ? 'true' : null}
                     disabled={disabled}
-                    part="native"
+                    part="container"
                 >
                     {icon ? (
                         <rux-icon

--- a/packages/web-components/src/components/rux-checkbox-group/readme.md
+++ b/packages/web-components/src/components/rux-checkbox-group/readme.md
@@ -2,7 +2,6 @@
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property    | Attribute    | Description                                                                      | Type                  | Default     |
@@ -12,7 +11,6 @@
 | `invalid`   | `invalid`    | Presentational only. Renders the Checkbox Group as invalid.                      | `boolean`             | `false`     |
 | `label`     | `label`      | The label of the checkbox group. For HTML content, use the `label` slot instead. | `string \| undefined` | `undefined` |
 
-
 ## Slots
 
 | Slot          | Description              |
@@ -20,15 +18,14 @@
 | `"(default)"` | The checkbox elements    |
 | `"label"`     | The checkbox group label |
 
-
 ## Shadow Parts
 
-| Part           | Description                              |
-| -------------- | ---------------------------------------- |
-| `"container"`  | The container div of checkbox elements   |
-| `"form-field"` | The form-field wrapper container         |
-| `"label"`      | The input label when `label` prop is set |
-
+| Part                   | Description                              |
+| ---------------------- | ---------------------------------------- |
+| `"container"`          | The container div of checkbox elements   |
+| `"form-field"`         | The form-field wrapper container         |
+| `"form-field-message"` | The error/help text container            |
+| `"label"`              | The input label when `label` prop is set |
 
 ## CSS Custom Properties
 
@@ -36,7 +33,6 @@
 | ------------------------------ | ---------------------------- |
 | `--checkboxgroup-border-color` | the radio group border color |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-checkbox-group/rux-checkbox-group.tsx
+++ b/packages/web-components/src/components/rux-checkbox-group/rux-checkbox-group.tsx
@@ -8,6 +8,7 @@ import { hasSlot } from '../../utils/utils'
  * @part container - The container div of checkbox elements
  * @part form-field - The form-field wrapper container
  * @part label - The input label when `label` prop is set
+ * @part form-field-message - The error/help text container
  */
 @Component({
     tag: 'rux-checkbox-group',

--- a/packages/web-components/src/components/rux-checkbox/readme.md
+++ b/packages/web-components/src/components/rux-checkbox/readme.md
@@ -35,7 +35,6 @@ git clone https://github.com/RocketCommunicationsInc/astro-components.git
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property        | Attribute       | Description                                                                                                                                                                                                                                       | Type                  | Default     |
@@ -48,7 +47,6 @@ git clone https://github.com/RocketCommunicationsInc/astro-components.git
 | `name`          | `name`          | The checkbox name                                                                                                                                                                                                                                 | `string`              | `''`        |
 | `value`         | `value`         | The checkbox value                                                                                                                                                                                                                                | `string`              | `''`        |
 
-
 ## Events
 
 | Event       | Description                                                                                                                                                                    | Type               |
@@ -57,13 +55,18 @@ git clone https://github.com/RocketCommunicationsInc/astro-components.git
 | `ruxchange` | Fired when the value of the input changes - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)                                | `CustomEvent<any>` |
 | `ruxinput`  | Fired when an alteration to the input's value is committed by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) | `CustomEvent<any>` |
 
-
 ## Slots
 
 | Slot          | Description                |
 | ------------- | -------------------------- |
 | `"(default)"` | the label of the checkbox. |
 
+## Shadow Parts
+
+| Part           | Description                      |
+| -------------- | -------------------------------- |
+| `"form-field"` | the form field wrapper container |
+| `"label"`      | the label of rux-checkbox        |
 
 ## CSS Custom Properties
 
@@ -75,7 +78,6 @@ git clone https://github.com/RocketCommunicationsInc/astro-components.git
 | `--checkbox-hover-border-color` | Hover border color           |
 | `--checkbox-label-color`        | Label text color             |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-checkbox/readme.md
+++ b/packages/web-components/src/components/rux-checkbox/readme.md
@@ -63,10 +63,11 @@ git clone https://github.com/RocketCommunicationsInc/astro-components.git
 
 ## Shadow Parts
 
-| Part           | Description                      |
-| -------------- | -------------------------------- |
-| `"form-field"` | the form field wrapper container |
-| `"label"`      | the label of rux-checkbox        |
+| Part                   | Description                      |
+| ---------------------- | -------------------------------- |
+| `"form-field"`         | the form field wrapper container |
+| `"form-field-message"` | The help text container          |
+| `"label"`              | the label of rux-checkbox        |
 
 ## CSS Custom Properties
 

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
@@ -19,6 +19,8 @@ let id = 0
  * @slot (default) - the label of the checkbox.
  * @part form-field - the form field wrapper container
  * @part label - the label of rux-checkbox
+ * @part form-field-message - The help text container
+ *
  */
 @Component({
     tag: 'rux-checkbox',

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
@@ -146,7 +146,7 @@ export class RuxCheckbox implements FormFieldInterface {
 
         return (
             <Host>
-                <div class="rux-form-field">
+                <div class="rux-form-field" part="form-field">
                     <div
                         class={{
                             'rux-checkbox': true,
@@ -168,7 +168,7 @@ export class RuxCheckbox implements FormFieldInterface {
                             onBlur={this._onBlur}
                             ref={(el) => (this._inputEl = el)}
                         />
-                        <label htmlFor={checkboxId}>
+                        <label htmlFor={checkboxId} part="label">
                             {this.label}
                             <span
                                 class={{

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
@@ -17,6 +17,8 @@ let id = 0
 
 /**
  * @slot (default) - the label of the checkbox.
+ * @part form-field - the form field wrapper container
+ * @part label - the label of rux-checkbox
  */
 @Component({
     tag: 'rux-checkbox',

--- a/packages/web-components/src/components/rux-checkbox/test/__snapshots__/rux-checkbox.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-checkbox/test/__snapshots__/rux-checkbox.spec.tsx.snap
@@ -3,10 +3,10 @@
 exports[`rux-checkbox renders 1`] = `
 <rux-checkbox value="">
   <mock:shadow-root>
-    <div class="rux-form-field">
+    <div class="rux-form-field" part="form-field">
       <div class="rux-checkbox">
         <input id="rux-checkbox-2" type="checkbox" value="">
-        <label htmlfor="rux-checkbox-2">
+        <label htmlfor="rux-checkbox-2" part="label">
           <span>
             <slot></slot>
           </span>

--- a/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.tsx
+++ b/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.tsx
@@ -94,6 +94,7 @@ export class RuxGlobalStatusBar {
                                         ? 'shifted-up'
                                         : ''
                                 }
+                                exportparts="icon"
                             />
                         )}
                     </slot>

--- a/packages/web-components/src/components/rux-global-status-bar/test/__snapshots__/rux-global-status-bar.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-global-status-bar/test/__snapshots__/rux-global-status-bar.spec.tsx.snap
@@ -20,7 +20,7 @@ exports[`rux-global-status-bar renders with icon and app meta 1`] = `
   <mock:shadow-root>
     <header part="container">
       <slot name="left-side">
-        <rux-icon class="shifted-up" icon="apps" size="small"></rux-icon>
+        <rux-icon class="shifted-up" exportparts="icon" icon="apps" size="small"></rux-icon>
       </slot>
       <slot name="app-meta">
         <div class="app-meta">
@@ -59,7 +59,7 @@ exports[`rux-global-status-bar renders with icon, app meta and slotted content 1
   <mock:shadow-root>
     <header part="container">
       <slot name="left-side">
-        <rux-icon class="shifted-up" icon="apps" size="small"></rux-icon>
+        <rux-icon class="shifted-up" exportparts="icon" icon="apps" size="small"></rux-icon>
       </slot>
       <slot name="app-meta">
         <div class="app-meta">

--- a/packages/web-components/src/components/rux-icon/readme.md
+++ b/packages/web-components/src/components/rux-icon/readme.md
@@ -123,9 +123,9 @@ In Astro 4.0, these groups have been flattened, and each icon is now imported di
 
 ## Shadow Parts
 
-| Part     | Description                    |
-| -------- | ------------------------------ |
-| `"icon"` | the icon container in rux-icon |
+| Part     | Description          |
+| -------- | -------------------- |
+| `"icon"` | the icon in rux-icon |
 
 ## CSS Custom Properties
 

--- a/packages/web-components/src/components/rux-icon/rux-icon.tsx
+++ b/packages/web-components/src/components/rux-icon/rux-icon.tsx
@@ -1,7 +1,7 @@
 import { Component, Host, Prop, h } from '@stencil/core'
 
 /**
- * @part icon - the icon container in rux-icon
+ * @part icon - the icon in rux-icon
  */
 @Component({
     tag: 'rux-icon',

--- a/packages/web-components/src/components/rux-icon/rux-icon.tsx
+++ b/packages/web-components/src/components/rux-icon/rux-icon.tsx
@@ -44,8 +44,13 @@ export class RuxIcon {
         const SVG = `rux-icon-${this.icon}`
 
         return (
-            <Host part="icon">
-                <SVG class="icon" size={this.size} title={this.iconLabel}></SVG>
+            <Host>
+                <SVG
+                    class="icon"
+                    part="icon"
+                    size={this.size}
+                    title={this.iconLabel}
+                ></SVG>
             </Host>
         )
     }

--- a/packages/web-components/src/components/rux-icon/test/__snapshots__/rux-icon.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-icon/test/__snapshots__/rux-icon.spec.tsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`rux-icon renders 1`] = `
-<rux-icon icon="360" part="icon" size="normal">
+<rux-icon icon="360" size="normal">
   <mock:shadow-root>
-    <rux-icon-360 class="icon" size="normal" title="360"></rux-icon-360>
+    <rux-icon-360 class="icon" part="icon" size="normal" title="360"></rux-icon-360>
   </mock:shadow-root>
 </rux-icon>
 `;

--- a/packages/web-components/src/components/rux-input/readme.md
+++ b/packages/web-components/src/components/rux-input/readme.md
@@ -44,6 +44,7 @@
 | -------------- | --------------------------------------------------- |
 | `"form-field"` | The form-field wrapper container                    |
 | `"icon"`       | The icon displayed when toggle-password prop is set |
+| `"input"`      | the shadow dom input of rux-input                   |
 | `"label"`      | The input label when `label` prop is set            |
 
 ## CSS Custom Properties

--- a/packages/web-components/src/components/rux-input/rux-input.tsx
+++ b/packages/web-components/src/components/rux-input/rux-input.tsx
@@ -310,6 +310,7 @@ export class RuxInput implements FormFieldInterface {
                         onChange={_onChange}
                         onInput={_onInput}
                         onBlur={_onBlur}
+                        part="input"
                     ></input>
                     {togglePassword && (
                         <div
@@ -320,7 +321,7 @@ export class RuxInput implements FormFieldInterface {
                             }}
                         >
                             <rux-icon
-                                part="icon"
+                                exportparts="icon"
                                 onClick={_handleTogglePassword}
                                 icon={iconName}
                                 size="extra-small"

--- a/packages/web-components/src/components/rux-input/rux-input.tsx
+++ b/packages/web-components/src/components/rux-input/rux-input.tsx
@@ -19,6 +19,7 @@ let id = 0
  * @slot label - The input label
  * @part form-field - The form-field wrapper container
  * @part label - The input label when `label` prop is set
+ * @part input - the shadow dom input of rux-input
  * @part icon - The icon displayed when toggle-password prop is set
  */
 @Component({

--- a/packages/web-components/src/components/rux-input/test/__snapshots__/rux-input.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-input/test/__snapshots__/rux-input.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`rux-input renders 1`] = `
           <slot name="label"></slot>
         </span>
       </label>
-      <input aria-invalid="false" class="rux-input rux-input--medium" id="rux-input-1" type="text" value="">
+      <input aria-invalid="false" class="rux-input rux-input--medium" id="rux-input-1" part="input" type="text" value="">
     </div>
   </mock:shadow-root>
   <input class="aux-input" type="hidden" value="">
@@ -27,7 +27,7 @@ exports[`rux-input renders label prop 1`] = `
           </slot>
         </span>
       </label>
-      <input aria-invalid="false" class="rux-input rux-input--medium" id="rux-input-2" type="text" value="">
+      <input aria-invalid="false" class="rux-input rux-input--medium" id="rux-input-2" part="input" type="text" value="">
     </div>
   </mock:shadow-root>
   <input class="aux-input" type="hidden" value="">
@@ -43,7 +43,7 @@ exports[`rux-input renders label slot 1`] = `
           <slot name="label"></slot>
         </span>
       </label>
-      <input aria-invalid="false" class="rux-input rux-input--medium" id="rux-input-3" type="text" value="">
+      <input aria-invalid="false" class="rux-input rux-input--medium" id="rux-input-3" part="input" type="text" value="">
     </div>
   </mock:shadow-root>
   <div slot="label">
@@ -62,9 +62,9 @@ exports[`rux-input renders rux-icon if type is password 1`] = `
           <slot name="label"></slot>
         </span>
       </label>
-      <input aria-invalid="false" autocomplete="off" class="rux-input rux-input--medium" id="rux-input-4" type="password" value="">
+      <input aria-invalid="false" autocomplete="off" class="rux-input rux-input--medium" id="rux-input-4" part="input" type="password" value="">
       <div class="icon-container show-password">
-        <rux-icon icon="visibility" part="icon" size="extra-small"></rux-icon>
+        <rux-icon exportparts="icon" icon="visibility" size="extra-small"></rux-icon>
       </div>
     </div>
   </mock:shadow-root>

--- a/packages/web-components/src/components/rux-menu-item-divider/readme.md
+++ b/packages/web-components/src/components/rux-menu-item-divider/readme.md
@@ -53,6 +53,11 @@ Pass properties as slotted components in the Astro Pop Up Menu or Astro Select M
 
 <!-- Auto Generated Below -->
 
+## Shadow Parts
+
+| Part          | Description |
+| ------------- | ----------- |
+| `"container"` |             |
 
 ## CSS Custom Properties
 
@@ -60,7 +65,6 @@ Pass properties as slotted components in the Astro Pop Up Menu or Astro Select M
 | ---------------------------------- | ------------------------------ |
 | `--menu-item-divider-border-color` | Menu Item Divider Border Color |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-menu-item-divider/rux-menu-item-divider.tsx
+++ b/packages/web-components/src/components/rux-menu-item-divider/rux-menu-item-divider.tsx
@@ -5,8 +5,11 @@ import { Component, h } from '@stencil/core'
     styleUrl: 'rux-menu-item-divider.scss',
     shadow: true,
 })
+/**
+ * @part container - the container of the rux-menu-item-divider
+ */
 export class RuxMenuItemDivider {
     render() {
-        return <li role="separator"></li>
+        return <li part="container" role="separator"></li>
     }
 }

--- a/packages/web-components/src/components/rux-menu-item-divider/test/__snapshots__/rux-menu-item-divider.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-menu-item-divider/test/__snapshots__/rux-menu-item-divider.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`rux-menu-item-divider renders 1`] = `
 <rux-menu-item-divider>
   <mock:shadow-root>
-    <li role="separator"></li>
+    <li part="container" role="separator"></li>
   </mock:shadow-root>
 </rux-menu-item-divider>
 `;

--- a/packages/web-components/src/components/rux-menu-item/readme.md
+++ b/packages/web-components/src/components/rux-menu-item/readme.md
@@ -53,7 +53,6 @@ Pass properties as slotted components in the Astro Pop Up Menu or Astro Select M
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property   | Attribute  | Description                                                                                                                                                                                                                                                                               | Type                  | Default     |
@@ -65,13 +64,11 @@ Pass properties as slotted components in the Astro Pop Up Menu or Astro Select M
 | `target`   | `target`   | Specifies where to display the linked URL. Only applies when an `href` is provided. Special keywords: `"_blank"`, `"_self"`, `"_parent"`, `"_top"`.                                                                                                                                       | `string \| undefined` | `undefined` |
 | `value`    | `value`    | Value returned when item is selected. If no value is given, the text content will be used.                                                                                                                                                                                                | `any`                 | `undefined` |
 
-
 ## Events
 
 | Event                 | Description                                     | Type                  |
 | --------------------- | ----------------------------------------------- | --------------------- |
 | `ruxmenuitemselected` | Emitted when item is clicked. Ex `{value : 10}` | `CustomEvent<object>` |
-
 
 ## Slots
 
@@ -79,6 +76,11 @@ Pass properties as slotted components in the Astro Pop Up Menu or Astro Select M
 | --------- | --------------------------------------------- |
 | `"start"` | before element text. Typically used for icons |
 
+## Shadow Parts
+
+| Part          | Description                        |
+| ------------- | ---------------------------------- |
+| `"container"` | the container of the rux-menu-item |
 
 ## CSS Custom Properties
 
@@ -88,7 +90,6 @@ Pass properties as slotted components in the Astro Pop Up Menu or Astro Select M
 | `--popup-menu-item-hover-background-color` | Menu Item Hover Background Color |
 | `--popup-menu-text-color`                  | Menu Text Color                  |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-menu-item/rux-menu-item.tsx
+++ b/packages/web-components/src/components/rux-menu-item/rux-menu-item.tsx
@@ -11,6 +11,7 @@ import {
 
 /**
  * @slot start - before element text. Typically used for icons
+ * @part container - the container of the rux-menu-item
  */
 
 @Component({
@@ -88,7 +89,7 @@ export class RuxMenuItem {
 
         return (
             <Host aria-disabled={disabled ? 'true' : null}>
-                <li>
+                <li part="container">
                     <TagType {...attributes}>
                         <slot name="start"></slot>
                         <slot></slot>

--- a/packages/web-components/src/components/rux-menu-item/test/__snapshots__/rux-menu-item.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-menu-item/test/__snapshots__/rux-menu-item.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`rux-menu-item changes to anchor tag based on an href prop 1`] = `
 <rux-menu-item href="https://www.astrouxds.com">
   <mock:shadow-root>
-    <li>
+    <li part="container">
       <a href="https://www.astrouxds.com">
         <slot name="start"></slot>
         <slot></slot>
@@ -16,7 +16,7 @@ exports[`rux-menu-item changes to anchor tag based on an href prop 1`] = `
 exports[`rux-menu-item renders 1`] = `
 <rux-menu-item>
   <mock:shadow-root>
-    <li>
+    <li part="container">
       <div>
         <slot name="start"></slot>
         <slot></slot>

--- a/packages/web-components/src/components/rux-modal/readme.md
+++ b/packages/web-components/src/components/rux-modal/readme.md
@@ -50,7 +50,6 @@ Pass properties as attributes of the Astro Rux Modal custom element:
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property       | Attribute       | Description                  | Type                  | Default     |
@@ -61,20 +60,22 @@ Pass properties as attributes of the Astro Rux Modal custom element:
 | `modalTitle`   | `modal-title`   | Modal header title           | `string \| undefined` | `undefined` |
 | `open`         | `open`          | Shows and hides modal        | `boolean`             | `false`     |
 
-
 ## Events
 
 | Event            | Description                           | Type                   |
 | ---------------- | ------------------------------------- | ---------------------- |
 | `ruxmodalclosed` | Event that is fired when modal closes | `CustomEvent<boolean>` |
 
-
 ## Shadow Parts
 
-| Part        | Description               |
-| ----------- | ------------------------- |
-| `"wrapper"` | the modal wrapper overlay |
-
+| Part               | Description                                                    |
+| ------------------ | -------------------------------------------------------------- |
+| `"confirm-button"` | the modal's confirm button                                     |
+| `"container"`      | the modal container                                            |
+| `"deny-button"`    | the modal's deny button                                        |
+| `"header"`         | the header of the modal                                        |
+| `"message"`        | the message of the modal                                       |
+| `"wrapper"`        | the modal wrapper overlay ! DEPRECATED IN FAVOR OF CONTAINER ! |
 
 ## CSS Custom Properties
 
@@ -84,15 +85,15 @@ Pass properties as attributes of the Astro Rux Modal custom element:
 | `--modal-border-color`     | Modal border color     |
 | `--modal-title-color`      | Modal title color      |
 
-
 ## Dependencies
 
 ### Depends on
 
-- [rux-button-group](../rux-button-group)
-- [rux-button](../rux-button)
+-   [rux-button-group](../rux-button-group)
+-   [rux-button](../rux-button)
 
 ### Graph
+
 ```mermaid
 graph TD;
   rux-modal --> rux-button-group
@@ -101,6 +102,6 @@ graph TD;
   style rux-modal fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-modal/rux-modal.tsx
+++ b/packages/web-components/src/components/rux-modal/rux-modal.tsx
@@ -15,6 +15,8 @@ import {
  * @part container - the modal container
  * @part header - the header of the modal
  * @part message - the message of the modal
+ * @part confirm-button - the modal's confirm button
+ * @part deny-button - the modal's deny button
  */
 @Component({
     tag: 'rux-modal',

--- a/packages/web-components/src/components/rux-modal/rux-modal.tsx
+++ b/packages/web-components/src/components/rux-modal/rux-modal.tsx
@@ -166,7 +166,7 @@ export class RuxModal {
                                         data-value="false"
                                         hidden={!denyText}
                                         tabindex="-1"
-                                        exportparts="container:confirm-button"
+                                        exportparts="container:deny-button"
                                     >
                                         {denyText}
                                     </rux-button>
@@ -175,7 +175,7 @@ export class RuxModal {
                                         data-value="true"
                                         hidden={!confirmText}
                                         tabindex="0"
-                                        exportparts="container:deny-button"
+                                        exportparts="container:confirm-button"
                                     >
                                         {confirmText}
                                     </rux-button>

--- a/packages/web-components/src/components/rux-modal/rux-modal.tsx
+++ b/packages/web-components/src/components/rux-modal/rux-modal.tsx
@@ -11,8 +11,10 @@ import {
 } from '@stencil/core'
 
 /**
- * @part wrapper - the modal wrapper overlay
- *
+ * @part wrapper - the modal wrapper overlay ! DEPRECATED IN FAVOR OF CONTAINER !
+ * @part container - the modal container
+ * @part header - the header of the modal
+ * @part message - the message of the modal
  */
 @Component({
     tag: 'rux-modal',
@@ -143,15 +145,18 @@ export class RuxModal {
         return (
             open && (
                 <Host>
-                    <div part="wrapper" class="rux-modal__wrapper">
+                    <div part="wrapper container" class="rux-modal__wrapper">
                         <dialog class="rux-modal__dialog" role="dialog">
                             {modalTitle && (
-                                <header class="rux-modal__titlebar">
+                                <header
+                                    class="rux-modal__titlebar"
+                                    part="header"
+                                >
                                     <div>{modalTitle}</div>
                                 </header>
                             )}
                             <div class="rux-modal__content">
-                                <div class="rux-modal__message">
+                                <div class="rux-modal__message" part="message">
                                     {modalMessage}
                                 </div>
                                 <rux-button-group h-align="right">
@@ -161,6 +166,7 @@ export class RuxModal {
                                         data-value="false"
                                         hidden={!denyText}
                                         tabindex="-1"
+                                        exportparts="native"
                                     >
                                         {denyText}
                                     </rux-button>
@@ -169,6 +175,7 @@ export class RuxModal {
                                         data-value="true"
                                         hidden={!confirmText}
                                         tabindex="0"
+                                        exportparts="native"
                                     >
                                         {confirmText}
                                     </rux-button>

--- a/packages/web-components/src/components/rux-modal/rux-modal.tsx
+++ b/packages/web-components/src/components/rux-modal/rux-modal.tsx
@@ -166,7 +166,7 @@ export class RuxModal {
                                         data-value="false"
                                         hidden={!denyText}
                                         tabindex="-1"
-                                        exportparts="native"
+                                        exportparts="container:button"
                                     >
                                         {denyText}
                                     </rux-button>
@@ -175,7 +175,7 @@ export class RuxModal {
                                         data-value="true"
                                         hidden={!confirmText}
                                         tabindex="0"
-                                        exportparts="native"
+                                        exportparts="container:button"
                                     >
                                         {confirmText}
                                     </rux-button>

--- a/packages/web-components/src/components/rux-modal/rux-modal.tsx
+++ b/packages/web-components/src/components/rux-modal/rux-modal.tsx
@@ -166,7 +166,7 @@ export class RuxModal {
                                         data-value="false"
                                         hidden={!denyText}
                                         tabindex="-1"
-                                        exportparts="container:button"
+                                        exportparts="container:confirm-button"
                                     >
                                         {denyText}
                                     </rux-button>
@@ -175,7 +175,7 @@ export class RuxModal {
                                         data-value="true"
                                         hidden={!confirmText}
                                         tabindex="0"
-                                        exportparts="container:button"
+                                        exportparts="container:deny-button"
                                     >
                                         {confirmText}
                                     </rux-button>

--- a/packages/web-components/src/components/rux-monitoring-icon/readme.md
+++ b/packages/web-components/src/components/rux-monitoring-icon/readme.md
@@ -118,9 +118,11 @@ Pass properties as attributes of the Astro Monitoring Progress Icon custom eleme
 
 | Part                    | Description                        |
 | ----------------------- | ---------------------------------- |
+| `"container"`           | the components container           |
 | `"monitoring-badge"`    | The component's notification badge |
 | `"monitoring-label"`    | The component's label              |
 | `"monitoring-sublabel"` | The component's sublabel           |
+| `"status-icon"`         | the components status symbol       |
 
 
 ## Dependencies

--- a/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.tsx
+++ b/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.tsx
@@ -74,6 +74,7 @@ export class RuxMonitoringIcon {
                         icon={this.icon}
                         class={`rux-status--${this.status}`}
                         size="2.5rem"
+                        exportparts="icon"
                     ></rux-icon>
                     <MonitoringBadge notifications={this.notifications} />
                 </div>

--- a/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.tsx
+++ b/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.tsx
@@ -4,9 +4,11 @@ import MonitoringBadge from '../../common/functional-components/MonitoringBadge/
 import MonitoringLabel from '../../common/functional-components/MonitoringLabel'
 
 /**
+ * @part container - the components container
  * @part monitoring-badge - The component's notification badge
  * @part monitoring-label - The component's label
  * @part monitoring-sublabel - The component's sublabel
+ * @part status-icon - the components status symbol
  */
 @Component({
     tag: 'rux-monitoring-icon',
@@ -64,10 +66,14 @@ export class RuxMonitoringIcon {
                 id="rux-advanced-status__icon"
                 class="rux-advanced-status"
                 title={`${this.notifications} ${this.label} ${this.sublabel}`}
+                part="container"
             >
                 <div class="rux-advanced-status__icon-group">
                     <div class="rux-advanced-status__status">
-                        <rux-status status={this.status}></rux-status>
+                        <rux-status
+                            status={this.status}
+                            part="status-icon"
+                        ></rux-status>
                     </div>
 
                     <rux-icon

--- a/packages/web-components/src/components/rux-monitoring-icon/test/__snapshots__/rux-monitoring-icon.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-monitoring-icon/test/__snapshots__/rux-monitoring-icon.spec.tsx.snap
@@ -3,12 +3,12 @@
 exports[`rux-monitoring-icon renders 1`] = `
 <rux-monitoring-icon icon="altitude" label="Altitude for satellite X" notifications="10210" status="standby" sublabel="100000m">
   <mock:shadow-root>
-    <div class="rux-advanced-status" id="rux-advanced-status__icon" title="10210 Altitude for satellite X 100000m">
+    <div class="rux-advanced-status" id="rux-advanced-status__icon" part="container" title="10210 Altitude for satellite X 100000m">
       <div class="rux-advanced-status__icon-group">
         <div class="rux-advanced-status__status">
-          <rux-status status="standby"></rux-status>
+          <rux-status part="status-icon" status="standby"></rux-status>
         </div>
-        <rux-icon class="rux-status--standby" icon="altitude" size="2.5rem"></rux-icon>
+        <rux-icon class="rux-status--standby" exportparts="icon" icon="altitude" size="2.5rem"></rux-icon>
         <div class="rux-advanced-status__badge" part="monitoring-badge">
           10K
         </div>

--- a/packages/web-components/src/components/rux-notification/readme.md
+++ b/packages/web-components/src/components/rux-notification/readme.md
@@ -82,6 +82,12 @@ The Astro UXDS Notification Banner hides from view using absolute positioning in
 | ----------- | -------------------------------------------- | ---------------------- |
 | `ruxclosed` | Fires when the notification banner is closed | `CustomEvent<boolean>` |
 
+## Shadow Parts
+
+| Part     | Description          |
+| -------- | -------------------- |
+| `"icon"` | the icon of rux-icon |
+
 ## CSS Custom Properties
 
 | Name                        | Description                 |

--- a/packages/web-components/src/components/rux-notification/rux-notification.tsx
+++ b/packages/web-components/src/components/rux-notification/rux-notification.tsx
@@ -10,6 +10,9 @@ import {
 } from '@stencil/core'
 import { Status } from '../../common/commonTypes.module'
 
+/**
+ * @part icon - the icon of rux-icon
+ */
 @Component({
     tag: 'rux-notification',
     styleUrl: 'rux-notification.scss',
@@ -111,6 +114,7 @@ export class RuxNotification {
                     onClick={() => this._onClick()}
                     icon="close"
                     size="36px"
+                    exportparts="icon"
                 ></rux-icon>
             </Host>
         )

--- a/packages/web-components/src/components/rux-notification/test/__snapshots__/rux-notification.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-notification/test/__snapshots__/rux-notification.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`rux-notification renders 1`] = `
     <div class="rux-notification__message">
       hello there
     </div>
-    <rux-icon icon="close" label="Close notification" role="button" size="36px"></rux-icon>
+    <rux-icon exportparts="icon" icon="close" label="Close notification" role="button" size="36px"></rux-icon>
   </mock:shadow-root>
 </rux-notification>
 `;

--- a/packages/web-components/src/components/rux-pop-up-menu/readme.md
+++ b/packages/web-components/src/components/rux-pop-up-menu/readme.md
@@ -92,7 +92,6 @@ Extending Astro Pop Up Menu with custom content. Content passed without a slot n
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property    | Attribute | Description                                                                                                                                   | Type                       | Default     |
@@ -100,7 +99,6 @@ Extending Astro Pop Up Menu with custom content. Content passed without a slot n
 | `anchorEl`  | --        | Element to anchor the menu to. If none is given the menu will anchor to the trigger element where aria-controls === menu id                   | `HTMLElement \| undefined` | `undefined` |
 | `open`      | `open`    | Boolean which controls when to show the menu                                                                                                  | `boolean`                  | `false`     |
 | `triggerEl` | --        | Optional element to trigger opening and closing of the menu. If none is supplied the element where aria-controls === menu id will be assigned | `HTMLElement \| undefined` | `undefined` |
-
 
 ## Events
 
@@ -110,7 +108,6 @@ Extending Astro Pop Up Menu with custom content. Content passed without a slot n
 | `ruxmenudidopen`   | Emitted when the menu is open.          | `CustomEvent<void>` |
 | `ruxmenuwillclose` | Emitted when the menu is about to close | `CustomEvent<void>` |
 | `ruxmenuwillopen`  | Emitted when the menu is about to open. | `CustomEvent<void>` |
-
 
 ## Methods
 
@@ -122,8 +119,6 @@ Closes the menu. If the menu is already closed it returns 'false'.
 
 Type: `Promise<boolean>`
 
-
-
 ### `isOpen() => Promise<boolean>`
 
 Returns 'true' if the menu is open, 'false' if it is not.
@@ -131,8 +126,6 @@ Returns 'true' if the menu is open, 'false' if it is not.
 #### Returns
 
 Type: `Promise<boolean>`
-
-
 
 ### `show() => Promise<boolean>`
 
@@ -142,8 +135,6 @@ Opens the menu. If the menu is already open it returns 'false'.
 
 Type: `Promise<boolean>`
 
-
-
 ### `toggle() => Promise<boolean>`
 
 Toggles the menu open or close. Will return 'true' on menu open and 'false' on menu close
@@ -152,15 +143,17 @@ Toggles the menu open or close. Will return 'true' on menu open and 'false' on m
 
 Type: `Promise<boolean>`
 
-
-
-
 ## Slots
 
 | Slot         | Description                                                                                        |
 | ------------ | -------------------------------------------------------------------------------------------------- |
 | `"menu-end"` | Area below the menu list to insert elements. For example, confirmation and/or cancel button group. |
 
+## Shadow Parts
+
+| Part          | Description                       |
+| ------------- | --------------------------------- |
+| `"container"` | the container for the pop-up-menu |
 
 ## CSS Custom Properties
 
@@ -173,7 +166,6 @@ Type: `Promise<boolean>`
 | `--popup-menu-caret-size`             | Size of Caret                       |
 | `--popup-menu-transition-speed`       | Transition Time of Pop Up Animation |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-progress/readme.md
+++ b/packages/web-components/src/components/rux-progress/readme.md
@@ -85,7 +85,6 @@ Indeterminate progress
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property    | Attribute    | Description                                                                         | Type                  | Default     |
@@ -94,6 +93,12 @@ Indeterminate progress
 | `max`       | `max`        | For progress bars where progress bars have a maximum value greater or less than 100 | `number`              | `100`       |
 | `value`     | `value`      | Current progress value between 0 and 100 (or the max, if defined below).            | `number \| undefined` | `undefined` |
 
+## Shadow Parts
+
+| Part         | Description                 |
+| ------------ | --------------------------- |
+| `"output"`   | the native output element   |
+| `"progress"` | the native progress element |
 
 ## CSS Custom Properties
 
@@ -109,7 +114,6 @@ Indeterminate progress
 | `--progress-radius`                             | The border radius of rux-progress bar          |
 | `--progress-width`                              | The width of rux-progress                      |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-progress/rux-progress.tsx
+++ b/packages/web-components/src/components/rux-progress/rux-progress.tsx
@@ -1,5 +1,9 @@
 import { Component, Host, h, Prop, Watch } from '@stencil/core'
 
+/**
+ * @part progress - the native progress element
+ * @part output - the native output element
+ */
 @Component({
     tag: 'rux-progress',
     styleUrl: 'rux-progress.scss',
@@ -64,10 +68,12 @@ export class RuxProgress {
                             class="rux-progress"
                             value={this.value}
                             max={this.max}
+                            part="progress"
                         ></progress>,
                         <output
                             class="rux-progress__value"
                             hidden={this.hideLabel}
+                            part="output"
                         >
                             {this._getProgressAsString()}
                         </output>,

--- a/packages/web-components/src/components/rux-progress/test/__snapshots__/rux-progress.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-progress/test/__snapshots__/rux-progress.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`rux-progress only renders the value if max is set to "" 1`] = `
 <rux-progress max="" value="20">
   <mock:shadow-root>
-    <progress class="rux-progress" max="NaN" value="20"></progress><output class="rux-progress__value">20</output>
+    <progress class="rux-progress" max="NaN" part="progress" value="20"></progress><output class="rux-progress__value" part="output">20</output>
     <slot></slot>
   </mock:shadow-root>
 </rux-progress>
@@ -21,7 +21,7 @@ exports[`rux-progress renders 1`] = `
 exports[`rux-progress renders a progress bar of 0/100 if value provided is 0 1`] = `
 <rux-progress value="0">
   <mock:shadow-root>
-    <progress class="rux-progress" max="100" value="0"></progress><output class="rux-progress__value">0%</output>
+    <progress class="rux-progress" max="100" part="progress" value="0"></progress><output class="rux-progress__value" part="output">0%</output>
     <slot></slot>
   </mock:shadow-root>
 </rux-progress>

--- a/packages/web-components/src/components/rux-push-button/readme.md
+++ b/packages/web-components/src/components/rux-push-button/readme.md
@@ -107,7 +107,6 @@ For more information about AstroUXDS usage outside of a Web Component environmen
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property   | Attribute   | Description                                                                                                                                                                                                                                                                                                   | Type                                          | Default         |
@@ -121,7 +120,6 @@ For more information about AstroUXDS usage outside of a Web Component environmen
 | `size`     | `size`      | Changes size of a push button from medium to small or large by setting sizing classes rux-button--small rux-button--large                                                                                                                                                                                     | `"large" \| "medium" \| "small" \| undefined` | `undefined`     |
 | `value`    | `value`     | The value of the push button.                                                                                                                                                                                                                                                                                 | `string`                                      | `''`            |
 
-
 ## Events
 
 | Event       | Description                                                                                                                                                                    | Type               |
@@ -129,6 +127,12 @@ For more information about AstroUXDS usage outside of a Web Component environmen
 | `ruxblur`   | Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)                                           | `CustomEvent<any>` |
 | `ruxchange` | Fired when an alteration to the input's value is committed by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) | `CustomEvent<any>` |
 
+## Shadow Parts
+
+| Part      | Description                  |
+| --------- | ---------------------------- |
+| `"icon"`  | the optional rux-icon        |
+| `"label"` | the label of rux-push-button |
 
 ## CSS Custom Properties
 
@@ -141,20 +145,20 @@ For more information about AstroUXDS usage outside of a Web Component environmen
 | `--pushbutton-selected-text-color`       | the Push Button text color when checked       |
 | `--pushbutton-text-color`                | the Push Button text color                    |
 
-
 ## Dependencies
 
 ### Depends on
 
-- [rux-icon](../rux-icon)
+-   [rux-icon](../rux-icon)
 
 ### Graph
+
 ```mermaid
 graph TD;
   rux-push-button --> rux-icon
   style rux-push-button fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-push-button/rux-push-button.tsx
+++ b/packages/web-components/src/components/rux-push-button/rux-push-button.tsx
@@ -9,6 +9,10 @@ import {
 } from '@stencil/core'
 import { renderHiddenInput } from '../../utils/utils'
 
+/**
+ * @part label - the label of rux-push-button
+ * @part icon - the optional rux-icon in rux-push-button
+ */
 @Component({
     tag: 'rux-push-button',
     styleUrl: 'rux-push-button.scss',
@@ -131,9 +135,14 @@ export class RuxPushButton {
                         'rux-push-button__button--icon-only': iconOnly,
                     }}
                     htmlFor={this.pushButtonId}
+                    part="label"
                 >
                     {icon ? (
-                        <rux-icon size="extra-small" icon={icon}></rux-icon>
+                        <rux-icon
+                            size="extra-small"
+                            exportparts="icon"
+                            icon={icon}
+                        ></rux-icon>
                     ) : null}
 
                     {label}

--- a/packages/web-components/src/components/rux-push-button/rux-push-button.tsx
+++ b/packages/web-components/src/components/rux-push-button/rux-push-button.tsx
@@ -11,7 +11,7 @@ import { renderHiddenInput } from '../../utils/utils'
 
 /**
  * @part label - the label of rux-push-button
- * @part icon - the optional rux-icon in rux-push-button
+ * @part icon - the optional rux-icon
  */
 @Component({
     tag: 'rux-push-button',

--- a/packages/web-components/src/components/rux-push-button/test/__snapshots__/rux-push-button.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-push-button/test/__snapshots__/rux-push-button.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`rux-push-button should render the default push button 1`] = `
 <rux-push-button aria-checked="false" role="switch" value="">
   <mock:shadow-root>
     <input class="rux-push-button__input" id="rux-push-button-0" type="checkbox" value="">
-    <label class="rux-push-button__button" htmlfor="rux-push-button-0">
+    <label class="rux-push-button__button" htmlfor="rux-push-button-0" part="label">
       Push Button
     </label>
     <slot></slot>

--- a/packages/web-components/src/components/rux-radio-group/readme.md
+++ b/packages/web-components/src/components/rux-radio-group/readme.md
@@ -2,7 +2,6 @@
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property    | Attribute    | Description                                                                                                         | Type                  | Default     |
@@ -14,13 +13,11 @@
 | `name`      | `name`       | The name of the radio group - submitted with form data. Must match the name of the radios in the group.             | `string`              | `''`        |
 | `value`     | `value`      | The value of the current selected radio in the group. Changing this will also mark that radio as checked in the UI. | `any`                 | `undefined` |
 
-
 ## Events
 
 | Event       | Description                                                                                                                                     | Type               |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
 | `ruxchange` | Fired when the value of the input changes - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) | `CustomEvent<any>` |
-
 
 ## Slots
 
@@ -28,15 +25,14 @@
 | --------- | --------------------- |
 | `"label"` | The radio group label |
 
-
 ## Shadow Parts
 
-| Part           | Description                              |
-| -------------- | ---------------------------------------- |
-| `"form-field"` | The form-field wrapper container         |
-| `"label"`      | The input label when `label` prop is set |
-| `"radiogroup"` | The container of radios                  |
-
+| Part                   | Description                              |
+| ---------------------- | ---------------------------------------- |
+| `"form-field"`         | The form-field wrapper container         |
+| `"form-field-message"` | The error/help text container.           |
+| `"label"`              | The input label when `label` prop is set |
+| `"radiogroup"`         | The container of radios                  |
 
 ## CSS Custom Properties
 
@@ -44,7 +40,6 @@
 | --------------------------- | ---------------------------- |
 | `--radiogroup-border-color` | the radio group border color |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-radio-group/rux-radio-group.tsx
+++ b/packages/web-components/src/components/rux-radio-group/rux-radio-group.tsx
@@ -18,6 +18,7 @@ import { hasSlot, renderHiddenInput } from '../../utils/utils'
  * @part form-field - The form-field wrapper container
  * @part label - The input label when `label` prop is set
  * @part radiogroup - The container of radios
+ * @part form-field-message - The error/help text container.
  */
 @Component({
     tag: 'rux-radio-group',

--- a/packages/web-components/src/components/rux-radio/readme.md
+++ b/packages/web-components/src/components/rux-radio/readme.md
@@ -23,7 +23,6 @@ Radio Buttons allow users to mutually select an option from a predefined set of 
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property   | Attribute  | Description                                                                                                                                                                           | Type                  | Default     |
@@ -34,13 +33,11 @@ Radio Buttons allow users to mutually select an option from a predefined set of 
 | `name`     | `name`     | The radio name                                                                                                                                                                        | `string`              | `''`        |
 | `value`    | `value`    | The radio value                                                                                                                                                                       | `string`              | `''`        |
 
-
 ## Events
 
 | Event     | Description                                                                                                                          | Type               |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
 | `ruxblur` | Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event) | `CustomEvent<any>` |
-
 
 ## Slots
 
@@ -48,6 +45,12 @@ Radio Buttons allow users to mutually select an option from a predefined set of 
 | ------------- | --------------- |
 | `"(default)"` | The radio label |
 
+## Shadow Parts
+
+| Part           | Description                 |
+| -------------- | --------------------------- |
+| `"form-field"` | the form field of the radio |
+| `"label"`      | the label of the radio      |
 
 ## CSS Custom Properties
 
@@ -59,7 +62,6 @@ Radio Buttons allow users to mutually select an option from a predefined set of 
 | `--radio-label-color`        | label text color            |
 | `--radio-selected-color`     | the radio selected color    |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-radio/rux-radio.tsx
+++ b/packages/web-components/src/components/rux-radio/rux-radio.tsx
@@ -96,7 +96,7 @@ export class RuxRadio {
         } = this
 
         return (
-            <div class="rux-form-field">
+            <div class="rux-form-field" part="form-field">
                 <div class="rux-radio">
                     <input
                         type="radio"
@@ -108,7 +108,7 @@ export class RuxRadio {
                         onChange={_onChange}
                         onBlur={_onBlur}
                     />
-                    <label htmlFor={radioId}>
+                    <label htmlFor={radioId} part="label">
                         <slot>{label}</slot>
                     </label>
                 </div>

--- a/packages/web-components/src/components/rux-radio/rux-radio.tsx
+++ b/packages/web-components/src/components/rux-radio/rux-radio.tsx
@@ -4,6 +4,8 @@ let id = 0
 
 /**
  * @slot (default) - The radio label
+ * @part form-field - the form field of the radio
+ * @part label - the label of the radio
  */
 
 @Component({

--- a/packages/web-components/src/components/rux-radio/test/__snapshots__/rux-radio.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-radio/test/__snapshots__/rux-radio.spec.tsx.snap
@@ -3,10 +3,10 @@
 exports[`rux-radio renders 1`] = `
 <rux-radio value="test">
   <mock:shadow-root>
-    <div class="rux-form-field">
+    <div class="rux-form-field" part="form-field">
       <div class="rux-radio">
         <input id="rux-radio-2" type="radio" value="test">
-        <label htmlfor="rux-radio-2">
+        <label htmlfor="rux-radio-2" part="label">
           <slot></slot>
         </label>
       </div>

--- a/packages/web-components/src/components/rux-segmented-button/readme.md
+++ b/packages/web-components/src/components/rux-segmented-button/readme.md
@@ -42,7 +42,6 @@ document.addEventListener('change', (e) =>
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property   | Attribute  | Description                                                                                                                                                                                                                                                                                                                                                                                                    | Type                | Default |
@@ -50,13 +49,17 @@ document.addEventListener('change', (e) =>
 | `data`     | --         | Items in this Array are the individual button segments.                                                                                                                                                                                                                                                                                                                                                        | `SegmentedButton[]` | `[]`    |
 | `selected` | `selected` | When passed in on load, this selects the first button segment with a matching label. When the selected segment changes, this property updates with the currently selected value, which reflects back to the component attribute. If no button segment label matches this string, then no segment is selected. This value takes priority over setting selected boolean property on the items in the data array. | `string`            | `''`    |
 
-
 ## Events
 
 | Event       | Description                                  | Type               |
 | ----------- | -------------------------------------------- | ------------------ |
 | `ruxchange` | Emitted when the value property has changed. | `CustomEvent<any>` |
 
+## Shadow Parts
+
+| Part      | Description                       |
+| --------- | --------------------------------- |
+| `"label"` | the label of rux-segmented-button |
 
 ## CSS Custom Properties
 
@@ -75,7 +78,6 @@ document.addEventListener('change', (e) =>
 | `--segmented-button-selected-text-color`             | Segmented button selected text color             |
 | `--segmented-button-text-color`                      | Segmented button text color                      |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
@@ -9,6 +9,9 @@ import {
 } from '@stencil/core'
 import { SegmentedButton } from './rux-segmented-button.model'
 
+/**
+ * @part label - the label of rux-segmented-button
+ */
 @Component({
     tag: 'rux-segmented-button',
     styleUrl: 'rux-segmented-button.scss',

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
@@ -110,7 +110,7 @@ export class RuxSegmentedButton {
                             data-label={item.label}
                             onChange={this._handleChange}
                         />
-                        <label htmlFor={this._slugify(item.label)}>
+                        <label htmlFor={this._slugify(item.label)} part="label">
                             {item.label}
                         </label>
                     </li>

--- a/packages/web-components/src/components/rux-select/readme.md
+++ b/packages/web-components/src/components/rux-select/readme.md
@@ -75,6 +75,14 @@ Select Menu renders a native `<select>` element and allows native `<option>` and
 | `"(default)"` | The select options |
 | `"label"`     | The select label   |
 
+## Shadow Parts
+
+| Part                   | Description                                  |
+| ---------------------- | -------------------------------------------- |
+| `"form-field-message"` | the container for the error/help text        |
+| `"label"`              | The select label                             |
+| `"select"`             | the native select element used by rux-select |
+
 ## CSS Custom Properties
 
 | Name                                             | Description                                 |

--- a/packages/web-components/src/components/rux-select/rux-select.tsx
+++ b/packages/web-components/src/components/rux-select/rux-select.tsx
@@ -18,6 +18,9 @@ import { hasSlot, renderHiddenInput } from '../../utils/utils'
 /**
  * @slot (default) - The select options
  * @slot label - The select label
+ * @part label - The select label
+ * @part select - the native select element used by rux-select
+ * @part form-field-message - the container for the error/help text
  */
 @Component({
     tag: 'rux-select',
@@ -248,6 +251,7 @@ export class RuxSelect implements FormFieldInterface {
                     id={labelId}
                     htmlFor={inputId}
                     aria-hidden={this.hasLabel ? 'false' : 'true'}
+                    part="label"
                 >
                     <span class={{ hidden: !this.hasLabel }}>
                         <slot
@@ -269,6 +273,7 @@ export class RuxSelect implements FormFieldInterface {
                     name={name}
                     onChange={(e) => this._onChange(e)}
                     onBlur={this._onBlur}
+                    part="select"
                 ></select>
                 <div
                     aria-hidden="true"

--- a/packages/web-components/src/components/rux-select/test/__snapshots__/rux-select.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-select/test/__snapshots__/rux-select.spec.tsx.snap
@@ -3,14 +3,14 @@
 exports[`rux-select renders 1`] = `
 <rux-select label="test">
   <mock:shadow-root>
-    <label aria-hidden="false">
+    <label aria-hidden="false" part="label">
       <span>
         <slot name="label">
           test
         </slot>
       </span>
     </label>
-    <select class="rux-select"></select>
+    <select class="rux-select" part="select"></select>
     <div aria-hidden="true" class="hidden">
       <slot></slot>
     </div>
@@ -24,12 +24,12 @@ exports[`rux-select renders 1`] = `
 exports[`rux-select renders option groups 1`] = `
 <rux-select>
   <mock:shadow-root>
-    <label aria-hidden="true">
+    <label aria-hidden="true" part="label">
       <span class="hidden">
         <slot name="label"></slot>
       </span>
     </label>
-    <select class="rux-select"></select>
+    <select class="rux-select" part="select"></select>
     <div aria-hidden="true" class="hidden">
       <slot></slot>
     </div>

--- a/packages/web-components/src/components/rux-slider/readme.md
+++ b/packages/web-components/src/components/rux-slider/readme.md
@@ -54,7 +54,6 @@ Pass properties via attributes similar to the native [HTML Input Range](https://
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property    | Attribute    | Description                                                                                                                                                                                                   | Type                  | Default                                   |
@@ -69,7 +68,6 @@ Pass properties via attributes similar to the native [HTML Input Range](https://
 | `step`      | `step`       | Step amount of slider value.                                                                                                                                                                                  | `number`              | `1`                                       |
 | `value`     | `value`      | Current value of the slider. The default value is halfway between the specified minimum and maximum. - [HTMLElement/input_type_range>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range) | `number`              | `(this.max! - this.min!) / 2 + this.min!` |
 
-
 ## Events
 
 | Event      | Description                                                                                                                                     | Type               |
@@ -77,21 +75,20 @@ Pass properties via attributes similar to the native [HTML Input Range](https://
 | `ruxblur`  | Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)            | `CustomEvent<any>` |
 | `ruxinput` | Fired when the value of the input changes - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) | `CustomEvent<any>` |
 
-
 ## Slots
 
 | Slot      | Description      |
 | --------- | ---------------- |
 | `"label"` | The slider label |
 
-
 ## Shadow Parts
 
-| Part           | Description                              |
-| -------------- | ---------------------------------------- |
-| `"form-field"` | The form-field wrapper container         |
-| `"label"`      | The input label when `label` prop is set |
-
+| Part                   | Description                                 |
+| ---------------------- | ------------------------------------------- |
+| `"form-field"`         | The form-field wrapper container            |
+| `"form-field-message"` | the error/help text container               |
+| `"input"`              | The native input element used by rux-slider |
+| `"label"`              | The input label when `label` prop is set    |
 
 ## CSS Custom Properties
 
@@ -111,7 +108,6 @@ Pass properties via attributes similar to the native [HTML Input Range](https://
 | `--slider-track-height`                    | the slider track height                                     |
 | `--slider-value-percent`                   | The current value of the slider in a percent.               |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-slider/rux-slider.tsx
+++ b/packages/web-components/src/components/rux-slider/rux-slider.tsx
@@ -19,6 +19,8 @@ let id = 0
  * @slot label - The slider label
  * @part form-field - The form-field wrapper container
  * @part label - The input label when `label` prop is set
+ * @part input - The native input element used by rux-slider
+ * @part form-field-message - the error/help text container
  */
 @Component({
     tag: 'rux-slider',
@@ -230,6 +232,7 @@ export class RuxSlider implements FormFieldInterface {
                             aria-label="slider"
                             aria-disabled={disabled ? 'true' : 'false'}
                             onBlur={_onBlur}
+                            part="input"
                         ></input>
                     </div>
                 </div>

--- a/packages/web-components/src/components/rux-slider/test/__snapshots__/rux-slider.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-slider/test/__snapshots__/rux-slider.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`rux-slider renders 1`] = `
         </span>
       </label>
       <div class="rux-slider">
-        <input aria-disabled="false" aria-label="slider" class="rux-range" id="rux-slider-1" max="100" min="0" step="1" type="range" value="50">
+        <input aria-disabled="false" aria-label="slider" class="rux-range" id="rux-slider-1" max="100" min="0" part="input" step="1" type="range" value="50">
       </div>
     </div>
   </mock:shadow-root>
@@ -30,7 +30,7 @@ exports[`rux-slider renders label prop 1`] = `
         </span>
       </label>
       <div class="rux-slider">
-        <input aria-disabled="false" aria-label="slider" class="rux-range" id="rux-slider-2" max="100" min="0" step="1" type="range" value="50">
+        <input aria-disabled="false" aria-label="slider" class="rux-range" id="rux-slider-2" max="100" min="0" part="input" step="1" type="range" value="50">
       </div>
     </div>
   </mock:shadow-root>
@@ -48,7 +48,7 @@ exports[`rux-slider renders label slot 1`] = `
         </span>
       </label>
       <div class="rux-slider">
-        <input aria-disabled="false" aria-label="slider" class="rux-range" id="rux-slider-3" max="100" min="0" step="1" type="range" value="50">
+        <input aria-disabled="false" aria-label="slider" class="rux-range" id="rux-slider-3" max="100" min="0" part="input" step="1" type="range" value="50">
       </div>
     </div>
   </mock:shadow-root>

--- a/packages/web-components/src/components/rux-switch/readme.md
+++ b/packages/web-components/src/components/rux-switch/readme.md
@@ -78,7 +78,6 @@ Configure the component using native HTML attributes.
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property   | Attribute  | Description                                                                                                                                                                             | Type                  | Default     |
@@ -89,7 +88,6 @@ Configure the component using native HTML attributes.
 | `name`     | `name`     | The switch name                                                                                                                                                                         | `string`              | `''`        |
 | `value`    | `value`    | The switch value                                                                                                                                                                        | `string`              | `''`        |
 
-
 ## Events
 
 | Event       | Description                                                                                                                                                                    | Type               |
@@ -98,13 +96,18 @@ Configure the component using native HTML attributes.
 | `ruxchange` | Fired when the value of the input changes - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)                                | `CustomEvent<any>` |
 | `ruxinput`  | Fired when an alteration to the input's value is committed by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) | `CustomEvent<any>` |
 
-
 ## Slots
 
 | Slot      | Description      |
 | --------- | ---------------- |
 | `"label"` | The switch label |
 
+## Shadow Parts
+
+| Part       | Description                                                 |
+| ---------- | ----------------------------------------------------------- |
+| `"label"`  | the label of switch                                         |
+| `"switch"` | the track (::before) and the button (::after) on rux-switch |
 
 ## CSS Custom Properties
 
@@ -116,7 +119,6 @@ Configure the component using native HTML attributes.
 | `--switch-off-border-color` | the Switch off border color |
 | `--switch-on-color`         | the Switch on color         |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-switch/rux-switch.tsx
+++ b/packages/web-components/src/components/rux-switch/rux-switch.tsx
@@ -15,6 +15,8 @@ let id = 0
 
 /**
  * @slot label - The switch label
+ * @part switch - the track (::before) and the button (::after) on rux-switch
+ * @part label - the label of switch
  */
 @Component({
     tag: 'rux-switch',

--- a/packages/web-components/src/components/rux-switch/rux-switch.tsx
+++ b/packages/web-components/src/components/rux-switch/rux-switch.tsx
@@ -149,12 +149,17 @@ export class RuxSwitch {
                         onInput={this._onInput}
                         onBlur={this._onBlur}
                     />
-                    <label class="rux-switch__button" htmlFor={switchId}>
+                    <label
+                        class="rux-switch__button"
+                        htmlFor={switchId}
+                        part="switch"
+                    >
                         <span
                             class={{
                                 'rux-switch__label': true,
                                 hidden: !this.hasLabel,
                             }}
+                            part="label"
                         >
                             <slot
                                 onSlotchange={this._handleSlotChange}

--- a/packages/web-components/src/components/rux-switch/test/__snapshots__/rux-switch.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-switch/test/__snapshots__/rux-switch.spec.tsx.snap
@@ -5,8 +5,8 @@ exports[`rux-switch renders 1`] = `
   <mock:shadow-root>
     <div class="rux-switch">
       <input aria-checked="false" class="rux-switch__input" id="rux-switch-3" role="switch" type="checkbox" value="">
-      <label class="rux-switch__button" htmlfor="rux-switch-3">
-        <span class="hidden rux-switch__label">
+      <label class="rux-switch__button" htmlfor="rux-switch-3" part="switch">
+        <span class="hidden rux-switch__label" part="label">
           <slot name="label"></slot>
         </span>
       </label>
@@ -20,8 +20,8 @@ exports[`rux-switch renders label prop 1`] = `
   <mock:shadow-root>
     <div class="rux-switch">
       <input aria-checked="false" class="rux-switch__input" id="rux-switch-4" role="switch" type="checkbox" value="">
-      <label class="rux-switch__button" htmlfor="rux-switch-4">
-        <span class="rux-switch__label">
+      <label class="rux-switch__button" htmlfor="rux-switch-4" part="switch">
+        <span class="rux-switch__label" part="label">
           <slot name="label">
             hello
           </slot>
@@ -37,8 +37,8 @@ exports[`rux-switch renders label slot 1`] = `
   <mock:shadow-root>
     <div class="rux-switch">
       <input aria-checked="false" class="rux-switch__input" id="rux-switch-5" role="switch" type="checkbox" value="">
-      <label class="rux-switch__button" htmlfor="rux-switch-5">
-        <span class="rux-switch__label">
+      <label class="rux-switch__button" htmlfor="rux-switch-5" part="switch">
+        <span class="rux-switch__label" part="label">
           <slot name="label"></slot>
         </span>
       </label>

--- a/packages/web-components/src/components/rux-textarea/readme.md
+++ b/packages/web-components/src/components/rux-textarea/readme.md
@@ -2,14 +2,13 @@
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property      | Attribute     | Description                                                                                                                                                                             | Type                  | Default     |
 | ------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | ----------- |
 | `disabled`    | `disabled`    | Disables the button via HTML disabled attribute. Button takes on a distinct visual state. Cursor uses the not-allowed system replacement and all keyboard and mouse events are ignored. | `boolean`             | `false`     |
 | `errorText`   | `error-text`  | The validation error text                                                                                                                                                               | `string \| undefined` | `undefined` |
-| `helpText`    | `help-text`   | The  or explanation text                                                                                                                                                                | `string \| undefined` | `undefined` |
+| `helpText`    | `help-text`   | The or explanation text                                                                                                                                                                 | `string \| undefined` | `undefined` |
 | `invalid`     | `invalid`     | Presentational only. Renders the Textarea as invalid.                                                                                                                                   | `boolean`             | `false`     |
 | `label`       | `label`       | The textarea label text. For HTML content, use the `label` slot instead.                                                                                                                | `string \| undefined` | `undefined` |
 | `maxLength`   | `max-length`  | The input maxLength attribute                                                                                                                                                           | `string \| undefined` | `undefined` |
@@ -21,7 +20,6 @@
 | `small`       | `small`       | Styles the input element and label smaller for space-limited situations.                                                                                                                | `boolean`             | `false`     |
 | `value`       | `value`       | The input value                                                                                                                                                                         | `string`              | `''`        |
 
-
 ## Events
 
 | Event       | Description                                                                                                                                                                    | Type               |
@@ -30,21 +28,20 @@
 | `ruxchange` | Fired when the value of the input changes - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)                                | `CustomEvent<any>` |
 | `ruxinput`  | Fired when an alteration to the input's value is committed by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) | `CustomEvent<any>` |
 
-
 ## Slots
 
 | Slot      | Description        |
 | --------- | ------------------ |
 | `"label"` | The textarea label |
 
-
 ## Shadow Parts
 
-| Part           | Description                              |
-| -------------- | ---------------------------------------- |
-| `"form-field"` | The form-field wrapper container         |
-| `"label"`      | The input label when `label` prop is set |
-
+| Part                   | Description                                 |
+| ---------------------- | ------------------------------------------- |
+| `"form-field"`         | The form-field wrapper container            |
+| `"form-field-message"` | The error/help text container               |
+| `"label"`              | The input label when `label` prop is set    |
+| `"textarea"`           | The native textarea element in rux-textarea |
 
 ## CSS Custom Properties
 
@@ -57,7 +54,6 @@
 | `--textarea-selection-background-color` | Background color while in a selected state |
 | `--textarea-text-color`                 | Text color                                 |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.tsx
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.tsx
@@ -19,6 +19,8 @@ let id = 0
  * @slot label - The textarea label
  * @part form-field - The form-field wrapper container
  * @part label - The input label when `label` prop is set
+ * @part textarea - The native textarea element in rux-textarea
+ * @part form-field-message - The error/help text container
  */
 @Component({
     tag: 'rux-textarea',
@@ -196,6 +198,7 @@ export class RuxTextarea implements FormFieldInterface {
                         onChange={this._onChange}
                         onInput={this._onInput}
                         onBlur={this._onBlur}
+                        part="textarea"
                     ></textarea>
                 </div>
                 <FormFieldMessage

--- a/packages/web-components/src/components/rux-textarea/test/__snapshots__/rux-textarea.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-textarea/test/__snapshots__/rux-textarea.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`rux-textarea renders 1`] = `
         <span class="hidden">
           <slot name="label"></slot>
         </span>
-      </label><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-1" value=""></textarea>
+      </label><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-1" part="textarea" value=""></textarea>
     </div>
   </mock:shadow-root>
   <input class="aux-input" type="hidden" value="">
@@ -25,7 +25,7 @@ exports[`rux-textarea renders label prop 1`] = `
             hello
           </slot>
         </span>
-      </label><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-2" value=""></textarea>
+      </label><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-2" part="textarea" value=""></textarea>
     </div>
   </mock:shadow-root>
   <input class="aux-input" type="hidden" value="">
@@ -40,7 +40,7 @@ exports[`rux-textarea renders label slot 1`] = `
         <span>
           <slot name="label"></slot>
         </span>
-      </label><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-3" value=""></textarea>
+      </label><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-3" part="textarea" value=""></textarea>
     </div>
   </mock:shadow-root>
   <div slot="label">


### PR DESCRIPTION
## Brief Description

Added shadow parts to relevant components.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2607

## Related Issue

## General Notes

I added container shadow parts to rux-menu-item and item divider, but I'm unsure if they are completely necessary. Let me know what you think!

Also, I added label parts to components that also have label slots because those slots aren't rendering a particular component.

## Motivation and Context

Shadow part PI 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
