### PR TITLE
docs(SB): Astro 2755 sb code examples

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+dist
+loader
+storybook-static
+*.mdx
+*readme.md
+
+# Ignore Stencil Build files
+src/components.d.ts
+src/globals.d.ts

--- a/packages/web-components/src/stories/button-group.stories.mdx
+++ b/packages/web-components/src/stories/button-group.stories.mdx
@@ -23,35 +23,35 @@ Common button groupings follow these conventions:
 
 export const Default = (args) => {
     return html`
-        <style>
-            .light-theme {
-                --exampleContainerBackgroundColor: var(--color-inverse-text);
-                --exampleContainerBorderColor: var(--colorQuaternaryLighten1);
-            }
-            .dark-theme {
-                --exampleContainerBackgroundColor: var(
-                    --color-global-tertiary-600
-                );
-                --exampleContainerBorderColor: #283f58;
-            }
-            .example-container {
-                min-width: 20rem;
-                background: var(--exampleContainerBackgroundColor);
-                border: 1px solid var(--exampleContainerBorderColor);
-                padding: 0.625rem;
-                display: block;
-            }
-        </style>
-        <div style="padding: 10%; display: flex; justify-content: center;">
-            <div class="example-container">
-                <rux-button-group
-                    .hAlign="${args.hAlign ? args.hAlign : 'right'}"
-                >
-                    <rux-button secondary>Cancel</rux-button>
-                    <rux-button>Continue</rux-button>
-                </rux-button-group>
-            </div>
-        </div>
+<style>
+    .light-theme {
+        --exampleContainerBackgroundColor: var(--color-inverse-text);
+        --exampleContainerBorderColor: var(--colorQuaternaryLighten1);
+    }
+    .dark-theme {
+        --exampleContainerBackgroundColor: var(
+            --color-global-tertiary-600
+        );
+        --exampleContainerBorderColor: #283f58;
+    }
+    .example-container {
+        min-width: 20rem;
+        background: var(--exampleContainerBackgroundColor);
+        border: 1px solid var(--exampleContainerBorderColor);
+        padding: 0.625rem;
+        display: block;
+    }
+</style>
+<div style="padding: 10%; display: flex; justify-content: center;">
+    <div class="example-container">
+        <rux-button-group
+            hAlign="${args.hAlign ? args.hAlign : 'right'}"
+        >
+            <rux-button secondary>Cancel</rux-button>
+            <rux-button>Continue</rux-button>
+        </rux-button-group>
+    </div>
+</div>
     `
 }
 

--- a/packages/web-components/src/stories/button.stories.mdx
+++ b/packages/web-components/src/stories/button.stories.mdx
@@ -19,17 +19,17 @@ Buttons allow users to trigger actions.
 
 export const Default = (args) => {
     return html`
-        <div style="padding: 10%; display: flex; justify-content: center;">
-            <rux-button
-                ?disabled="${args.disabled}"
-                ?icon-only="${args.iconOnly}"
-                ?secondary="${args.secondary}"
-                .size="${args.size}"
-                .icon="${args.icon}"
-            >
-                Button
-            </rux-button>
-        </div>
+<div style="padding: 10%; display: flex; justify-content: center;">
+    <rux-button
+        ?disabled="${args.disabled}"
+        ?icon-only="${args.iconOnly}"
+        ?secondary="${args.secondary}"
+        .size="${args.size}"
+        .icon="${args.icon}"
+    >
+        Button
+    </rux-button>
+</div>
     `
 }
 
@@ -50,18 +50,18 @@ The component auto-imports the default Astro Icon Web Component for icons, if yo
 export const slottedIconButton = (args) => {
     const { size, disabled, secondary, iconOnly } = args
     return html`
-        <div style="padding: 10%; display: flex; justify-content: center;">
-            <rux-button
-                ?disabled="${args.disabled}"
-                ?icon-only="${args.iconOnly}"
-                ?secondary="${args.secondary}"
-                .size="${args.size}"
-                .icon="${args.icon}"
-            >
-                <rux-icon icon="palette" size="extra-small"></rux-icon>
-                Slotted icon button
-            </rux-button>
-        </div>
+<div style="padding: 10%; display: flex; justify-content: center;">
+    <rux-button
+        ?disabled="${args.disabled}"
+        ?icon-only="${args.iconOnly}"
+        ?secondary="${args.secondary}"
+        .size="${args.size}"
+        .icon="${args.icon}"
+    >
+        <rux-icon icon="palette" size="extra-small"></rux-icon>
+        Slotted icon button
+    </rux-button>
+</div>
     `
 }
 
@@ -73,17 +73,17 @@ export const slottedIconButton = (args) => {
 
 export const Secondary = (args) => {
     return html`
-        <div style="padding: 10%; display: flex; justify-content: center;">
-            <rux-button
-                ?disabled="${args.disabled}"
-                ?icon-only="${args.iconOnly}"
-                ?secondary="${args.secondary}"
-                .size="${args.size}"
-                .icon="${args.icon}"
-            >
-                Button
-            </rux-button>
-        </div>
+<div style="padding: 10%; display: flex; justify-content: center;">
+    <rux-button
+        ?disabled="${args.disabled}"
+        ?icon-only="${args.iconOnly}"
+        ?secondary="${args.secondary}"
+        .size="${args.size}"
+        .icon="${args.icon}"
+    >
+        Button
+    </rux-button>
+</div>
     `
 }
 
@@ -97,188 +97,188 @@ export const Secondary = (args) => {
 
 export const AllVariants = () => {
     return html`
-        <style>
-            .button-list {
-                list-style-type: none;
-                margin: 0 1rem 0 0;
-                padding: 0;
-                display: flex;
-                flex-flow: column;
-            }
-            .button-list li {
-                margin: 0 1rem 1rem 0;
-                display: flex;
-            }
-            .button-list li rux-button:not(:last-child) {
-                margin-right: 1rem;
-            }
-        </style>
-        <div
-            style="padding: 8vh 2vw; display: flex; flex-flow: row wrap; justify-content: space-evenly;"
-        >
-            <ul class="button-list">
-                <li>
-                    <rux-button size="small" icon-only icon="settings"
-                        >Small icon-only button</rux-button
-                    >
-                    <rux-button size="small">Small button</rux-button>
-                </li>
-                <li>
-                    <rux-button size="small" icon="settings"
-                        >Small button with icon</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button size="small" icon-only disabled icon="settings"
-                        >Small disabled icon-only button</rux-button
-                    >
-                    <rux-button size="small" disabled
-                        >Small disabled button</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button size="small" disabled icon="settings"
-                        >Small disabled button with icon</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button size="small" icon-only secondary icon="settings"
-                        >Small secondary icon-only button</rux-button
-                    >
-                    <rux-button size="small" secondary
-                        >Small secondary button</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button size="small" secondary icon="settings"
-                        >Small secondary button with icon</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button
-                        size="small"
-                        icon-only
-                        disabled
-                        secondary
-                        icon="settings"
-                        >Small disabled secondary icon-only button</rux-button
-                    >
-                    <rux-button size="small" secondary disabled
-                        >Small disabled secondary button</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button size="small" secondary disabled icon="settings"
-                        >Small disabled secondary button with icon</rux-button
-                    >
-                </li>
-            </ul>
-            <ul class="button-list">
-                <li>
-                    <rux-button icon-only icon="settings"
-                        >Medium icon-only button</rux-button
-                    >
-                    <rux-button>Medium button</rux-button>
-                </li>
-                <li>
-                    <rux-button icon="settings"
-                        >Medium button with icon</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button icon-only disabled icon="settings"
-                        >Medium disabled icon-only button</rux-button
-                    >
-                    <rux-button disabled>Medium disabled button</rux-button>
-                </li>
-                <li>
-                    <rux-button disabled icon="settings"
-                        >Medium disabled button with icon</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button icon-only secondary icon="settings"
-                        >Medium secondary icon-only button</rux-button
-                    >
-                    <rux-button secondary>Medium secondary button</rux-button>
-                </li>
-                <li>
-                    <rux-button secondary icon="settings"
-                        >Medium secondary button with icon</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button icon-only disabled secondary icon="settings"
-                        >Medium disabled secondary icon-only button</rux-button
-                    >
-                    <rux-button secondary disabled
-                        >Medium disabled secondary button</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button secondary disabled icon="settings"
-                        >Medium disabled secondary button with icon</rux-button
-                    >
-                </li>
-            </ul>
-            <ul class="button-list">
-                <li>
-                    <rux-button size="large" icon-only icon="settings"
-                        >Large icon-only button</rux-button
-                    >
-                    <rux-button size="large">Large button</rux-button>
-                </li>
-                <li>
-                    <rux-button size="large" icon="settings"
-                        >Large button with icon</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button size="large" icon-only disabled icon="settings"
-                        >Large disabled icon-only button</rux-button
-                    >
-                    <rux-button size="large" disabled
-                        >Large disabled button</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button size="large" disabled icon="settings"
-                        >Large disabled button with icon</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button size="large" icon-only secondary icon="settings"
-                        >Large secondary icon-only button</rux-button
-                    >
-                    <rux-button size="large" secondary
-                        >Large secondary button</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button size="large" secondary icon="settings"
-                        >Large secondary button with icon</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button
-                        size="large"
-                        icon-only
-                        disabled
-                        secondary
-                        icon="settings"
-                        >Large disabled secondary icon-only button</rux-button
-                    >
-                    <rux-button size="large" secondary disabled
-                        >Large disabled secondary button</rux-button
-                    >
-                </li>
-                <li>
-                    <rux-button size="large" secondary disabled icon="settings"
-                        >Large disabled secondary button with icon</rux-button
-                    >
-                </li>
-            </ul>
-        </div>
+<style>
+    .button-list {
+        list-style-type: none;
+        margin: 0 1rem 0 0;
+        padding: 0;
+        display: flex;
+        flex-flow: column;
+    }
+    .button-list li {
+        margin: 0 1rem 1rem 0;
+        display: flex;
+    }
+    .button-list li rux-button:not(:last-child) {
+        margin-right: 1rem;
+    }
+</style>
+<div
+    style="padding: 8vh 2vw; display: flex; flex-flow: row wrap; justify-content: space-evenly;"
+>
+    <ul class="button-list">
+        <li>
+            <rux-button size="small" icon-only icon="settings"
+                >Small icon-only button</rux-button
+            >
+            <rux-button size="small">Small button</rux-button>
+        </li>
+        <li>
+            <rux-button size="small" icon="settings"
+                >Small button with icon</rux-button
+            >
+        </li>
+        <li>
+            <rux-button size="small" icon-only disabled icon="settings"
+                >Small disabled icon-only button</rux-button
+            >
+            <rux-button size="small" disabled
+                >Small disabled button</rux-button
+            >
+        </li>
+        <li>
+            <rux-button size="small" disabled icon="settings"
+                >Small disabled button with icon</rux-button
+            >
+        </li>
+        <li>
+            <rux-button size="small" icon-only secondary icon="settings"
+                >Small secondary icon-only button</rux-button
+            >
+            <rux-button size="small" secondary
+                >Small secondary button</rux-button
+            >
+        </li>
+        <li>
+            <rux-button size="small" secondary icon="settings"
+                >Small secondary button with icon</rux-button
+            >
+        </li>
+        <li>
+            <rux-button
+                size="small"
+                icon-only
+                disabled
+                secondary
+                icon="settings"
+                >Small disabled secondary icon-only button</rux-button
+            >
+            <rux-button size="small" secondary disabled
+                >Small disabled secondary button</rux-button
+            >
+        </li>
+        <li>
+            <rux-button size="small" secondary disabled icon="settings"
+                >Small disabled secondary button with icon</rux-button
+            >
+        </li>
+    </ul>
+    <ul class="button-list">
+        <li>
+            <rux-button icon-only icon="settings"
+                >Medium icon-only button</rux-button
+            >
+            <rux-button>Medium button</rux-button>
+        </li>
+        <li>
+            <rux-button icon="settings"
+                >Medium button with icon</rux-button
+            >
+        </li>
+        <li>
+            <rux-button icon-only disabled icon="settings"
+                >Medium disabled icon-only button</rux-button
+            >
+            <rux-button disabled>Medium disabled button</rux-button>
+        </li>
+        <li>
+            <rux-button disabled icon="settings"
+                >Medium disabled button with icon</rux-button
+            >
+        </li>
+        <li>
+            <rux-button icon-only secondary icon="settings"
+                >Medium secondary icon-only button</rux-button
+            >
+            <rux-button secondary>Medium secondary button</rux-button>
+        </li>
+        <li>
+            <rux-button secondary icon="settings"
+                >Medium secondary button with icon</rux-button
+            >
+        </li>
+        <li>
+            <rux-button icon-only disabled secondary icon="settings"
+                >Medium disabled secondary icon-only button</rux-button
+            >
+            <rux-button secondary disabled
+                >Medium disabled secondary button</rux-button
+            >
+        </li>
+        <li>
+            <rux-button secondary disabled icon="settings"
+                >Medium disabled secondary button with icon</rux-button
+            >
+        </li>
+    </ul>
+    <ul class="button-list">
+        <li>
+            <rux-button size="large" icon-only icon="settings"
+                >Large icon-only button</rux-button
+            >
+            <rux-button size="large">Large button</rux-button>
+        </li>
+        <li>
+            <rux-button size="large" icon="settings"
+                >Large button with icon</rux-button
+            >
+        </li>
+        <li>
+            <rux-button size="large" icon-only disabled icon="settings"
+                >Large disabled icon-only button</rux-button
+            >
+            <rux-button size="large" disabled
+                >Large disabled button</rux-button
+            >
+        </li>
+        <li>
+            <rux-button size="large" disabled icon="settings"
+                >Large disabled button with icon</rux-button
+            >
+        </li>
+        <li>
+            <rux-button size="large" icon-only secondary icon="settings"
+                >Large secondary icon-only button</rux-button
+            >
+            <rux-button size="large" secondary
+                >Large secondary button</rux-button
+            >
+        </li>
+        <li>
+            <rux-button size="large" secondary icon="settings"
+                >Large secondary button with icon</rux-button
+            >
+        </li>
+        <li>
+            <rux-button
+                size="large"
+                icon-only
+                disabled
+                secondary
+                icon="settings"
+                >Large disabled secondary icon-only button</rux-button
+            >
+            <rux-button size="large" secondary disabled
+                >Large disabled secondary button</rux-button
+            >
+        </li>
+        <li>
+            <rux-button size="large" secondary disabled icon="settings"
+                >Large disabled secondary button with icon</rux-button
+            >
+        </li>
+    </ul>
+</div>
     `
 }
 

--- a/packages/web-components/src/stories/checkbox-group.stories.mdx
+++ b/packages/web-components/src/stories/checkbox-group.stories.mdx
@@ -22,7 +22,7 @@ export const Default = (args) => {
     return html`
         <rux-checkbox-group
             name="checkboxes"
-            .label="${args.label}"
+            label="${args.label}"
             .value="${args.value}"
             ?invalid="${args.invalid}"
             .helpText="${args.helpText}"
@@ -56,18 +56,18 @@ export const Default = (args) => {
 
 export const Invalid = (args) => {
     return html`
-        <rux-checkbox-group
-            name="checkboxes"
-            .label="${args.label}"
-            .value="${args.value}"
-            ?invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .errorText="${args.errorText}"
-        >
-            <rux-checkbox value="one" name="checkboxes">One</rux-checkbox>
-            <rux-checkbox value="two" name="checkboxes">Two</rux-checkbox>
-            <rux-checkbox value="three" name="checkboxes">Three</rux-checkbox>
-        </rux-checkbox-group>
+<rux-checkbox-group
+    name="checkboxes"
+    label="${args.label}"
+    .value="${args.value}"
+    ?invalid="${args.invalid}"
+    .helpText="${args.helpText}"
+    .errorText="${args.errorText}"
+>
+    <rux-checkbox value="one" name="checkboxes">One</rux-checkbox>
+    <rux-checkbox value="two" name="checkboxes">Two</rux-checkbox>
+    <rux-checkbox value="three" name="checkboxes">Three</rux-checkbox>
+</rux-checkbox-group>
     `
 }
 
@@ -88,18 +88,18 @@ export const Invalid = (args) => {
 
 export const WithHelpText = (args) => {
     return html`
-        <rux-checkbox-group
-            name="checkboxes"
-            .label="${args.label}"
-            .value="${args.value}"
-            ?invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .errorText="${args.errorText}"
-        >
-            <rux-checkbox value="one" name="checkboxes">One</rux-checkbox>
-            <rux-checkbox value="two" name="checkboxes">Two</rux-checkbox>
-            <rux-checkbox value="three" name="checkboxes">Three</rux-checkbox>
-        </rux-checkbox-group>
+<rux-checkbox-group
+    name="checkboxes"
+    label="${args.label}"
+    .value="${args.value}"
+    ?invalid="${args.invalid}"
+    help-text="${args.helpText}"
+    .errorText="${args.errorText}"
+>
+    <rux-checkbox value="one" name="checkboxes">One</rux-checkbox>
+    <rux-checkbox value="two" name="checkboxes">Two</rux-checkbox>
+    <rux-checkbox value="three" name="checkboxes">Three</rux-checkbox>
+</rux-checkbox-group>
     `
 }
 
@@ -120,18 +120,18 @@ export const WithHelpText = (args) => {
 
 export const WithErrorText = (args) => {
     return html`
-        <rux-checkbox-group
-            name="checkboxes"
-            .label="${args.label}"
-            .value="${args.value}"
-            ?invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .errorText="${args.errorText}"
-        >
-            <rux-checkbox value="one" name="checkboxes">One</rux-checkbox>
-            <rux-checkbox value="two" name="checkboxes">Two</rux-checkbox>
-            <rux-checkbox value="three" name="checkboxes">Three</rux-checkbox>
-        </rux-checkbox-group>
+<rux-checkbox-group
+    name="checkboxes"
+    label="${args.label}"
+    .value="${args.value}"
+    ?invalid="${args.invalid}"
+    .helpText="${args.helpText}"
+    error-text="${args.errorText}"
+>
+    <rux-checkbox value="one" name="checkboxes">One</rux-checkbox>
+    <rux-checkbox value="two" name="checkboxes">Two</rux-checkbox>
+    <rux-checkbox value="three" name="checkboxes">Three</rux-checkbox>
+</rux-checkbox-group>
     `
 }
 
@@ -167,20 +167,20 @@ rux-checkbox-group::part(label) {
 
 export const HorizontalLabel = (args) => {
     return html`
-        <style>
-            #left-example::part(form-field) {
-                display: flex;
-                flex-direction: row;
-            }
-            #left-example::part(label) {
-                margin-right: var(--spacing-input-label-left);
-            }
-        </style>
-        <rux-checkbox-group id="left-example" label="Label">
-            <rux-checkbox value="1">one</rux-checkbox>
-            <rux-checkbox value="2">two</rux-checkbox>
-            <rux-checkbox value="3">three</rux-checkbox>
-        </rux-checkbox-group>
+<style>
+    #left-example::part(form-field) {
+        display: flex;
+        flex-direction: row;
+    }
+    #left-example::part(label) {
+        margin-right: var(--spacing-input-label-left);
+    }
+</style>
+<rux-checkbox-group id="left-example" label="Label">
+    <rux-checkbox value="1">one</rux-checkbox>
+    <rux-checkbox value="2">two</rux-checkbox>
+    <rux-checkbox value="3">three</rux-checkbox>
+</rux-checkbox-group>
     `
 }
 

--- a/packages/web-components/src/stories/checkbox.stories.mdx
+++ b/packages/web-components/src/stories/checkbox.stories.mdx
@@ -31,16 +31,15 @@ For displaying invalid state, consider using a [Checkbox Group](?path=/docs/form
 
 export const Default = (args) => {
     return html`
-        <rux-checkbox
-            ?disabled="${args.disabled}"
-            ?checked="${args.checked}"
-            ?indeterminate="${args.indeterminate}"
-            .helpText="${args.helpText}"
-            name="${args.name}"
-            .value="${args.value}"
-        >
-            Checkbox Label
-        </rux-checkbox>
+<rux-checkbox
+    ?disabled="${args.disabled}"
+    ?checked="${args.checked}"
+    ?indeterminate="${args.indeterminate}"
+    .helpText="${args.helpText}"
+    name="${args.name}"
+    .value="${args.value}"
+    label="${args.label}"
+>Checkbox Label</rux-checkbox>
     `
 }
 
@@ -49,6 +48,7 @@ export const Default = (args) => {
         name="Default"
         args={{
             name: 'checkbox',
+            label: 'Checkbox Label'
         }}
     >
         {Default.bind()}
@@ -65,21 +65,22 @@ export const Default = (args) => {
 
 export const Checked = (args) => {
     return html`
-        <rux-checkbox
-            ?disabled="${args.disabled}"
-            ?checked="${args.checked}"
-            ?indeterminate="${args.indeterminate}"
-            .helpText="${args.helpText}"
-            name="${args.name}"
-            .value="${args.value}"
-        >
-            Checkbox Label
-        </rux-checkbox>
+<rux-checkbox
+    ?disabled="${args.disabled}"
+    ?checked="${args.checked}"
+    ?indeterminate="${args.indeterminate}"
+    .helpText="${args.helpText}"
+    name="${args.name}"
+    .value="${args.value}"
+    label="${args.label}"
+>
+    Checkbox Label
+</rux-checkbox>
     `
 }
 
 <Canvas>
-    <Story args={{ checked: true }} name="Checked">
+    <Story args={{ checked: true, label: 'Checkbox Label' }} name="Checked">
         {Checked.bind()}
     </Story>
 </Canvas>
@@ -88,21 +89,22 @@ export const Checked = (args) => {
 
 export const Disabled = (args) => {
     return html`
-        <rux-checkbox
-            ?disabled="${args.disabled}"
-            ?checked="${args.checked}"
-            ?indeterminate="${args.indeterminate}"
-            .helpText="${args.helpText}"
-            name="${args.name}"
-            .value="${args.value}"
-        >
-            Checkbox Label
-        </rux-checkbox>
+<rux-checkbox
+    ?disabled="${args.disabled}"
+    ?checked="${args.checked}"
+    ?indeterminate="${args.indeterminate}"
+    .helpText="${args.helpText}"
+    name="${args.name}"
+    .value="${args.value}"
+    label="${args.label}"
+>
+Checkbox Label
+</rux-checkbox>
     `
 }
 
 <Canvas>
-    <Story args={{ disabled: true }} name="Disabled">
+    <Story args={{ disabled: true, label: 'Checkbox Label' }} name="Disabled">
         {Disabled.bind()}
     </Story>
 </Canvas>
@@ -113,21 +115,22 @@ An Indeterminate state (a dash symbol rather than checked) may display when a ch
 
 export const Indeterminate = (args) => {
     return html`
-        <rux-checkbox
-            ?disabled="${args.disabled}"
-            ?checked="${args.checked}"
-            ?indeterminate="${args.indeterminate}"
-            .helpText="${args.helpText}"
-            name="${args.name}"
-            .value="${args.value}"
-        >
-            Checkbox Label
-        </rux-checkbox>
-    `
+<rux-checkbox
+    ?disabled="${args.disabled}"
+    ?checked="${args.checked}"
+    ?indeterminate="${args.indeterminate}"
+    .helpText="${args.helpText}"
+    name="${args.name}"
+    .value="${args.value}"
+    label="${args.label}"
+>
+    Checkbox Label
+</rux-checkbox>
+`
 }
 
 <Canvas>
-    <Story args={{ indeterminate: true, checked: true }} name="Indeterminate">
+    <Story args={{ indeterminate: true, checked: true, label: 'Checkbox Label' }} name="Indeterminate">
         {Indeterminate.bind()}
     </Story>
 </Canvas>
@@ -136,21 +139,22 @@ export const Indeterminate = (args) => {
 
 export const WithHelpText = (args) => {
     return html`
-        <rux-checkbox
-            ?disabled="${args.disabled}"
-            ?checked="${args.checked}"
-            ?indeterminate="${args.indeterminate}"
-            .helpText="${args.helpText}"
-            name="${args.name}"
-            .value="${args.value}"
-        >
-            Checkbox Label
-        </rux-checkbox>
+<rux-checkbox
+    ?disabled="${args.disabled}"
+    ?checked="${args.checked}"
+    ?indeterminate="${args.indeterminate}"
+    help-text="${args.helpText}"
+    name="${args.name}"
+    .value="${args.value}"
+    label="${args.label}"
+>
+    Checkbox Label
+</rux-checkbox>
     `
 }
 
 <Canvas>
-    <Story args={{ helpText: 'Help text' }} name="With Help Text">
+    <Story args={{ helpText: 'Help text', label: 'Checkbox Label' }} name="With Help Text">
         {WithHelpText.bind()}
     </Story>
 </Canvas>

--- a/packages/web-components/src/stories/classification-marking.stories.mdx
+++ b/packages/web-components/src/stories/classification-marking.stories.mdx
@@ -22,16 +22,15 @@ For the most up-to-date policies, see the [ISOO Training Aids](https://www.archi
 
 export const Default = (args) => {
     return html`
-        <div
-            style="display: flex; flex-flow: column; justify-content: center; margin-bottom:50px; position: relative;"
-        >
-            <rux-classification-marking
-                classification="${args.classification}"
-                .label="${args.label}"
-                ?tag="${args.tag}"
-            >
-            </rux-classification-marking>
-        </div>
+<div
+    style="display: flex; flex-flow: column; justify-content: center; margin-bottom:50px; position: relative;"
+>
+    <rux-classification-marking
+        classification="${args.classification}"
+        .label="${args.label}"
+        ?tag="${args.tag}"
+    ></rux-classification-marking>
+</div>
     `
 }
 

--- a/packages/web-components/src/stories/classification-marking.stories.mdx
+++ b/packages/web-components/src/stories/classification-marking.stories.mdx
@@ -53,16 +53,16 @@ Applying the `label` property attribute to the classification custom element add
 
 export const WithLabel = (args) => {
     return html`
-        <div
-            style="display: flex; flex-flow: column; justify-content: center; margin-bottom:50px; position: relative;"
-        >
-            <rux-classification-marking
-                classification="${args.classification}"
-                .label="${args.label}"
-                ?tag="${args.tag}"
-            >
-            </rux-classification-marking>
-        </div>
+<div
+    style="display: flex; flex-flow: column; justify-content: center; margin-bottom:50px; position: relative;"
+>
+    <rux-classification-marking
+        classification="${args.classification}"
+        label="${args.label}"
+        ?tag="${args.tag}"
+    >
+    </rux-classification-marking>
+</div>
     `
 }
 
@@ -84,91 +84,91 @@ When using the classification marking component as a wrapper with slotted childr
 
 export const WithFooterBanner = (args) => {
     return html`
-        <div
-            style="display: flex; flex-flow: column; justify-content: center; margin-bottom:50px; position: relative;"
-        >
-            <rux-classification-marking classification="${args.classification}">
-                <h1>Document Title</h1>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                    Phasellus vitae euismod lacus. Pellentesque sollicitudin
-                    quam tristique tristique eleifend. Nam nec nibh magna. Duis
-                    iaculis nisi nec quam lobortis, id feugiat risus maximus.
-                    Cras purus massa, vulputate id orci quis, semper iaculis
-                    risus. Nam turpis ante, molestie auctor semper et, auctor
-                    nec diam. Morbi vehicula enim ac enim ullamcorper
-                    scelerisque. Etiam lacinia metus quis ligula ullamcorper,
-                    sed suscipit orci sodales. venenatis. Donec a mi mattis,
-                    scelerisque nisl in, tincidunt ipsum. Donec venenatis dui
-                    sit amet neque auctor, vitae vulputate sem volutpat.
-                </p>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                    Phasellus vitae euismod lacus. Pellentesque sollicitudin
-                    quam tristique tristique eleifend. Nam nec nibh magna. Duis
-                    iaculis nisi nec quam lobortis, id feugiat risus maximus.
-                    Cras purus massa, vulputate id orci quis, semper iaculis
-                    risus. Nam turpis ante, molestie auctor semper et, auctor
-                    nec diam. Morbi vehicula enim ac enim ullamcorper
-                    scelerisque. Etiam lacinia metus quis ligula ullamcorper,
-                    sed suscipit orci sodales. venenatis. Donec a mi mattis,
-                    scelerisque nisl in, tincidunt ipsum. Donec venenatis dui
-                    sit amet neque auctor, vitae vulputate sem volutpat.
-                </p>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                    Phasellus vitae euismod lacus. Pellentesque sollicitudin
-                    quam tristique tristique eleifend. Nam nec nibh magna. Duis
-                    iaculis nisi nec quam lobortis, id feugiat risus maximus.
-                    Cras purus massa, vulputate id orci quis, semper iaculis
-                    risus. Nam turpis ante, molestie auctor semper et, auctor
-                    nec diam. Morbi vehicula enim ac enim ullamcorper
-                    scelerisque. Etiam lacinia metus quis ligula ullamcorper,
-                    sed suscipit orci sodales. venenatis. Donec a mi mattis,
-                    scelerisque nisl in, tincidunt ipsum. Donec venenatis dui
-                    sit amet neque auctor, vitae vulputate sem volutpat.
-                </p>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                    Phasellus vitae euismod lacus. Pellentesque sollicitudin
-                    quam tristique tristique eleifend. Nam nec nibh magna. Duis
-                    iaculis nisi nec quam lobortis, id feugiat risus maximus.
-                    Cras purus massa, vulputate id orci quis, semper iaculis
-                    risus. Nam turpis ante, molestie auctor semper et, auctor
-                    nec diam. Morbi vehicula enim ac enim ullamcorper
-                    scelerisque. Etiam lacinia metus quis ligula ullamcorper,
-                    sed suscipit orci sodales. venenatis. Donec a mi mattis,
-                    scelerisque nisl in, tincidunt ipsum. Donec venenatis dui
-                    sit amet neque auctor, vitae vulputate sem volutpat.
-                </p>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                    Phasellus vitae euismod lacus. Pellentesque sollicitudin
-                    quam tristique tristique eleifend. Nam nec nibh magna. Duis
-                    iaculis nisi nec quam lobortis, id feugiat risus maximus.
-                    Cras purus massa, vulputate id orci quis, semper iaculis
-                    risus. Nam turpis ante, molestie auctor semper et, auctor
-                    nec diam. Morbi vehicula enim ac enim ullamcorper
-                    scelerisque. Etiam lacinia metus quis ligula ullamcorper,
-                    sed suscipit orci sodales. venenatis. Donec a mi mattis,
-                    scelerisque nisl in, tincidunt ipsum. Donec venenatis dui
-                    sit amet neque auctor, vitae vulputate sem volutpat.
-                </p>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                    Phasellus vitae euismod lacus. Pellentesque sollicitudin
-                    quam tristique tristique eleifend. Nam nec nibh magna. Duis
-                    iaculis nisi nec quam lobortis, id feugiat risus maximus.
-                    Cras purus massa, vulputate id orci quis, semper iaculis
-                    risus. Nam turpis ante, molestie auctor semper et, auctor
-                    nec diam. Morbi vehicula enim ac enim ullamcorper
-                    scelerisque. Etiam lacinia metus quis ligula ullamcorper,
-                    sed suscipit orci sodales. venenatis. Donec a mi mattis,
-                    scelerisque nisl in, tincidunt ipsum. Donec venenatis dui
-                    sit amet neque auctor, vitae vulputate sem volutpat.
-                </p>
-            </rux-classification-marking>
-        </div>
+<div
+    style="display: flex; flex-flow: column; justify-content: center; margin-bottom:50px; position: relative;"
+>
+    <rux-classification-marking classification="${args.classification}">
+        <h1>Document Title</h1>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            Phasellus vitae euismod lacus. Pellentesque sollicitudin
+            quam tristique tristique eleifend. Nam nec nibh magna. Duis
+            iaculis nisi nec quam lobortis, id feugiat risus maximus.
+            Cras purus massa, vulputate id orci quis, semper iaculis
+            risus. Nam turpis ante, molestie auctor semper et, auctor
+            nec diam. Morbi vehicula enim ac enim ullamcorper
+            scelerisque. Etiam lacinia metus quis ligula ullamcorper,
+            sed suscipit orci sodales. venenatis. Donec a mi mattis,
+            scelerisque nisl in, tincidunt ipsum. Donec venenatis dui
+            sit amet neque auctor, vitae vulputate sem volutpat.
+        </p>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            Phasellus vitae euismod lacus. Pellentesque sollicitudin
+            quam tristique tristique eleifend. Nam nec nibh magna. Duis
+            iaculis nisi nec quam lobortis, id feugiat risus maximus.
+            Cras purus massa, vulputate id orci quis, semper iaculis
+            risus. Nam turpis ante, molestie auctor semper et, auctor
+            nec diam. Morbi vehicula enim ac enim ullamcorper
+            scelerisque. Etiam lacinia metus quis ligula ullamcorper,
+            sed suscipit orci sodales. venenatis. Donec a mi mattis,
+            scelerisque nisl in, tincidunt ipsum. Donec venenatis dui
+            sit amet neque auctor, vitae vulputate sem volutpat.
+        </p>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            Phasellus vitae euismod lacus. Pellentesque sollicitudin
+            quam tristique tristique eleifend. Nam nec nibh magna. Duis
+            iaculis nisi nec quam lobortis, id feugiat risus maximus.
+            Cras purus massa, vulputate id orci quis, semper iaculis
+            risus. Nam turpis ante, molestie auctor semper et, auctor
+            nec diam. Morbi vehicula enim ac enim ullamcorper
+            scelerisque. Etiam lacinia metus quis ligula ullamcorper,
+            sed suscipit orci sodales. venenatis. Donec a mi mattis,
+            scelerisque nisl in, tincidunt ipsum. Donec venenatis dui
+            sit amet neque auctor, vitae vulputate sem volutpat.
+        </p>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            Phasellus vitae euismod lacus. Pellentesque sollicitudin
+            quam tristique tristique eleifend. Nam nec nibh magna. Duis
+            iaculis nisi nec quam lobortis, id feugiat risus maximus.
+            Cras purus massa, vulputate id orci quis, semper iaculis
+            risus. Nam turpis ante, molestie auctor semper et, auctor
+            nec diam. Morbi vehicula enim ac enim ullamcorper
+            scelerisque. Etiam lacinia metus quis ligula ullamcorper,
+            sed suscipit orci sodales. venenatis. Donec a mi mattis,
+            scelerisque nisl in, tincidunt ipsum. Donec venenatis dui
+            sit amet neque auctor, vitae vulputate sem volutpat.
+        </p>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            Phasellus vitae euismod lacus. Pellentesque sollicitudin
+            quam tristique tristique eleifend. Nam nec nibh magna. Duis
+            iaculis nisi nec quam lobortis, id feugiat risus maximus.
+            Cras purus massa, vulputate id orci quis, semper iaculis
+            risus. Nam turpis ante, molestie auctor semper et, auctor
+            nec diam. Morbi vehicula enim ac enim ullamcorper
+            scelerisque. Etiam lacinia metus quis ligula ullamcorper,
+            sed suscipit orci sodales. venenatis. Donec a mi mattis,
+            scelerisque nisl in, tincidunt ipsum. Donec venenatis dui
+            sit amet neque auctor, vitae vulputate sem volutpat.
+        </p>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            Phasellus vitae euismod lacus. Pellentesque sollicitudin
+            quam tristique tristique eleifend. Nam nec nibh magna. Duis
+            iaculis nisi nec quam lobortis, id feugiat risus maximus.
+            Cras purus massa, vulputate id orci quis, semper iaculis
+            risus. Nam turpis ante, molestie auctor semper et, auctor
+            nec diam. Morbi vehicula enim ac enim ullamcorper
+            scelerisque. Etiam lacinia metus quis ligula ullamcorper,
+            sed suscipit orci sodales. venenatis. Donec a mi mattis,
+            scelerisque nisl in, tincidunt ipsum. Donec venenatis dui
+            sit amet neque auctor, vitae vulputate sem volutpat.
+        </p>
+    </rux-classification-marking>
+</div>
     `
 }
 
@@ -187,59 +187,59 @@ export const WithFooterBanner = (args) => {
 
 export const AllBannerVariants = (args) => {
     return html`
-        <div
-            style="display: flex; flex-flow: column; justify-content: center; margin:20px;"
-        >
-            <div
-                style="position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
-            >
-                <rux-classification-marking
-                    classification="top-secret-sci"
-                ></rux-classification-marking>
-            </div>
-            <div
-                style="position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
-            >
-                <rux-classification-marking
-                    classification="top-secret"
-                ></rux-classification-marking>
-            </div>
-            <div
-                style="position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
-            >
-                <rux-classification-marking
-                    classification="secret"
-                ></rux-classification-marking>
-            </div>
-            <div
-                style="position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
-            >
-                <rux-classification-marking
-                    classification="confidential"
-                ></rux-classification-marking>
-            </div>
-            <div
-                style="position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
-            >
-                <rux-classification-marking
-                    classification="controlled"
-                ></rux-classification-marking>
-            </div>
-            <div
-                style="position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
-            >
-                <rux-classification-marking
-                    classification="cui"
-                ></rux-classification-marking>
-            </div>
-            <div
-                style="position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
-            >
-                <rux-classification-marking
-                    classification="unclassified"
-                ></rux-classification-marking>
-            </div>
-        </div>
+<div
+    style="display: flex; flex-flow: column; justify-content: center; margin:20px;"
+>
+    <div
+        style="position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <rux-classification-marking
+            classification="top-secret-sci"
+        ></rux-classification-marking>
+    </div>
+    <div
+        style="position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <rux-classification-marking
+            classification="top-secret"
+        ></rux-classification-marking>
+    </div>
+    <div
+        style="position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <rux-classification-marking
+            classification="secret"
+        ></rux-classification-marking>
+    </div>
+    <div
+        style="position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <rux-classification-marking
+            classification="confidential"
+        ></rux-classification-marking>
+    </div>
+    <div
+        style="position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <rux-classification-marking
+            classification="controlled"
+        ></rux-classification-marking>
+    </div>
+    <div
+        style="position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <rux-classification-marking
+            classification="cui"
+        ></rux-classification-marking>
+    </div>
+    <div
+        style="position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <rux-classification-marking
+            classification="unclassified"
+        ></rux-classification-marking>
+    </div>
+</div>
     `
 }
 
@@ -251,101 +251,101 @@ export const AllBannerVariants = (args) => {
 
 export const AllTagVariants = () => {
     return html`
-        <div
-            style="display: flex; flex-flow: column; justify-content: flex-start; width: 400px; margin:60px auto;"
+<div
+    style="display: flex; flex-flow: column; justify-content: flex-start; width: 400px; margin:60px auto;"
+>
+    <div
+        style="display: flex; align-items:baseline; position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <p
+            style="display:flex; width:225px; font-size:14px; font-style:italic; color:#d5d7d9; margin: 0 0 1rem 0;"
         >
-            <div
-                style="display: flex; align-items:baseline; position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
-            >
-                <p
-                    style="display:flex; width:225px; font-size:14px; font-style:italic; color:#d5d7d9; margin: 0 0 1rem 0;"
-                >
-                    Top Secret//SCI
-                </p>
-                <rux-classification-marking
-                    tag
-                    classification="top-secret-sci"
-                ></rux-classification-marking>
-            </div>
-            <div
-                style="display: flex; align-items:baseline; position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
-            >
-                <p
-                    style="display:flex; width:225px; font-size:14px; font-style:italic; color:#d5d7d9; margin: 0 0 1rem 0;"
-                >
-                    Top Secret
-                </p>
-                <rux-classification-marking
-                    tag
-                    classification="top-secret"
-                ></rux-classification-marking>
-            </div>
-            <div
-                style="display: flex; align-items:baseline;  position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
-            >
-                <p
-                    style="display:flex; width:225px; font-size:14px; font-style:italic; color:#d5d7d9; margin: 0 0 1rem 0;"
-                >
-                    Secret
-                </p>
-                <rux-classification-marking
-                    tag
-                    classification="secret"
-                ></rux-classification-marking>
-            </div>
-            <div
-                style="display: flex; align-items:baseline; position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
-            >
-                <p
-                    style="display:flex; width:225px; font-size:14px; font-style:italic; color:#d5d7d9; margin: 0 0 1rem 0;"
-                >
-                    Confidential
-                </p>
-                <rux-classification-marking
-                    tag
-                    classification="confidential"
-                ></rux-classification-marking>
-            </div>
-            <div
-                style="display: flex; align-items:baseline; position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
-            >
-                <p
-                    style="display:flex; width:225px; font-size:14px; font-style:italic; color:#d5d7d9; margin: 0 0 1rem 0;"
-                >
-                    Controlled Unclassified
-                </p>
-                <rux-classification-marking
-                    tag
-                    classification="controlled"
-                ></rux-classification-marking>
-            </div>
-            <div
-                style="display: flex; align-items:baseline; position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
-            >
-                <p
-                    style="display:flex; width:225px; font-size:14px; font-style:italic; color:#d5d7d9; margin: 0 0 1rem 0;"
-                >
-                    CUI Unclassified
-                </p>
-                <rux-classification-marking
-                    tag
-                    classification="cui"
-                ></rux-classification-marking>
-            </div>
-            <div
-                style="display: flex; align-items:baseline; position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
-            >
-                <p
-                    style="display: flex; width:225px; font-size:13px; font-style:italic; color:#d5d7d9; margin: 0 0 1rem 0;"
-                >
-                    Uncontrolled Unclassified
-                </p>
-                <rux-classification-marking
-                    tag
-                    classification="unclassified"
-                ></rux-classification-marking>
-            </div>
-        </div>
+            Top Secret//SCI
+        </p>
+        <rux-classification-marking
+            tag
+            classification="top-secret-sci"
+        ></rux-classification-marking>
+    </div>
+    <div
+        style="display: flex; align-items:baseline; position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <p
+            style="display:flex; width:225px; font-size:14px; font-style:italic; color:#d5d7d9; margin: 0 0 1rem 0;"
+        >
+            Top Secret
+        </p>
+        <rux-classification-marking
+            tag
+            classification="top-secret"
+        ></rux-classification-marking>
+    </div>
+    <div
+        style="display: flex; align-items:baseline;  position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <p
+            style="display:flex; width:225px; font-size:14px; font-style:italic; color:#d5d7d9; margin: 0 0 1rem 0;"
+        >
+            Secret
+        </p>
+        <rux-classification-marking
+            tag
+            classification="secret"
+        ></rux-classification-marking>
+    </div>
+    <div
+        style="display: flex; align-items:baseline; position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <p
+            style="display:flex; width:225px; font-size:14px; font-style:italic; color:#d5d7d9; margin: 0 0 1rem 0;"
+        >
+            Confidential
+        </p>
+        <rux-classification-marking
+            tag
+            classification="confidential"
+        ></rux-classification-marking>
+    </div>
+    <div
+        style="display: flex; align-items:baseline; position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <p
+            style="display:flex; width:225px; font-size:14px; font-style:italic; color:#d5d7d9; margin: 0 0 1rem 0;"
+        >
+            Controlled Unclassified
+        </p>
+        <rux-classification-marking
+            tag
+            classification="controlled"
+        ></rux-classification-marking>
+    </div>
+    <div
+        style="display: flex; align-items:baseline; position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <p
+            style="display:flex; width:225px; font-size:14px; font-style:italic; color:#d5d7d9; margin: 0 0 1rem 0;"
+        >
+            CUI Unclassified
+        </p>
+        <rux-classification-marking
+            tag
+            classification="cui"
+        ></rux-classification-marking>
+    </div>
+    <div
+        style="display: flex; align-items:baseline; position: relative; height: 40px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <p
+            style="display: flex; width:225px; font-size:13px; font-style:italic; color:#d5d7d9; margin: 0 0 1rem 0;"
+        >
+            Uncontrolled Unclassified
+        </p>
+        <rux-classification-marking
+            tag
+            classification="unclassified"
+        ></rux-classification-marking>
+    </div>
+</div>
     `
 }
 

--- a/packages/web-components/src/stories/clock.stories.mdx
+++ b/packages/web-components/src/stories/clock.stories.mdx
@@ -18,25 +18,22 @@ Clock shows the current date and time, and optional AOS and LOS timers. It will 
 
 export const Default = (args) => {
     return html`
-        <div style="padding: 10%; display: flex; justify-content: center;">
-            <rux-clock
-                .aos="${args.aos}"
-                .los="${args.los}"
-                .timezone="${args.timezone}"
-                ?hide-timezone="${args.hideTimezone}"
-                ?hide-date="${args.hideDate}"
-                ?hide-labels="${args.hideLabels}"
-                ?small="${args.small}"
-            ></rux-clock>
-        </div>
+<div style="padding: 10%; display: flex; justify-content: center;">
+    <rux-clock
+        .aos="${args.aos}"
+        .los="${args.los}"
+        .timezone="${args.timezone}"
+        ?hide-timezone="${args.hideTimezone}"
+        ?hide-date="${args.hideDate}"
+        ?hide-labels="${args.hideLabels}"
+        ?small="${args.small}"
+    ></rux-clock>
+</div>
     `
 }
 
 <Canvas>
     <Story
-        parameters={{
-            docs: { source: { code: '<rux-clock></rux-clock>' } },
-        }}
         name="Default"
     >
         {Default.bind()}
@@ -56,17 +53,17 @@ export const Default = (args) => {
 
 export const ClockWithAosLos = (args) => {
     return html`
-        <div style="padding: 10%; display: flex; justify-content: center;">
-            <rux-clock
-                .timezone="${args.timezone}"
-                .aos="${args.aos}"
-                .los="${args.los}"
-                ?hide-timezone="${args.hideTimezone}"
-                ?hide-date="${args.hideDate}"
-                ?hide-labels="${args.hideLabels}"
-                ?small="${args.small}"
-            ></rux-clock>
-        </div>
+<div style="padding: 10%; display: flex; justify-content: center;">
+    <rux-clock
+        .timezone="${args.timezone}"
+        aos="${args.aos}"
+        los="${args.los}"
+        ?hide-timezone="${args.hideTimezone}"
+        ?hide-date="${args.hideDate}"
+        ?hide-labels="${args.hideLabels}"
+        ?small="${args.small}"
+    ></rux-clock>
+</div>
     `
 }
 
@@ -86,17 +83,17 @@ export const ClockWithAosLos = (args) => {
 
 export const Small = (args) => {
     return html`
-        <div style="padding: 10%; display: flex; justify-content: center;">
-            <rux-clock
-                .timezone="${args.timezone}"
-                .aos="${args.aos}"
-                .los="${args.los}"
-                ?hide-timezone="${args.hideTimezone}"
-                ?hide-date="${args.hideDate}"
-                ?hide-labels="${args.hideLabels}"
-                ?small="${args.small}"
-            ></rux-clock>
-        </div>
+<div style="padding: 10%; display: flex; justify-content: center;">
+    <rux-clock
+        .timezone="${args.timezone}"
+        .aos="${args.aos}"
+        .los="${args.los}"
+        ?hide-timezone="${args.hideTimezone}"
+        ?hide-date="${args.hideDate}"
+        ?hide-labels="${args.hideLabels}"
+        ?small="${args.small}"
+    ></rux-clock>
+</div>
     `
 }
 

--- a/packages/web-components/src/stories/datetime.stories.mdx
+++ b/packages/web-components/src/stories/datetime.stories.mdx
@@ -14,23 +14,18 @@ Datetime is a utility component that provides a convenient wrapper around the [I
 
 export const Default = (args) => {
     return html`
-        <div style="padding: 10%; display: flex; justify-content: center;">
-            <rux-datetime
-                date=${args.date}
-                .day=${args.day}
-                .era=${args.era}
-                .hour=${args.hour}
-                .hour12=${args.hour12}
-                .locale=${args.locale}
-                .minute=${args.minute}
-                .month=${args.month}
-                .second=${args.second}
-                .timeZone=${args.timeZone}
-                .timeZoneName=${args.timeZoneName}
-                .weekday=${args.weekday}
-                .year=${args.year}
-            ></rux-datetime>
-        </div>
+<div style="padding: 10%; display: flex; justify-content: center;">
+    <rux-datetime
+        date=${args.date}
+        day=${args.day}
+        hour=${args.hour}
+        minute=${args.minute}
+        month=${args.month}
+        second=${args.second}
+        time-zone=${args.timeZone}
+        year=${args.year}
+    ></rux-datetime>
+</div>
     `
 }
 

--- a/packages/web-components/src/stories/global-status-bar.stories.mdx
+++ b/packages/web-components/src/stories/global-status-bar.stories.mdx
@@ -25,6 +25,9 @@ export const Default = (args) => {
         app-name="${args.appName}"
         app-version="${args.appVersion}"
         menu-icon="${args.menuIcon}"
+        .username="${args.username}"
+        .app-state-color="${args.appStateColor}"
+        .app-state="${args.appState}"
     >
     </rux-global-status-bar>
 </div>

--- a/packages/web-components/src/stories/global-status-bar.stories.mdx
+++ b/packages/web-components/src/stories/global-status-bar.stories.mdx
@@ -20,14 +20,11 @@ export const Default = (args) => {
     return html`
         <div style="display: flex; justify-content: center;">
             <rux-global-status-bar
-                .includeIcon="${args.includeIcon}"
-                .appState="${args.appState}"
-                .appStateColor="${args.appStateColor}"
-                .username="${args.username}"
-                .appDomain="${args.appDomain}"
-                .appName="${args.appName}"
-                .appVersion="${args.appVersion}"
-                .menuIcon="${args.menuIcon}"
+                include-icon="${args.includeIcon}"
+                app-domain="${args.appDomain}"
+                app-name="${args.appName}"
+                app-version="${args.appVersion}"
+                menu-icon="${args.menuIcon}"
             >
             </rux-global-status-bar>
         </div>
@@ -61,14 +58,14 @@ export const GlobalStatusBarWithAppState = (args) => {
     return html`
         <div style="display: flex; justify-content: center;">
             <rux-global-status-bar
-                .includeIcon="${args.includeIcon}"
-                .appState="${args.appState}"
-                .appStateColor="${args.appStateColor}"
-                .username="${args.username}"
-                .appDomain="${args.appDomain}"
-                .appName="${args.appName}"
-                .appVersion="${args.appVersion}"
-                .menuIcon="${args.menuIcon}"
+                include-icon="${args.includeIcon}"
+                app-state="${args.appState}"
+                app-state-color="${args.appStateColor}"
+                username="${args.username}"
+                app-domain="${args.appDomain}"
+                app-name="${args.appName}"
+                app-version="${args.appVersion}"
+                menu-icon="${args.menuIcon}"
             >
             </rux-global-status-bar>
         </div>
@@ -99,14 +96,14 @@ export const GlobalStatusBarWithSlotContent = (args) => {
     return html`
         <div style="display: flex; justify-content: center;">
             <rux-global-status-bar
-                .includeIcon="${args.includeIcon}"
-                .appState="${args.appState}"
-                .appStateColor="${args.appStateColor}"
-                .username="${args.username}"
-                .appDomain="${args.appDomain}"
-                .appName="${args.appName}"
-                .appVersion="${args.appVersion}"
-                .menuIcon="${args.menuIcon}"
+                include-icon="${args.includeIcon}"
+                app-state="${args.appState}"
+                app-state-color="${args.appStateColor}"
+                username="${args.username}"
+                app-domain="${args.appDomain}"
+                app-name="${args.appName}"
+                app-version="${args.appVersion}"
+                menu-icon="${args.menuIcon}"
             >
                 <rux-clock></rux-clock>
                 <rux-button slot="right-side">Emergency shut off</rux-button>
@@ -138,14 +135,14 @@ export const GlobalStatusBarWithSlotContent = (args) => {
 export const GlobalStatusBarWithTabs = (args) => {
     return html`
         <rux-global-status-bar
-            .includeIcon="${args.includeIcon}"
-            .appState="${args.appState}"
-            .appStateColor="${args.appStateColor}"
-            .username="${args.username}"
-            .appDomain="${args.appDomain}"
-            .appName="${args.appName}"
-            .appVersion="${args.appVersion}"
-            .menuIcon="${args.menuIcon}"
+            include-icon="${args.includeIcon}"
+            app-state="${args.appState}"
+            app-state-color="${args.appStateColor}"
+            username="${args.username}"
+            app-domain="${args.appDomain}"
+            app-name="${args.appName}"
+            app-version="${args.appVersion}"
+            menu-icon="${args.menuIcon}"
         >
             <rux-tabs id="tab-set-id-1">
                 <rux-tab id="tab-id-1">Tab 1</rux-tab>

--- a/packages/web-components/src/stories/global-status-bar.stories.mdx
+++ b/packages/web-components/src/stories/global-status-bar.stories.mdx
@@ -18,17 +18,17 @@ The Global Status Bar is a full-width view across the top of an application — 
 
 export const Default = (args) => {
     return html`
-        <div style="display: flex; justify-content: center;">
-            <rux-global-status-bar
-                include-icon="${args.includeIcon}"
-                app-domain="${args.appDomain}"
-                app-name="${args.appName}"
-                app-version="${args.appVersion}"
-                menu-icon="${args.menuIcon}"
-            >
-            </rux-global-status-bar>
-        </div>
-    `
+<div style="display: flex; justify-content: center;">
+    <rux-global-status-bar
+        include-icon="${args.includeIcon}"
+        app-domain="${args.appDomain}"
+        app-name="${args.appName}"
+        app-version="${args.appVersion}"
+        menu-icon="${args.menuIcon}"
+    >
+    </rux-global-status-bar>
+</div>
+`
 }
 
 <Canvas>
@@ -56,20 +56,20 @@ export const Default = (args) => {
 
 export const GlobalStatusBarWithAppState = (args) => {
     return html`
-        <div style="display: flex; justify-content: center;">
-            <rux-global-status-bar
-                include-icon="${args.includeIcon}"
-                app-state="${args.appState}"
-                app-state-color="${args.appStateColor}"
-                username="${args.username}"
-                app-domain="${args.appDomain}"
-                app-name="${args.appName}"
-                app-version="${args.appVersion}"
-                menu-icon="${args.menuIcon}"
-            >
-            </rux-global-status-bar>
-        </div>
-    `
+<div style="display: flex; justify-content: center;">
+    <rux-global-status-bar
+        include-icon="${args.includeIcon}"
+        app-state="${args.appState}"
+        app-state-color="${args.appStateColor}"
+        username="${args.username}"
+        app-domain="${args.appDomain}"
+        app-name="${args.appName}"
+        app-version="${args.appVersion}"
+        menu-icon="${args.menuIcon}"
+    >
+    </rux-global-status-bar>
+</div>
+`
 }
 
 <Canvas>
@@ -94,22 +94,22 @@ export const GlobalStatusBarWithAppState = (args) => {
 
 export const GlobalStatusBarWithSlotContent = (args) => {
     return html`
-        <div style="display: flex; justify-content: center;">
-            <rux-global-status-bar
-                include-icon="${args.includeIcon}"
-                app-state="${args.appState}"
-                app-state-color="${args.appStateColor}"
-                username="${args.username}"
-                app-domain="${args.appDomain}"
-                app-name="${args.appName}"
-                app-version="${args.appVersion}"
-                menu-icon="${args.menuIcon}"
-            >
-                <rux-clock></rux-clock>
-                <rux-button slot="right-side">Emergency shut off</rux-button>
-            </rux-global-status-bar>
-        </div>
-    `
+<div style="display: flex; justify-content: center;">
+    <rux-global-status-bar
+        include-icon="${args.includeIcon}"
+        app-state="${args.appState}"
+        app-state-color="${args.appStateColor}"
+        username="${args.username}"
+        app-domain="${args.appDomain}"
+        app-name="${args.appName}"
+        app-version="${args.appVersion}"
+        menu-icon="${args.menuIcon}"
+    >
+        <rux-clock></rux-clock>
+        <rux-button slot="right-side">Emergency shut off</rux-button>
+    </rux-global-status-bar>
+</div>
+`
 }
 
 <Canvas>

--- a/packages/web-components/src/stories/global-status-bar.stories.mdx
+++ b/packages/web-components/src/stories/global-status-bar.stories.mdx
@@ -134,46 +134,46 @@ export const GlobalStatusBarWithSlotContent = (args) => {
 
 export const GlobalStatusBarWithTabs = (args) => {
     return html`
-        <rux-global-status-bar
-            include-icon="${args.includeIcon}"
-            app-state="${args.appState}"
-            app-state-color="${args.appStateColor}"
-            username="${args.username}"
-            app-domain="${args.appDomain}"
-            app-name="${args.appName}"
-            app-version="${args.appVersion}"
-            menu-icon="${args.menuIcon}"
+<rux-global-status-bar
+    include-icon="${args.includeIcon}"
+    app-state="${args.appState}"
+    app-state-color="${args.appStateColor}"
+    username="${args.username}"
+    app-domain="${args.appDomain}"
+    app-name="${args.appName}"
+    app-version="${args.appVersion}"
+    menu-icon="${args.menuIcon}"
+>
+    <rux-tabs id="tab-set-id-1">
+        <rux-tab id="tab-id-1">Tab 1</rux-tab>
+        <rux-tab id="tab-id-2">Tab 2</rux-tab>
+        <rux-tab id="tab-id-3">Tab 3</rux-tab>
+    </rux-tabs>
+    <rux-button slot="right-side">Emergency shut off</rux-button>
+</rux-global-status-bar>
+<rux-tab-panels aria-labelledby="tab-set-id-1">
+    <rux-tab-panel aria-labelledby="tab-id-1">
+        <div
+            style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; font-family: monospace;"
         >
-            <rux-tabs id="tab-set-id-1">
-                <rux-tab id="tab-id-1">Tab 1</rux-tab>
-                <rux-tab id="tab-id-2">Tab 2</rux-tab>
-                <rux-tab id="tab-id-3">Tab 3</rux-tab>
-            </rux-tabs>
-            <rux-button slot="right-side">Emergency shut off</rux-button>
-        </rux-global-status-bar>
-        <rux-tab-panels aria-labelledby="tab-set-id-1">
-            <rux-tab-panel aria-labelledby="tab-id-1">
-                <div
-                    style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; font-family: monospace;"
-                >
-                    <pre><<span>!-- Tab 1 HTML content --</span>></pre>
-                </div>
-            </rux-tab-panel>
-            <rux-tab-panel aria-labelledby="tab-id-2">
-                <div
-                    style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; font-family: monospace;"
-                >
-                    <pre><<span>!-- Tab 2 HTML content --</span>></pre>
-                </div>
-            </rux-tab-panel>
-            <rux-tab-panel aria-labelledby="tab-id-3">
-                <div
-                    style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; font-family: monospace;"
-                >
-                    <pre><<span>!-- Tab 3 HTML content --</span>></pre>
-                </div>
-            </rux-tab-panel>
-        </rux-tab-panels>
+            <pre><<span>!-- Tab 1 HTML content --</span>></pre>
+        </div>
+    </rux-tab-panel>
+    <rux-tab-panel aria-labelledby="tab-id-2">
+        <div
+            style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; font-family: monospace;"
+        >
+            <pre><<span>!-- Tab 2 HTML content --</span>></pre>
+        </div>
+    </rux-tab-panel>
+    <rux-tab-panel aria-labelledby="tab-id-3">
+        <div
+            style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; font-family: monospace;"
+        >
+            <pre><<span>!-- Tab 3 HTML content --</span>></pre>
+        </div>
+    </rux-tab-panel>
+</rux-tab-panels>
     `
 }
 

--- a/packages/web-components/src/stories/icon-and-symbols.stories.mdx
+++ b/packages/web-components/src/stories/icon-and-symbols.stories.mdx
@@ -96,87 +96,87 @@ You can also manually set the `width` and `height` using CSS.
 export const AllIcons = (args) => {
     const displaySection = (section) => {
         return html`
-            <div class="icon__section">
-                <div class="icon-group__header">
-                    ${section}
-                    <span class="icon-style">Solid</span>
-                </div>
-                ${Object.keys(ruxIconsJson[section]).map((category) => {
-                    return html`
-                        <div>
-                            <div class="icon-list">
-                                ${Object.values(
-                                    ruxIconsJson[section][category]
-                                ).map((icon) => {
-                                    const idx = icon.lastIndexOf('/')
-                                    const name = icon
-                                        .substring(idx + 1)
-                                        .replace(/\//g, '-')
-                                        .replace(/ /g, '-')
-                                        .replace(/.svg/g, '')
-                                        .toLowerCase()
-                                    return html`
-                                        <div class="icon">
-                                            <rux-icon
-                                                size="normal"
-                                                icon="${name}"
-                                            ></rux-icon>
-                                            <div class="icon-label">
-                                                ${name}
-                                            </div>
-                                        </div>
-                                    `
-                                })}
+<div class="icon__section">
+    <div class="icon-group__header">
+        ${section}
+        <span class="icon-style">Solid</span>
+    </div>
+    ${Object.keys(ruxIconsJson[section]).map((category) => {
+        return html`
+            <div>
+                <div class="icon-list">
+                    ${Object.values(
+                        ruxIconsJson[section][category]
+                    ).map((icon) => {
+                        const idx = icon.lastIndexOf('/')
+                        const name = icon
+                            .substring(idx + 1)
+                            .replace(/\//g, '-')
+                            .replace(/ /g, '-')
+                            .replace(/.svg/g, '')
+                            .toLowerCase()
+                        return html`
+                            <div class="icon">
+                                <rux-icon
+                                    size="normal"
+                                    icon="${name}"
+                                ></rux-icon>
+                                <div class="icon-label">
+                                    ${name}
+                                </div>
                             </div>
-                            <div></div>
-                        </div>
-                    `
-                })}
+                        `
+                    })}
+                </div>
+                <div></div>
             </div>
+        `
+    })}
+</div>
         `
     }
     return html`
-        <style>
-            .icon {
-                display: flex;
-                flex-direction: column;
-                align-items: center;
-            }
-            .icon-label {
-                margin-top: 1rem;
-                font-size: 0.75rem;
-            }
-            .icon-style {
-                font-size: 1.5rem;
-                margin-left: auto;
-            }
-            .icon-group__header {
-                display: flex;
-                align-items: center;
-                font-size: 3rem;
-                font-weight: 400;
-                text-align: left;
-                text-transform: capitalize;
-                margin-bottom: 1rem;
-            }
-            .icon-list {
-                display: grid;
-                grid-template-columns: repeat(6, minmax(0, 1fr));
-                grid-auto-rows: minmax(70px, auto);
-                grid-gap: 1rem;
-                padding-bottom: 60px;
-            }
-            .icon__wrapper {
-                padding: 1rem;
-            }
-        </style>
-        <div class="icon__wrapper">
-            ${displaySection('Astro')} ${Object.keys(
-                ruxIconsJson
-            ).map((section) =>
-                section !== 'Astro' ? displaySection(section) : null
-            )}
-        </div>
+<style>
+    .icon {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+    .icon-label {
+        margin-top: 1rem;
+        font-size: 0.75rem;
+    }
+    .icon-style {
+        font-size: 1.5rem;
+        margin-left: auto;
+    }
+    .icon-group__header {
+        display: flex;
+        align-items: center;
+        font-size: 3rem;
+        font-weight: 400;
+        text-align: left;
+        text-transform: capitalize;
+        margin-bottom: 1rem;
+    }
+    .icon-list {
+        display: grid;
+        grid-template-columns: repeat(6, minmax(0, 1fr));
+        grid-auto-rows: minmax(70px, auto);
+        grid-gap: 1rem;
+        padding-bottom: 60px;
+    }
+    .icon__wrapper {
+        padding: 1rem;
+    }
+</style>
+<div class="icon__wrapper">
+    ${displaySection('Astro')} ${Object.keys(
+        ruxIconsJson
+    ).map((section) =>
+        section !== 'Astro' ? displaySection(section) : null
+    )}
+</div>
     `
 }
 

--- a/packages/web-components/src/stories/input.stories.mdx
+++ b/packages/web-components/src/stories/input.stories.mdx
@@ -27,24 +27,24 @@ Input allow users to enter freeform text. Variations on this field often provide
 
 export const Default = (args) => {
     return html`
-        <rux-input
-            .label="${args.label}"
-            .disabled="${args.disabled}"
-            .errorText="${args.errorText}"
-            .invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .min="${args.min}"
-            .max="${args.max}"
-            .name="${args.name}"
-            .placeholder="${args.placeholder}"
-            ?required="${args.required}"
-            .value="${args.value}"
-            .step="${args.step}"
-            .type=${args.type}
-            .readonly="${args.readonly}"
-            .autocomplete="${args.autocomplete}"
-            .spellcheck="${args.spellcheck}"
-        ></rux-input>
+<rux-input
+    label="${args.label}"
+    .disabled="${args.disabled}"
+    .errorText="${args.errorText}"
+    ?invalid="${args.invalid}"
+    .helpText="${args.helpText}"
+    .min="${args.min}"
+    .max="${args.max}"
+    .name="${args.name}"
+    .placeholder="${args.placeholder}"
+    ?required="${args.required}"
+    .value="${args.value}"
+    .step="${args.step}"
+    type=${args.type}
+    ?readonly="${args.readonly}"
+    ?autocomplete="${args.autocomplete}"
+    ?spellcheck="${args.spellcheck}"
+></rux-input>
     `
 }
 
@@ -70,25 +70,24 @@ export const Default = (args) => {
 
 export const Disabled = (args) => {
     return html`
-        <rux-input
-            .label="${args.label}"
-            .disabled="${args.disabled}"
-            .error-text="${args.errorText}"
-            .invalid="${args.invalid}"
-            .help-text="${args.helpText}"
-            .min="${args.min}"
-            .max="${args.max}"
-            .name="${args.name}"
-            .placeholder="${args.placeholder}"
-            ?required="${args.required}"
-            .value="${args.value}"
-            .step="${args.step}"
-            type=${args.type}
-            .readonly="${args.readonly}"
-            .autocomplete="${args.autocomplete}"
-            .spellcheck="${args.spellcheck}"
-        ></rux-input>
-        ${args.helpText}
+<rux-input
+    label="${args.label}"
+    ?disabled="${args.disabled}"
+    .error-text="${args.errorText}"
+    ?invalid="${args.invalid}"
+    .help-text="${args.helpText}"
+    .min="${args.min}"
+    .max="${args.max}"
+    .name="${args.name}"
+    .placeholder="${args.placeholder}"
+    ?required="${args.required}"
+    .value="${args.value}"
+    .step="${args.step}"
+    type=${args.type}
+    ?readonly="${args.readonly}"
+    ?autocomplete="${args.autocomplete}"
+    ?spellcheck="${args.spellcheck}"
+></rux-input>
     `
 }
 
@@ -109,65 +108,65 @@ export const Disabled = (args) => {
 
 export const Sizes = (args) => {
     return html`
-        <rux-input
-            label="Small input"
-            .disabled="${args.disabled}"
-            .errorText="${args.errorText}"
-            .invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .min="${args.min}"
-            .max="${args.max}"
-            .name="${args.name}"
-            .placeholder="${args.placeholder}"
-            ?required="${args.required}"
-            size="small"
-            .value="${args.value}"
-            type=${args.type}
-            .step="${args.step}"
-            .readonly="${args.readonly}"
-            .autocomplete="${args.autocomplete}"
-            .spellcheck="${args.spellcheck}"
-        ></rux-input>
-        <br />
-        <rux-input
-            label="Medium input"
-            .disabled="${args.disabled}"
-            .errorText="${args.errorText}"
-            .invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .min="${args.min}"
-            .max="${args.max}"
-            .name="${args.name}"
-            .placeholder="${args.placeholder}"
-            ?required="${args.required}"
-            size="medium"
-            .value="${args.value}"
-            type=${args.type}
-            .step="${args.step}"
-            .readonly="${args.readonly}"
-            .autocomplete="${args.autocomplete}"
-            .spellcheck="${args.spellcheck}"
-        ></rux-input>
-        <br />
-        <rux-input
-            label="Large input"
-            .disabled="${args.disabled}"
-            .errorText="${args.errorText}"
-            .invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .min="${args.min}"
-            .max="${args.max}"
-            .name="${args.name}"
-            .placeholder="${args.placeholder}"
-            ?required="${args.required}"
-            size="large"
-            .value="${args.value}"
-            type=${args.type}
-            .step="${args.step}"
-            .readonly="${args.readonly}"
-            .autocomplete="${args.autocomplete}"
-            .spellcheck="${args.spellcheck}"
-        ></rux-input>
+<rux-input
+    label="Small input"
+    ?disabled="${args.disabled}"
+    .errorText="${args.errorText}"
+    ?invalid="${args.invalid}"
+    .helpText="${args.helpText}"
+    .min="${args.min}"
+    .max="${args.max}"
+    .name="${args.name}"
+    .placeholder="${args.placeholder}"
+    ?required="${args.required}"
+    size="small"
+    .value="${args.value}"
+    type=${args.type}
+    .step="${args.step}"
+    ?readonly="${args.readonly}"
+    ?autocomplete="${args.autocomplete}"
+    ?spellcheck="${args.spellcheck}"
+></rux-input>
+<br />
+<rux-input
+    label="Medium input"
+    ?disabled="${args.disabled}"
+    .errorText="${args.errorText}"
+    ?invalid="${args.invalid}"
+    .helpText="${args.helpText}"
+    .min="${args.min}"
+    .max="${args.max}"
+    .name="${args.name}"
+    .placeholder="${args.placeholder}"
+    ?required="${args.required}"
+    size="medium"
+    .value="${args.value}"
+    type=${args.type}
+    .step="${args.step}"
+    ?readonly="${args.readonly}"
+    ?autocomplete="${args.autocomplete}"
+    ?spellcheck="${args.spellcheck}"
+></rux-input>
+<br />
+<rux-input
+    label="Large input"
+    ?disabled="${args.disabled}"
+    .errorText="${args.errorText}"
+    ?invalid="${args.invalid}"
+    .helpText="${args.helpText}"
+    .min="${args.min}"
+    .max="${args.max}"
+    .name="${args.name}"
+    .placeholder="${args.placeholder}"
+    ?required="${args.required}"
+    size="large"
+    .value="${args.value}"
+    type=${args.type}
+    .step="${args.step}"
+    ?readonly="${args.readonly}"
+    ?autocomplete="${args.autocomplete}"
+    ?spellcheck="${args.spellcheck}"
+></rux-input>
     `
 }
 
@@ -186,24 +185,24 @@ export const Sizes = (args) => {
 
 export const HelpText = (args) => {
     return html`
-        <rux-input
-            .label="${args.label}"
-            .disabled="${args.disabled}"
-            .errorText="${args.errorText}"
-            .invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .min="${args.min}"
-            .max="${args.max}"
-            .name="${args.name}"
-            .placeholder="${args.placeholder}"
-            ?required="${args.required}"
-            .value="${args.value}"
-            type=${args.type}
-            .step="${args.step}"
-            .readonly="${args.readonly}"
-            .autocomplete="${args.autocomplete}"
-            .spellcheck="${args.spellcheck}"
-        ></rux-input>
+<rux-input
+    label="${args.label}"
+    ?disabled="${args.disabled}"
+    .error-text="${args.errorText}"
+    ?invalid="${args.invalid}"
+    help-text="${args.helpText}"
+    .min="${args.min}"
+    .max="${args.max}"
+    .name="${args.name}"
+    .placeholder="${args.placeholder}"
+    ?required="${args.required}"
+    .value="${args.value}"
+    type=${args.type}
+    .step="${args.step}"
+    ?readonly="${args.readonly}"
+    ?autocomplete="${args.autocomplete}"
+    ?spellcheck="${args.spellcheck}"
+></rux-input>
     `
 }
 
@@ -224,24 +223,24 @@ export const HelpText = (args) => {
 
 export const Invalid = (args) => {
     return html`
-        <rux-input
-            .label="${args.label}"
-            .disabled="${args.disabled}"
-            .errorText="${args.errorText}"
-            .invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .min="${args.min}"
-            .max="${args.max}"
-            .name="${args.name}"
-            .placeholder="${args.placeholder}"
-            ?required="${args.required}"
-            .value="${args.value}"
-            type=${args.type}
-            .step="${args.step}"
-            .readonly="${args.readonly}"
-            .autocomplete="${args.autocomplete}"
-            .spellcheck="${args.spellcheck}"
-        ></rux-input>
+<rux-input
+    label="${args.label}"
+    .disabled="${args.disabled}"
+    error-text="${args.errorText}"
+    ?invalid="${args.invalid}"
+    .helpText="${args.helpText}"
+    .min="${args.min}"
+    .max="${args.max}"
+    .name="${args.name}"
+    .placeholder="${args.placeholder}"
+    ?required="${args.required}"
+    .value="${args.value}"
+    type=${args.type}
+    .step="${args.step}"
+    ?readonly="${args.readonly}"
+    ?autocomplete="${args.autocomplete}"
+    ?spellcheck="${args.spellcheck}"
+></rux-input>
     `
 }
 

--- a/packages/web-components/src/stories/log.stories.mdx
+++ b/packages/web-components/src/stories/log.stories.mdx
@@ -23,10 +23,10 @@ Log is a simple collection of other Astro components: [Table](?path=/docs/compon
 
 export const Log = (args) => {
     return html`
-        <div style="display: flex; flex-flow: column; justify-content: center;">
-            <rux-log ._filterValue="${args.filter}" .data="${args.data}">
-            </rux-log>
-        </div>
+<div style="display: flex; flex-flow: column; justify-content: center;">
+    <rux-log ._filterValue="${args.filter}" .data="${args.data}">
+    </rux-log>
+</div>
     `
 }
 

--- a/packages/web-components/src/stories/modal.stories.mdx
+++ b/packages/web-components/src/stories/modal.stories.mdx
@@ -23,15 +23,15 @@ A Modal interrupts the app experience to prompt a user to confirm an action or a
 
 export const Modal = (args) => {
     return html`
-        <div style="display: flex; flex-flow: column; justify-content: center;">
-            <rux-modal
-                ?open="${args.open}"
-                modal-message="${args.modalMessage}"
-                modal-title="${args.modalTitle}"
-                confirm-text="${args.confirmText}"
-                deny-text="${args.denyText}"
-            ></rux-modal>
-        </div
+<div style="display: flex; flex-flow: column; justify-content: center;">
+    <rux-modal
+        ?open="${args.open}"
+        modal-message="${args.modalMessage}"
+        modal-title="${args.modalTitle}"
+        confirm-text="${args.confirmText}"
+        deny-text="${args.denyText}"
+    ></rux-modal>
+</div
     `
 }
 

--- a/packages/web-components/src/stories/monitoring-icon.stories.mdx
+++ b/packages/web-components/src/stories/monitoring-icon.stories.mdx
@@ -18,24 +18,22 @@ These icons represent objects, equipment, and concepts that are being administer
 
 export const Default = (args) => {
     return html`
-        <div style="margin: 3rem auto; max-width: 5rem; text-align: center;">
-            <rux-monitoring-icon
-                icon="${args.icon}"
-                label="${args.label}"
-                .sublabel="${args.sublabel}"
-                .status="${args.status}"
-                .notifications="${args.notifications}"
-            ></rux-monitoring-icon>
-        </div>
-        <div style="margin: 3rem auto; max-width: 5rem; text-align: center;">
-            <rux-monitoring-icon
-                icon="widgets"
-                label="Widgets icon"
-                .sublabel="${args.sublabel}"
-                .status="${args.status}"
-                .notifications="${args.notifications}"
-            ></rux-monitoring-icon>
-        </div>
+<div style="margin: 3rem auto; max-width: 5rem; text-align: center;">
+    <rux-monitoring-icon
+        icon="${args.icon}"
+        label="${args.label}"
+        status="${args.status}"
+        notifications="${args.notifications}"
+    ></rux-monitoring-icon>
+</div>
+<div style="margin: 3rem auto; max-width: 5rem; text-align: center;">
+    <rux-monitoring-icon
+        icon="widgets"
+        label="Widgets icon"
+        status="${args.status}"
+        notifications="${args.notifications}"
+    ></rux-monitoring-icon>
+</div>
     `
 }
 
@@ -61,75 +59,75 @@ export const Default = (args) => {
 
 export const AllVariants = (args) => {
     return html`
-        <style>
-            ul {
-                display: flex;
-                list-style: none;
-                justify-content: space-around;
-                padding: 0 1rem;
-            }
-            ul li {
-                display: flex;
-                flex-direction: column;
-                align-items: center;
-            }
-        </style>
-        <ul>
-            <li>
-                <rux-monitoring-icon
-                    icon="mission"
-                    label="Mission"
-                    sublabel="Sub-label"
-                    status="off"
-                    notifications="4"
-                ></rux-monitoring-icon>
-            </li>
-            <li>
-                <rux-monitoring-icon
-                    icon="equipment"
-                    label="Equipment"
-                    sublabel="Sub-label"
-                    status="standby"
-                    notifications="100"
-                ></rux-monitoring-icon>
-            </li>
-            <li>
-                <rux-monitoring-icon
-                    icon="processor"
-                    label="Processor"
-                    sublabel="Sub-label"
-                    status="normal"
-                ></rux-monitoring-icon>
-            </li>
-            <li>
-                <rux-monitoring-icon
-                    icon="antenna"
-                    label="Antenna"
-                    sublabel="Sub-label"
-                    status="caution"
-                    notifications="1200"
-                ></rux-monitoring-icon>
-            </li>
-            <li>
-                <rux-monitoring-icon
-                    icon="antenna-transmit"
-                    label="NROL"
-                    sublabel="Sub-label"
-                    status="serious"
-                    notifications="1000000"
-                ></rux-monitoring-icon>
-            </li>
-            <li>
-                <rux-monitoring-icon
-                    icon="antenna-receive"
-                    label="SBSS=1"
-                    sublabel="Receiving"
-                    status="critical"
-                    notifications="34000000000000"
-                ></rux-monitoring-icon>
-            </li>
-        </ul>
-    `
+<style>
+    ul {
+        display: flex;
+        list-style: none;
+        justify-content: space-around;
+        padding: 0 1rem;
+    }
+    ul li {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+</style>
+<ul>
+    <li>
+        <rux-monitoring-icon
+            icon="mission"
+            label="Mission"
+            sublabel="Sub-label"
+            status="off"
+            notifications="4"
+        ></rux-monitoring-icon>
+    </li>
+    <li>
+        <rux-monitoring-icon
+            icon="equipment"
+            label="Equipment"
+            sublabel="Sub-label"
+            status="standby"
+            notifications="100"
+        ></rux-monitoring-icon>
+    </li>
+    <li>
+        <rux-monitoring-icon
+            icon="processor"
+            label="Processor"
+            sublabel="Sub-label"
+            status="normal"
+        ></rux-monitoring-icon>
+    </li>
+    <li>
+        <rux-monitoring-icon
+            icon="antenna"
+            label="Antenna"
+            sublabel="Sub-label"
+            status="caution"
+            notifications="1200"
+        ></rux-monitoring-icon>
+    </li>
+    <li>
+        <rux-monitoring-icon
+            icon="antenna-transmit"
+            label="NROL"
+            sublabel="Sub-label"
+            status="serious"
+            notifications="1000000"
+        ></rux-monitoring-icon>
+    </li>
+    <li>
+        <rux-monitoring-icon
+            icon="antenna-receive"
+            label="SBSS=1"
+            sublabel="Receiving"
+            status="critical"
+            notifications="34000000000000"
+        ></rux-monitoring-icon>
+    </li>
+</ul>
+`
 }
 
 <Canvas>

--- a/packages/web-components/src/stories/notification.stories.mdx
+++ b/packages/web-components/src/stories/notification.stories.mdx
@@ -32,15 +32,15 @@ If another Notification Banner is waiting, it appears when the current Banner is
 
 export const Default = (args) => {
     return html`
-        <div style="display: flex; flex-flow: column; justify-content: center;">
-            <rux-notification
-                ?open="${args.open}"
-                .closeAfter="${args.closeAfter}"
-                status="${args.status}"
-                message="${args.message}"
-            >
-            </rux-notification>
-        </div>
+<div style="display: flex; flex-flow: column; justify-content: center;">
+    <rux-notification
+        ?open="${args.open}"
+        .closeAfter="${args.closeAfter}"
+        status="${args.status}"
+        message="${args.message}"
+    >
+    </rux-notification>
+</div>
     `
 }
 
@@ -64,15 +64,15 @@ The Astro UXDS Notification Banner hides from view using absolute positioning in
 
 export const NotificationAutoClose = (args) => {
     return html`
-        <div style="display: flex; flex-flow: column; justify-content: center;">
-            <rux-notification
-                open="${args.open}"
-                .closeAfter="${args.closeAfter}"
-                status="${args.status}"
-                message="This is a notification banner. It will disappear in 2000 ms."
-            >
-            </rux-notification>
-        </div>
+<div style="display: flex; flex-flow: column; justify-content: center;">
+    <rux-notification
+        ?open="${args.open}"
+        .closeAfter="${args.closeAfter}"
+        .status="${args.status}"
+        message="This is a notification banner. It will disappear in 2000 ms."
+    >
+    </rux-notification>
+</div>
     `
 }
 
@@ -92,64 +92,64 @@ export const NotificationAutoClose = (args) => {
 ### All Variants
 
 export const AllVariants = () => html`
+<div
+    style="display: flex; flex-flow: column; justify-content: center; margin:20px;"
+>
     <div
-        style="display: flex; flex-flow: column; justify-content: center; margin:20px;"
+        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
     >
-        <div
-            style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
-        >
-            <rux-notification
-                open
-                status="off"
-                message="Off notification banner"
-            ></rux-notification>
-        </div>
-        <div
-            style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
-        >
-            <rux-notification
-                open
-                status="standby"
-                message="Standby notification banner"
-            ></rux-notification>
-        </div>
-        <div
-            style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
-        >
-            <rux-notification
-                open
-                status="normal"
-                message="Normal notification banner"
-            ></rux-notification>
-        </div>
-        <div
-            style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
-        >
-            <rux-notification
-                open
-                status="caution"
-                message="Caution notification banner"
-            ></rux-notification>
-        </div>
-        <div
-            style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
-        >
-            <rux-notification
-                open
-                status="serious"
-                message="Serious notification banner"
-            ></rux-notification>
-        </div>
-        <div
-            style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
-        >
-            <rux-notification
-                open
-                status="critical"
-                message="Critical notification banner"
-            ></rux-notification>
-        </div>
+        <rux-notification
+            open
+            status="off"
+            message="Off notification banner"
+        ></rux-notification>
     </div>
+    <div
+        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <rux-notification
+            open
+            status="standby"
+            message="Standby notification banner"
+        ></rux-notification>
+    </div>
+    <div
+        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <rux-notification
+            open
+            status="normal"
+            message="Normal notification banner"
+        ></rux-notification>
+    </div>
+    <div
+        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <rux-notification
+            open
+            status="caution"
+            message="Caution notification banner"
+        ></rux-notification>
+    </div>
+    <div
+        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <rux-notification
+            open
+            status="serious"
+            message="Serious notification banner"
+        ></rux-notification>
+    </div>
+    <div
+        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+    >
+        <rux-notification
+            open
+            status="critical"
+            message="Critical notification banner"
+        ></rux-notification>
+    </div>
+</div>
 `
 
 <Canvas>

--- a/packages/web-components/src/stories/popup.stories.mdx
+++ b/packages/web-components/src/stories/popup.stories.mdx
@@ -47,7 +47,7 @@ export const Default = (args) => {
         >Item 4 has a string value</rux-menu-item
     >
     <rux-menu-item href="https://www.astrouxds.com"
-        >Item 5 is an anchor/action item ...</rux-menu-item
+        >Item 5 is an anchor/action item...</rux-menu-item
     >
 </rux-pop-up-menu>
     `
@@ -188,105 +188,98 @@ export const WithAnchors = (args) => {
         <rux-menu-item>Item 1</rux-menu-item>
         <rux-menu-item-divider></rux-menu-item-divider>
         <rux-menu-item value="2" style="max-width: 344px"
-            >Item 2 with an exceedingly long title that overruns the
-            width</rux-menu-item
+            >Item 2</rux-menu-item
         >
         <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
         <rux-menu-item value="Item 4"
             >Item 4 has a string value</rux-menu-item
         >
         <rux-menu-item href="https://www.astrouxds.com"
-            >Item 5 is an anchor</rux-menu-item
+            >Item 5 is an anchor/action item...</rux-menu-item
         >
     </rux-pop-up-menu>
     <rux-pop-up-menu id="popup-menu-2">
         <rux-menu-item>Item 1</rux-menu-item>
         <rux-menu-item-divider></rux-menu-item-divider>
         <rux-menu-item value="2" style="max-width: 344px"
-            >Item 2 with an exceedingly long title that overruns the
-            width</rux-menu-item
+            >Item 2</rux-menu-item
         >
         <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
         <rux-menu-item value="Item 4"
             >Item 4 has a string value</rux-menu-item
         >
         <rux-menu-item href="https://www.astrouxds.com"
-            >Item 5 is an anchor</rux-menu-item
+            >Item 5 is an anchor/action item...</rux-menu-item
         >
     </rux-pop-up-menu>
     <rux-pop-up-menu id="popup-menu-3">
         <rux-menu-item>Item 1</rux-menu-item>
         <rux-menu-item-divider></rux-menu-item-divider>
         <rux-menu-item value="2" style="max-width: 344px"
-            >Item 2 with an exceedingly long title that overruns the
-            width</rux-menu-item
+            >Item 2</rux-menu-item
         >
         <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
         <rux-menu-item value="Item 4"
             >Item 4 has a string value</rux-menu-item
         >
         <rux-menu-item href="https://www.astrouxds.com"
-            >Item 5 is an anchor</rux-menu-item
+            >Item 5 is an anchor/action item...</rux-menu-item
         >
     </rux-pop-up-menu>
     <rux-pop-up-menu id="popup-menu-4">
         <rux-menu-item>Item 1</rux-menu-item>
         <rux-menu-item-divider></rux-menu-item-divider>
         <rux-menu-item value="2" style="max-width: 344px"
-            >Item 2 with an exceedingly long title that overruns the
-            width</rux-menu-item
+            >Item 2</rux-menu-item
         >
         <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
         <rux-menu-item value="Item 4"
             >Item 4 has a string value</rux-menu-item
         >
         <rux-menu-item href="https://www.astrouxds.com"
-            >Item 5 is an anchor</rux-menu-item
+            >Item 5 is an anchor/action item...</rux-menu-item
         >
     </rux-pop-up-menu>
     <rux-pop-up-menu id="popup-menu-5">
         <rux-menu-item>Item 1</rux-menu-item>
         <rux-menu-item-divider></rux-menu-item-divider>
         <rux-menu-item value="2" style="max-width: 344px"
-            >Item 2 with an exceedingly long title that overruns the
-            width</rux-menu-item
+            >Item 2</rux-menu-item
         >
         <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
         <rux-menu-item value="Item 4"
             >Item 4 has a string value</rux-menu-item
         >
         <rux-menu-item href="https://www.astrouxds.com"
-            >Item 5 is an anchor</rux-menu-item
+            >Item 5 is an anchor/action item...</rux-menu-item
         >
     </rux-pop-up-menu>
     <rux-pop-up-menu id="popup-menu-6">
         <rux-menu-item>Item 1</rux-menu-item>
         <rux-menu-item-divider></rux-menu-item-divider>
         <rux-menu-item value="2" style="max-width: 344px"
-            >Item 2 with an exceedingly long title that overruns the
-            width</rux-menu-item
+            >Item 2</rux-menu-item
         >
         <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
         <rux-menu-item value="Item 4"
             >Item 4 has a string value</rux-menu-item
         >
         <rux-menu-item href="https://www.astrouxds.com"
-            >Item 5 is an anchor</rux-menu-item
+            >Item 5 is an anchor/action item...</rux-menu-item
         >
     </rux-pop-up-menu>
     <rux-pop-up-menu id="popup-menu-7">
         <rux-menu-item>Item 1</rux-menu-item>
         <rux-menu-item-divider></rux-menu-item-divider>
         <rux-menu-item value="2" style="max-width: 344px"
-            >Item 2 with an exceedingly long title that overruns the
-            width</rux-menu-item
+            >Item 2</rux-menu-item
         >
         <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
         <rux-menu-item value="Item 4"
             >Item 4 has a string value</rux-menu-item
         >
         <rux-menu-item href="https://www.astrouxds.com"
-            >Item 5 is an anchor</rux-menu-item
+            >Item 5 is an anchor/action item...</rux-menu-item
         >
     </rux-pop-up-menu>
 </div>

--- a/packages/web-components/src/stories/popup.stories.mdx
+++ b/packages/web-components/src/stories/popup.stories.mdx
@@ -32,25 +32,24 @@ A Pop-Up Menu provides users with a quick way to access common actions for a hig
 
 export const Default = (args) => {
     return html`
-        <div style="display: flex; align-items: center;">
-            <rux-icon icon="apps" aria-controls="popup-menu-1"></rux-icon>
-            <span style="margin-left: 10px;">Click icon to see pop up</span>
-        </div>
-        <rux-pop-up-menu id="popup-menu-1" .open="${args.open}">
-            <rux-menu-item>Item 1</rux-menu-item>
-            <rux-menu-item-divider></rux-menu-item-divider>
-            <rux-menu-item value="2" style="max-width: 344px"
-                >Item 2 with an exceedingly long title that overruns the
-                width</rux-menu-item
-            >
-            <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
-            <rux-menu-item value="Item 4"
-                >Item 4 has a string value</rux-menu-item
-            >
-            <rux-menu-item href="https://www.astrouxds.com"
-                >Item 5 is an anchor</rux-menu-item
-            >
-        </rux-pop-up-menu>
+<div style="display: flex; align-items: center;">
+    <rux-icon icon="apps" aria-controls="popup-menu-1"></rux-icon>
+    <span style="margin-left: 10px;">Click icon to see pop up</span>
+</div>
+<rux-pop-up-menu id="popup-menu-1" ?open="${args.open}">
+    <rux-menu-item>Item 1</rux-menu-item>
+    <rux-menu-item-divider></rux-menu-item-divider>
+    <rux-menu-item value="2" style="max-width: 344px"
+        >Item 2</rux-menu-item
+    >
+    <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
+    <rux-menu-item value="Item 4"
+        >Item 4 has a string value</rux-menu-item
+    >
+    <rux-menu-item href="https://www.astrouxds.com"
+        >Item 5 is an anchor/action item ...</rux-menu-item
+    >
+</rux-pop-up-menu>
     `
 }
 
@@ -80,217 +79,217 @@ Make use of [Menu Item](?path=/docs/components-pop-up-menu-menu-item--default-st
 
 export const WithAnchors = (args) => {
     return html`
-        <style>
-            #demo {
-                padding: 5%;
-                display: flex;
-                justify-content: center;
-            }
-            #pop-demo {
-                position: absolute;
-                top: 0;
-                left: 0;
-                height: 100%;
-                width: 100%;
-            }
-            .button {
-                display: inline-block;
-                position: absolute;
-            }
-            #tl {
-                top: 2rem;
-                left: 2rem;
-            }
-            #tr {
-                top: 2rem;
-                right: 2rem;
-            }
-            #bl {
-                bottom: 2rem;
-                left: 2rem;
-            }
-            #br {
-                bottom: 2rem;
-                right: 2rem;
-            }
-            #tc {
-                top: 2rem;
-                right: 50vw;
-            }
-            #bc {
-                bottom: 2rem;
-                right: 50vw;
-            }
-            #static {
-                top: 20rem;
-                left: 50rem;
-            }
-        </style>
-        <div class="demo">
-            <div id="pop-demo">
-                <button
-                    aria-controls="popup-menu-1"
-                    aria-haspopup="true"
-                    class="button"
-                    id="tl"
-                >
-                    tl
-                </button>
-                <button
-                    aria-controls="popup-menu-2"
-                    aria-haspopup="true"
-                    class="button"
-                    id="tr"
-                >
-                    tr
-                </button>
-                <button
-                    aria-controls="popup-menu-3"
-                    aria-haspopup="true"
-                    class="button"
-                    id="bl"
-                >
-                    bl
-                </button>
-                <button
-                    aria-controls="popup-menu-4"
-                    aria-haspopup="true"
-                    class="button"
-                    id="br"
-                >
-                    br
-                </button>
-                <button
-                    aria-controls="popup-menu-5"
-                    aria-haspopup="true"
-                    class="button"
-                    id="tc"
-                >
-                    tv
-                </button>
-                <button
-                    aria-controls="popup-menu-6"
-                    aria-haspopup="true"
-                    class="button"
-                    id="bc"
-                >
-                    bc
-                </button>
-                <button
-                    aria-controls="popup-menu-7"
-                    aria-haspopup="true"
-                    class="button"
-                    id="static"
-                >
-                    bc
-                </button>
-            </div>
-            <rux-pop-up-menu id="popup-menu-1">
-                <rux-menu-item>Item 1</rux-menu-item>
-                <rux-menu-item-divider></rux-menu-item-divider>
-                <rux-menu-item value="2" style="max-width: 344px"
-                    >Item 2 with an exceedingly long title that overruns the
-                    width</rux-menu-item
-                >
-                <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
-                <rux-menu-item value="Item 4"
-                    >Item 4 has a string value</rux-menu-item
-                >
-                <rux-menu-item href="https://www.astrouxds.com"
-                    >Item 5 is an anchor</rux-menu-item
-                >
-            </rux-pop-up-menu>
-            <rux-pop-up-menu id="popup-menu-2">
-                <rux-menu-item>Item 1</rux-menu-item>
-                <rux-menu-item-divider></rux-menu-item-divider>
-                <rux-menu-item value="2" style="max-width: 344px"
-                    >Item 2 with an exceedingly long title that overruns the
-                    width</rux-menu-item
-                >
-                <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
-                <rux-menu-item value="Item 4"
-                    >Item 4 has a string value</rux-menu-item
-                >
-                <rux-menu-item href="https://www.astrouxds.com"
-                    >Item 5 is an anchor</rux-menu-item
-                >
-            </rux-pop-up-menu>
-            <rux-pop-up-menu id="popup-menu-3">
-                <rux-menu-item>Item 1</rux-menu-item>
-                <rux-menu-item-divider></rux-menu-item-divider>
-                <rux-menu-item value="2" style="max-width: 344px"
-                    >Item 2 with an exceedingly long title that overruns the
-                    width</rux-menu-item
-                >
-                <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
-                <rux-menu-item value="Item 4"
-                    >Item 4 has a string value</rux-menu-item
-                >
-                <rux-menu-item href="https://www.astrouxds.com"
-                    >Item 5 is an anchor</rux-menu-item
-                >
-            </rux-pop-up-menu>
-            <rux-pop-up-menu id="popup-menu-4">
-                <rux-menu-item>Item 1</rux-menu-item>
-                <rux-menu-item-divider></rux-menu-item-divider>
-                <rux-menu-item value="2" style="max-width: 344px"
-                    >Item 2 with an exceedingly long title that overruns the
-                    width</rux-menu-item
-                >
-                <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
-                <rux-menu-item value="Item 4"
-                    >Item 4 has a string value</rux-menu-item
-                >
-                <rux-menu-item href="https://www.astrouxds.com"
-                    >Item 5 is an anchor</rux-menu-item
-                >
-            </rux-pop-up-menu>
-            <rux-pop-up-menu id="popup-menu-5">
-                <rux-menu-item>Item 1</rux-menu-item>
-                <rux-menu-item-divider></rux-menu-item-divider>
-                <rux-menu-item value="2" style="max-width: 344px"
-                    >Item 2 with an exceedingly long title that overruns the
-                    width</rux-menu-item
-                >
-                <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
-                <rux-menu-item value="Item 4"
-                    >Item 4 has a string value</rux-menu-item
-                >
-                <rux-menu-item href="https://www.astrouxds.com"
-                    >Item 5 is an anchor</rux-menu-item
-                >
-            </rux-pop-up-menu>
-            <rux-pop-up-menu id="popup-menu-6">
-                <rux-menu-item>Item 1</rux-menu-item>
-                <rux-menu-item-divider></rux-menu-item-divider>
-                <rux-menu-item value="2" style="max-width: 344px"
-                    >Item 2 with an exceedingly long title that overruns the
-                    width</rux-menu-item
-                >
-                <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
-                <rux-menu-item value="Item 4"
-                    >Item 4 has a string value</rux-menu-item
-                >
-                <rux-menu-item href="https://www.astrouxds.com"
-                    >Item 5 is an anchor</rux-menu-item
-                >
-            </rux-pop-up-menu>
-            <rux-pop-up-menu id="popup-menu-7">
-                <rux-menu-item>Item 1</rux-menu-item>
-                <rux-menu-item-divider></rux-menu-item-divider>
-                <rux-menu-item value="2" style="max-width: 344px"
-                    >Item 2 with an exceedingly long title that overruns the
-                    width</rux-menu-item
-                >
-                <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
-                <rux-menu-item value="Item 4"
-                    >Item 4 has a string value</rux-menu-item
-                >
-                <rux-menu-item href="https://www.astrouxds.com"
-                    >Item 5 is an anchor</rux-menu-item
-                >
-            </rux-pop-up-menu>
-        </div>
+<style>
+    #demo {
+        padding: 5%;
+        display: flex;
+        justify-content: center;
+    }
+    #pop-demo {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+    }
+    .button {
+        display: inline-block;
+        position: absolute;
+    }
+    #tl {
+        top: 2rem;
+        left: 2rem;
+    }
+    #tr {
+        top: 2rem;
+        right: 2rem;
+    }
+    #bl {
+        bottom: 2rem;
+        left: 2rem;
+    }
+    #br {
+        bottom: 2rem;
+        right: 2rem;
+    }
+    #tc {
+        top: 2rem;
+        right: 50vw;
+    }
+    #bc {
+        bottom: 2rem;
+        right: 50vw;
+    }
+    #static {
+        top: 20rem;
+        left: 50rem;
+    }
+</style>
+<div class="demo">
+    <div id="pop-demo">
+        <button
+            aria-controls="popup-menu-1"
+            aria-haspopup="true"
+            class="button"
+            id="tl"
+        >
+            tl
+        </button>
+        <button
+            aria-controls="popup-menu-2"
+            aria-haspopup="true"
+            class="button"
+            id="tr"
+        >
+            tr
+        </button>
+        <button
+            aria-controls="popup-menu-3"
+            aria-haspopup="true"
+            class="button"
+            id="bl"
+        >
+            bl
+        </button>
+        <button
+            aria-controls="popup-menu-4"
+            aria-haspopup="true"
+            class="button"
+            id="br"
+        >
+            br
+        </button>
+        <button
+            aria-controls="popup-menu-5"
+            aria-haspopup="true"
+            class="button"
+            id="tc"
+        >
+            tv
+        </button>
+        <button
+            aria-controls="popup-menu-6"
+            aria-haspopup="true"
+            class="button"
+            id="bc"
+        >
+            bc
+        </button>
+        <button
+            aria-controls="popup-menu-7"
+            aria-haspopup="true"
+            class="button"
+            id="static"
+        >
+            bc
+        </button>
+    </div>
+    <rux-pop-up-menu id="popup-menu-1">
+        <rux-menu-item>Item 1</rux-menu-item>
+        <rux-menu-item-divider></rux-menu-item-divider>
+        <rux-menu-item value="2" style="max-width: 344px"
+            >Item 2 with an exceedingly long title that overruns the
+            width</rux-menu-item
+        >
+        <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
+        <rux-menu-item value="Item 4"
+            >Item 4 has a string value</rux-menu-item
+        >
+        <rux-menu-item href="https://www.astrouxds.com"
+            >Item 5 is an anchor</rux-menu-item
+        >
+    </rux-pop-up-menu>
+    <rux-pop-up-menu id="popup-menu-2">
+        <rux-menu-item>Item 1</rux-menu-item>
+        <rux-menu-item-divider></rux-menu-item-divider>
+        <rux-menu-item value="2" style="max-width: 344px"
+            >Item 2 with an exceedingly long title that overruns the
+            width</rux-menu-item
+        >
+        <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
+        <rux-menu-item value="Item 4"
+            >Item 4 has a string value</rux-menu-item
+        >
+        <rux-menu-item href="https://www.astrouxds.com"
+            >Item 5 is an anchor</rux-menu-item
+        >
+    </rux-pop-up-menu>
+    <rux-pop-up-menu id="popup-menu-3">
+        <rux-menu-item>Item 1</rux-menu-item>
+        <rux-menu-item-divider></rux-menu-item-divider>
+        <rux-menu-item value="2" style="max-width: 344px"
+            >Item 2 with an exceedingly long title that overruns the
+            width</rux-menu-item
+        >
+        <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
+        <rux-menu-item value="Item 4"
+            >Item 4 has a string value</rux-menu-item
+        >
+        <rux-menu-item href="https://www.astrouxds.com"
+            >Item 5 is an anchor</rux-menu-item
+        >
+    </rux-pop-up-menu>
+    <rux-pop-up-menu id="popup-menu-4">
+        <rux-menu-item>Item 1</rux-menu-item>
+        <rux-menu-item-divider></rux-menu-item-divider>
+        <rux-menu-item value="2" style="max-width: 344px"
+            >Item 2 with an exceedingly long title that overruns the
+            width</rux-menu-item
+        >
+        <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
+        <rux-menu-item value="Item 4"
+            >Item 4 has a string value</rux-menu-item
+        >
+        <rux-menu-item href="https://www.astrouxds.com"
+            >Item 5 is an anchor</rux-menu-item
+        >
+    </rux-pop-up-menu>
+    <rux-pop-up-menu id="popup-menu-5">
+        <rux-menu-item>Item 1</rux-menu-item>
+        <rux-menu-item-divider></rux-menu-item-divider>
+        <rux-menu-item value="2" style="max-width: 344px"
+            >Item 2 with an exceedingly long title that overruns the
+            width</rux-menu-item
+        >
+        <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
+        <rux-menu-item value="Item 4"
+            >Item 4 has a string value</rux-menu-item
+        >
+        <rux-menu-item href="https://www.astrouxds.com"
+            >Item 5 is an anchor</rux-menu-item
+        >
+    </rux-pop-up-menu>
+    <rux-pop-up-menu id="popup-menu-6">
+        <rux-menu-item>Item 1</rux-menu-item>
+        <rux-menu-item-divider></rux-menu-item-divider>
+        <rux-menu-item value="2" style="max-width: 344px"
+            >Item 2 with an exceedingly long title that overruns the
+            width</rux-menu-item
+        >
+        <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
+        <rux-menu-item value="Item 4"
+            >Item 4 has a string value</rux-menu-item
+        >
+        <rux-menu-item href="https://www.astrouxds.com"
+            >Item 5 is an anchor</rux-menu-item
+        >
+    </rux-pop-up-menu>
+    <rux-pop-up-menu id="popup-menu-7">
+        <rux-menu-item>Item 1</rux-menu-item>
+        <rux-menu-item-divider></rux-menu-item-divider>
+        <rux-menu-item value="2" style="max-width: 344px"
+            >Item 2 with an exceedingly long title that overruns the
+            width</rux-menu-item
+        >
+        <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
+        <rux-menu-item value="Item 4"
+            >Item 4 has a string value</rux-menu-item
+        >
+        <rux-menu-item href="https://www.astrouxds.com"
+            >Item 5 is an anchor</rux-menu-item
+        >
+    </rux-pop-up-menu>
+</div>
     `
 }
 

--- a/packages/web-components/src/stories/progress.stories.mdx
+++ b/packages/web-components/src/stories/progress.stories.mdx
@@ -18,13 +18,12 @@ A visual indicator of a task's progress. When indicating progress with a finite 
 
 export const Default = (args) => {
     return html`
-        <div style="margin: 3rem auto;  padding: 2rem; text-align: center;">
-            <rux-progress
-                value="${args.value}"
-                .max=${args.max}
-                ?hide-label="${args.hideLabel}"
-            ></rux-progress>
-        </div>
+<div style="margin: 3rem auto;  padding: 2rem; text-align: center;">
+    <rux-progress
+        value="${args.value}"
+        .max=${args.max}
+    ></rux-progress>
+</div>
     `
 }
 
@@ -59,7 +58,7 @@ export const DeterminateProgressMax = (args) => {
         <div style="margin: 3rem auto;  padding: 2rem; text-align: center;">
             <rux-progress
                 value="${args.value}"
-                .max=${args.max}
+                max=${args.max}
                 ?hide-label="${args.hideLabel}"
             ></rux-progress>
         </div>
@@ -82,13 +81,13 @@ export const DeterminateProgressMax = (args) => {
 
 export const DeterminateProgressCustomMax = (args) => {
     return html`
-        <div style="margin: 3rem auto;  padding: 2rem; text-align: center;">
-            <rux-progress
-                value="${args.value}"
-                .max=${args.max}
-                ?hide-label="${args.hideLabel}"
-            ></rux-progress>
-        </div>
+<div style="margin: 3rem auto;  padding: 2rem; text-align: center;">
+    <rux-progress
+        value="${args.value}"
+        max=${args.max}
+        ?hide-label="${args.hideLabel}"
+    ></rux-progress>
+</div>
     `
 }
 
@@ -107,13 +106,13 @@ export const DeterminateProgressCustomMax = (args) => {
 ## Indeterminate Progress
 
 export const IndeterminateProgress = (args) => html`
-    <div style="margin: 3rem auto; max-width: 5rem; text-align: center;">
-        <rux-progress
-            .value="${args.value}"
-            .max=${args.max}
-            ?hide-label="${args.hideLabel}"
-        ></rux-progress>
-    </div>
+<div style="margin: 3rem auto; max-width: 5rem; text-align: center;">
+    <rux-progress
+        .value="${args.value}"
+        .max=${args.max}
+        ?hide-label="${args.hideLabel}"
+    ></rux-progress>
+</div>
 `
 
 <Canvas>

--- a/packages/web-components/src/stories/push-button.stories.mdx
+++ b/packages/web-components/src/stories/push-button.stories.mdx
@@ -23,29 +23,19 @@ Push Buttons are a variant of the toggle button which incorporate label and acti
 
 export const PushButton = (args) => {
     return html`
-        <div style="padding: 10%; display: flex; justify-content: center;">
-            <rux-push-button
-                .size=${args.size}
-                .icon="${args.icon}"
-                ?icon-only="${args.iconOnly}"
-                .disabled=${args.disabled}
-                .checked=${args.checked}
-                .label=${args.label}
-                .value=${args.value}
-            ></rux-push-button>
-        </div>
+<div style="padding: 10%; display: flex; justify-content: center;">
+    <rux-push-button
+        label=${args.label}
+    ></rux-push-button>
+</div>
     `
 }
 
 <Canvas>
     <Story
-        parameters={{
-            docs: {
-                source: {
-                    code: '<rux-push-button>Push Button</rux-push-button>',
-                },
-            },
-        }}
+    args={{
+        label: "Push Button",    }
+    }
         name="Push Button"
     >
         {PushButton.bind()}
@@ -58,65 +48,65 @@ export const PushButton = (args) => {
 
 export const AllVariants = (args) => {
     return html`
-        <style>
-            .button-list {
-                list-style-type: none;
-                margin: 0 1rem 0 0;
-                padding: 0;
-                display: flex;
-                flex-flow: column;
-            }
-            .button-list li {
-                margin: 0 1rem 1rem 0;
-                display: flex;
-            }
-            .button-list li rux-button:not(:last-child) {
-                margin-right: 1rem;
-            }
-        </style>
-        <div
-            style="padding: 8vh 2vw; display: flex; flex-flow: row wrap; justify-content: space-evenly;"
-        >
-            <ul class="button-list">
-                <li>
-                    <rux-push-button
-                        label="Push button small"
-                        size="small"
-                    ></rux-push-button>
-                </li>
-                <li>
-                    <rux-push-button
-                        label="Push button medium"
-                    ></rux-push-button>
-                </li>
-                <li>
-                    <rux-push-button
-                        label="Push button large"
-                        size="large"
-                    ></rux-push-button>
-                </li>
-                <li>
-                    <rux-push-button
-                        checked
-                        label="Push button checked"
-                    ></rux-push-button>
-                </li>
-                <li>
-                    <rux-push-button
-                        disabled
-                        label="Push button disabled"
-                    ></rux-push-button>
-                </li>
-                <li>
-                    <rux-push-button
-                        checked
-                        disabled
-                        label="Push button disabled checked"
-                    ></rux-push-button>
-                </li>
-            </ul>
-        </div>
-    `
+<style>
+    .button-list {
+        list-style-type: none;
+        margin: 0 1rem 0 0;
+        padding: 0;
+        display: flex;
+        flex-flow: column;
+    }
+    .button-list li {
+        margin: 0 1rem 1rem 0;
+        display: flex;
+    }
+    .button-list li rux-button:not(:last-child) {
+        margin-right: 1rem;
+    }
+</style>
+<div
+    style="padding: 8vh 2vw; display: flex; flex-flow: row wrap; justify-content: space-evenly;"
+>
+    <ul class="button-list">
+        <li>
+            <rux-push-button
+                label="Push button small"
+                size="small"
+            ></rux-push-button>
+        </li>
+        <li>
+            <rux-push-button
+                label="Push button medium"
+            ></rux-push-button>
+        </li>
+        <li>
+            <rux-push-button
+                label="Push button large"
+                size="large"
+            ></rux-push-button>
+        </li>
+        <li>
+            <rux-push-button
+                checked
+                label="Push button checked"
+            ></rux-push-button>
+        </li>
+        <li>
+            <rux-push-button
+                disabled
+                label="Push button disabled"
+            ></rux-push-button>
+        </li>
+        <li>
+            <rux-push-button
+                checked
+                disabled
+                label="Push button disabled checked"
+            ></rux-push-button>
+        </li>
+    </ul>
+</div>
+`
 }
 
 <Canvas>

--- a/packages/web-components/src/stories/push-button.stories.mdx
+++ b/packages/web-components/src/stories/push-button.stories.mdx
@@ -26,6 +26,7 @@ export const PushButton = (args) => {
 <div style="padding: 10%; display: flex; justify-content: center;">
     <rux-push-button
         label=${args.label}
+        .size=${args.size}
     ></rux-push-button>
 </div>
     `

--- a/packages/web-components/src/stories/radio-group.stories.mdx
+++ b/packages/web-components/src/stories/radio-group.stories.mdx
@@ -27,18 +27,18 @@ The Radio Group component is responsible for checking and unchecking individual 
 
 export const Default = (args) => {
     return html`
-        <rux-radio-group
-            name="radios"
-            .label="${args.label}"
-            .value="${args.value}"
-            ?invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .errorText="${args.errorText}"
-        >
-            <rux-radio value="one" name="radios">One</rux-radio>
-            <rux-radio value="two" name="radios">Two</rux-radio>
-            <rux-radio value="three" name="radios">Three</rux-radio>
-        </rux-radio-group>
+<rux-radio-group
+    name="radios"
+    label="${args.label}"
+    .value="${args.value}"
+    ?invalid="${args.invalid}"
+    .helpText="${args.helpText}"
+    .errorText="${args.errorText}"
+>
+    <rux-radio value="one" name="radios">One</rux-radio>
+    <rux-radio value="two" name="radios">Two</rux-radio>
+    <rux-radio value="three" name="radios">Three</rux-radio>
+</rux-radio-group>
     `
 }
 
@@ -70,18 +70,18 @@ Make use of the `value` property to control the state of the checked radio value
 
 export const Invalid = (args) => {
     return html`
-        <rux-radio-group
-            name="radios"
-            .label="${args.label}"
-            .value="${args.value}"
-            ?invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .errorText="${args.errorText}"
-        >
-            <rux-radio value="one" name="radios">One</rux-radio>
-            <rux-radio value="two" name="radios">Two</rux-radio>
-            <rux-radio value="three" name="radios">Three</rux-radio>
-        </rux-radio-group>
+<rux-radio-group
+    name="radios"
+    label="${args.label}"
+    .value="${args.value}"
+    ?invalid="${args.invalid}"
+    .helpText="${args.helpText}"
+    .errorText="${args.errorText}"
+>
+    <rux-radio value="one" name="radios">One</rux-radio>
+    <rux-radio value="two" name="radios">Two</rux-radio>
+    <rux-radio value="three" name="radios">Three</rux-radio>
+</rux-radio-group>
     `
 }
 
@@ -102,18 +102,18 @@ export const Invalid = (args) => {
 
 export const WithHelpText = (args) => {
     return html`
-        <rux-radio-group
-            name="radios"
-            .label="${args.label}"
-            .value="${args.value}"
-            ?invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .errorText="${args.errorText}"
-        >
-            <rux-radio value="one" name="radios">One</rux-radio>
-            <rux-radio value="two" name="radios">Two</rux-radio>
-            <rux-radio value="three" name="radios">Three</rux-radio>
-        </rux-radio-group>
+<rux-radio-group
+    name="radios"
+    label="${args.label}"
+    .value="${args.value}"
+    ?invalid="${args.invalid}"
+    help-text="${args.helpText}"
+    .error-text="${args.errorText}"
+>
+    <rux-radio value="one" name="radios">One</rux-radio>
+    <rux-radio value="two" name="radios">Two</rux-radio>
+    <rux-radio value="three" name="radios">Three</rux-radio>
+</rux-radio-group>
     `
 }
 
@@ -134,18 +134,18 @@ export const WithHelpText = (args) => {
 
 export const WithErrorText = (args) => {
     return html`
-        <rux-radio-group
-            name="radios"
-            .label="${args.label}"
-            .value="${args.value}"
-            ?invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .errorText="${args.errorText}"
-        >
-            <rux-radio value="one" name="radios">One</rux-radio>
-            <rux-radio value="two" name="radios">Two</rux-radio>
-            <rux-radio value="three" name="radios">Three</rux-radio>
-        </rux-radio-group>
+<rux-radio-group
+    name="radios"
+    label="${args.label}"
+    .value="${args.value}"
+    ?invalid="${args.invalid}"
+    .help-text="${args.helpText}"
+    error-text="${args.errorText}"
+>
+    <rux-radio value="one" name="radios">One</rux-radio>
+    <rux-radio value="two" name="radios">Two</rux-radio>
+    <rux-radio value="three" name="radios">Three</rux-radio>
+</rux-radio-group>
     `
 }
 
@@ -181,20 +181,20 @@ rux-radio-group::part(label) {
 
 export const HorizontalLabel = (args) => {
     return html`
-        <style>
-            #left-example::part(form-field) {
-                display: flex;
-                flex-direction: row;
-            }
-            #left-example::part(label) {
-                margin-right: var(--spacing-input-label-left);
-            }
-        </style>
-        <rux-radio-group id="left-example" label="Label">
-            <rux-radio value="1">one</rux-radio>
-            <rux-radio value="2">two</rux-radio>
-            <rux-radio value="3">three</rux-radio>
-        </rux-radio-group>
+<style>
+    #left-example::part(form-field) {
+        display: flex;
+        flex-direction: row;
+    }
+    #left-example::part(label) {
+        margin-right: var(--spacing-input-label-left);
+    }
+</style>
+<rux-radio-group id="left-example" label="Label">
+    <rux-radio value="1">one</rux-radio>
+    <rux-radio value="2">two</rux-radio>
+    <rux-radio value="3">three</rux-radio>
+</rux-radio-group>
     `
 }
 

--- a/packages/web-components/src/stories/radio.stories.mdx
+++ b/packages/web-components/src/stories/radio.stories.mdx
@@ -29,13 +29,14 @@ The Radio Group component is responsible for checking and unchecking individual 
 
 export const Default = (args) => {
     return html`
-        <rux-radio
-            name="radios"
-            ?checked=${args.checked}
-            ?disabled=${args.disabled}
-            .value="${args.value}"
-            >${args.label}</rux-radio
-        >
+<rux-radio
+    name="radios"
+    ?checked=${args.checked}
+    ?disabled=${args.disabled}
+    .value="${args.value}"
+    .label="${args.label}"
+    >Radio Label</rux-radio
+>
     `
 }
 
@@ -61,13 +62,14 @@ export const Default = (args) => {
 
 export const Checked = (args) => {
     return html`
-        <rux-radio
-            .name="${args.name}"
-            ?checked=${args.checked}
-            ?disabled=${args.disabled}
-            .value="${args.value}"
-            >${args.label}</rux-radio
-        >
+<rux-radio
+    .name="${args.name}"
+    ?checked=${args.checked}
+    ?disabled=${args.disabled}
+    .value="${args.value}"
+    .label="${args.label}"
+    >Radio Label</rux-radio
+>
     `
 }
 
@@ -88,13 +90,14 @@ export const Checked = (args) => {
 
 export const Disabled = (args) => {
     return html`
-        <rux-radio
-            .name="${args.name}"
-            ?checked=${args.checked}
-            ?disabled=${args.disabled}
-            .value="${args.value}"
-            >${args.label}</rux-radio
-        >
+<rux-radio
+    .name="${args.name}"
+    ?checked=${args.checked}
+    ?disabled=${args.disabled}
+    .value="${args.value}"
+    .label="${args.label}"
+    >Radio Label</rux-radio
+>
     `
 }
 

--- a/packages/web-components/src/stories/segmented-button.stories.mdx
+++ b/packages/web-components/src/stories/segmented-button.stories.mdx
@@ -29,12 +29,11 @@ export const SegmentedButton = (args) => {
     ]
     document.addEventListener('change', (e) => action('change')(e.target))
     return html`
-        <div style="padding: 10vh 5vw; display: flex; justify-content: center;">
-            <rux-segmented-button
-                .data="${args.data}"
-                ?selected="${args.selected}"
-            ></rux-segmented-button>
-        </div>
+<div style="padding: 10vh 5vw; display: flex; justify-content: center;">
+    <rux-segmented-button
+        .data="${args.data}"
+    ></rux-segmented-button>
+</div>
     `
 }
 

--- a/packages/web-components/src/stories/select.stories.mdx
+++ b/packages/web-components/src/stories/select.stories.mdx
@@ -28,28 +28,28 @@ Select Menus allow users to select a value from a list of values.
 
 export const Default = (args) => {
     return html`
-        <div style="width: 200px; margin: 0 auto;">
-            <rux-select
-                ?disabled="${args.disabled}"
-                ?required="${args.required}"
-                ?invalid="${args.invalid}"
-                label="${args.label}"
-                input-id="${args.inputId}"
-                label-id="${args.labelId}"
-                .errorText="${args.errorText}"
-                .helpText="${args.helpText}"
-            >
-                <rux-option
-                    value=""
-                    selected
-                    label="Select an option"
-                ></rux-option>
-                <rux-option value="1.1" label="Option 1.1"></rux-option>
-                <rux-option value="1.2" label="Option 1.2"></rux-option>
-                <rux-option value="1.3" label="Option 1.3"></rux-option>
-                <rux-option value="1.4" label="Option 1.4"></rux-option>
-            </rux-select>
-        </div>
+<div style="width: 200px; margin: 0 auto;">
+    <rux-select
+        ?disabled="${args.disabled}"
+        ?required="${args.required}"
+        ?invalid="${args.invalid}"
+        label="${args.label}"
+        input-id="${args.inputId}"
+        label-id="${args.labelId}"
+        .errorText="${args.errorText}"
+        .helpText="${args.helpText}"
+    >
+        <rux-option
+            value=""
+            selected
+            label="Select an option"
+        ></rux-option>
+        <rux-option value="1.1" label="Option 1.1"></rux-option>
+        <rux-option value="1.2" label="Option 1.2"></rux-option>
+        <rux-option value="1.3" label="Option 1.3"></rux-option>
+        <rux-option value="1.4" label="Option 1.4"></rux-option>
+    </rux-select>
+</div>
     `
 }
 
@@ -88,37 +88,37 @@ For Grouping, make sure to use the Astro `<rux-option-group>` component instead 
 
 export const WithOptionGroups = (args) => {
     return html`
-        <div style="width: 200px; margin: 0 auto;">
-            <rux-select
-                ?disabled="${args.disabled}"
-                ?required="${args.required}"
-                ?invalid="${args.invalid}"
-                label="${args.label}"
-                input-id="${args.inputId}"
-                label-id="${args.labelId}"
-                .errorText="${args.errorText}"
-                .helpText="${args.helpText}"
-            >
-                <rux-option
-                    value=""
-                    label="Select an option"
-                    selected
-                ></rux-option>
-                <rux-option-group label="Group one">
-                    <rux-option value="1.1" label="Option 1.1"></rux-option>
-                    <rux-option value="1.2" label="Option 1.2"></rux-option>
-                    <rux-option value="1.3" label="Option 1.3"></rux-option>
-                    <rux-option value="1.4" label="Option 1.4"></rux-option>
-                </rux-option-group>
-                <rux-option-group label="Group two">
-                    <rux-option value="2.1" label="Option 2.1"></rux-option>
-                    <rux-option value="2.2" label="Option 2.2"></rux-option>
-                    <rux-option value="2.3" label="Option 2.3"></rux-option>
-                    <rux-option value="2.4" label="Option 2.4"></rux-option>
-                </rux-option-group>
-                <rux-option value="3.1" label="Option 3.1"></rux-option>
-            </rux-select>
-        </div>
+<div style="width: 200px; margin: 0 auto;">
+    <rux-select
+        ?disabled="${args.disabled}"
+        ?required="${args.required}"
+        ?invalid="${args.invalid}"
+        label="${args.label}"
+        input-id="${args.inputId}"
+        label-id="${args.labelId}"
+        .errorText="${args.errorText}"
+        .helpText="${args.helpText}"
+    >
+        <rux-option
+            value=""
+            label="Select an option"
+            selected
+        ></rux-option>
+        <rux-option-group label="Group one">
+            <rux-option value="1.1" label="Option 1.1"></rux-option>
+            <rux-option value="1.2" label="Option 1.2"></rux-option>
+            <rux-option value="1.3" label="Option 1.3"></rux-option>
+            <rux-option value="1.4" label="Option 1.4"></rux-option>
+        </rux-option-group>
+        <rux-option-group label="Group two">
+            <rux-option value="2.1" label="Option 2.1"></rux-option>
+            <rux-option value="2.2" label="Option 2.2"></rux-option>
+            <rux-option value="2.3" label="Option 2.3"></rux-option>
+            <rux-option value="2.4" label="Option 2.4"></rux-option>
+        </rux-option-group>
+        <rux-option value="3.1" label="Option 3.1"></rux-option>
+    </rux-select>
+</div>
     `
 }
 
@@ -139,28 +139,28 @@ export const WithOptionGroups = (args) => {
 
 export const Disabled = (args) => {
     return html`
-        <div style="width: 200px; margin: 0 auto;">
-            <rux-select
-                ?disabled="${args.disabled}"
-                ?required="${args.required}"
-                ?invalid="${args.invalid}"
-                label="${args.label}"
-                input-id="${args.inputId}"
-                label-id="${args.labelId}"
-                .errorText="${args.errorText}"
-                .helpText="${args.helpText}"
-            >
-                <rux-option
-                    value=""
-                    selected
-                    label="Select an option"
-                ></rux-option>
-                <rux-option value="1.1" label="Option 1.1"></rux-option>
-                <rux-option value="1.2" label="Option 1.2"></rux-option>
-                <rux-option value="1.3" label="Option 1.3"></rux-option>
-                <rux-option value="1.4" label="Option 1.4"></rux-option>
-            </rux-select>
-        </div>
+<div style="width: 200px; margin: 0 auto;">
+    <rux-select
+        ?disabled="${args.disabled}"
+        ?required="${args.required}"
+        ?invalid="${args.invalid}"
+        label="${args.label}"
+        input-id="${args.inputId}"
+        label-id="${args.labelId}"
+        .errorText="${args.errorText}"
+        .helpText="${args.helpText}"
+    >
+        <rux-option
+            value=""
+            selected
+            label="Select an option"
+        ></rux-option>
+        <rux-option value="1.1" label="Option 1.1"></rux-option>
+        <rux-option value="1.2" label="Option 1.2"></rux-option>
+        <rux-option value="1.3" label="Option 1.3"></rux-option>
+        <rux-option value="1.4" label="Option 1.4"></rux-option>
+    </rux-select>
+</div>
     `
 }
 
@@ -182,26 +182,26 @@ export const Disabled = (args) => {
 
 export const Invalid = (args) => {
     return html`
-        <div style="width: 200px; margin: 0 auto;">
-            <rux-select
-                ?disabled="${args.disabled}"
-                ?required="${args.required}"
-                ?invalid="${args.invalid}"
-                label="${args.label}"
-                input-id="${args.inputId}"
-                label-id="${args.labelId}"
-            >
-                <rux-option
-                    value=""
-                    selected
-                    label="Select an option"
-                ></rux-option>
-                <rux-option value="1.1" label="Option 1.1"></rux-option>
-                <rux-option value="1.2" label="Option 1.2"></rux-option>
-                <rux-option value="1.3" label="Option 1.3"></rux-option>
-                <rux-option value="1.4" label="Option 1.4"></rux-option>
-            </rux-select>
-        </div>
+<div style="width: 200px; margin: 0 auto;">
+    <rux-select
+        ?disabled="${args.disabled}"
+        ?required="${args.required}"
+        ?invalid="${args.invalid}"
+        label="${args.label}"
+        input-id="${args.inputId}"
+        label-id="${args.labelId}"
+    >
+        <rux-option
+            value=""
+            selected
+            label="Select an option"
+        ></rux-option>
+        <rux-option value="1.1" label="Option 1.1"></rux-option>
+        <rux-option value="1.2" label="Option 1.2"></rux-option>
+        <rux-option value="1.3" label="Option 1.3"></rux-option>
+        <rux-option value="1.4" label="Option 1.4"></rux-option>
+    </rux-select>
+</div>
     `
 }
 
@@ -221,28 +221,28 @@ export const Invalid = (args) => {
 
 export const WithHelpText = (args) => {
     return html`
-        <div style="width: 200px; margin: 0 auto;">
-            <rux-select
-                ?disabled="${args.disabled}"
-                ?required="${args.required}"
-                ?invalid="${args.invalid}"
-                label="${args.label}"
-                input-id="${args.inputId}"
-                label-id="${args.labelId}"
-                .errorText="${args.errorText}"
-                .helpText="${args.helpText}"
-            >
-                <rux-option
-                    value=""
-                    selected
-                    label="Select an option"
-                ></rux-option>
-                <rux-option value="1.1" label="Option 1.1"></rux-option>
-                <rux-option value="1.2" label="Option 1.2"></rux-option>
-                <rux-option value="1.3" label="Option 1.3"></rux-option>
-                <rux-option value="1.4" label="Option 1.4"></rux-option>
-            </rux-select>
-        </div>
+<div style="width: 200px; margin: 0 auto;">
+    <rux-select
+        ?disabled="${args.disabled}"
+        ?required="${args.required}"
+        ?invalid="${args.invalid}"
+        label="${args.label}"
+        input-id="${args.inputId}"
+        label-id="${args.labelId}"
+        .errot-text="${args.errorText}"
+        help-text="${args.helpText}"
+    >
+        <rux-option
+            value=""
+            selected
+            label="Select an option"
+        ></rux-option>
+        <rux-option value="1.1" label="Option 1.1"></rux-option>
+        <rux-option value="1.2" label="Option 1.2"></rux-option>
+        <rux-option value="1.3" label="Option 1.3"></rux-option>
+        <rux-option value="1.4" label="Option 1.4"></rux-option>
+    </rux-select>
+</div>
     `
 }
 
@@ -262,28 +262,28 @@ export const WithHelpText = (args) => {
 
 export const WithErrorText = (args) => {
     return html`
-        <div style="width: 200px; margin: 0 auto;">
-            <rux-select
-                ?disabled="${args.disabled}"
-                ?required="${args.required}"
-                ?invalid="${args.invalid}"
-                label="${args.label}"
-                input-id="${args.inputId}"
-                label-id="${args.labelId}"
-                .errorText="${args.errorText}"
-                .helpText="${args.helpText}"
-            >
-                <rux-option
-                    value=""
-                    selected
-                    label="Select an option"
-                ></rux-option>
-                <rux-option value="1.1" label="Option 1.1"></rux-option>
-                <rux-option value="1.2" label="Option 1.2"></rux-option>
-                <rux-option value="1.3" label="Option 1.3"></rux-option>
-                <rux-option value="1.4" label="Option 1.4"></rux-option>
-            </rux-select>
-        </div>
+<div style="width: 200px; margin: 0 auto;">
+    <rux-select
+        ?disabled="${args.disabled}"
+        ?required="${args.required}"
+        ?invalid="${args.invalid}"
+        label="${args.label}"
+        input-id="${args.inputId}"
+        label-id="${args.labelId}"
+        error-text="${args.errorText}"
+        .help-text="${args.helpText}"
+    >
+        <rux-option
+            value=""
+            selected
+            label="Select an option"
+        ></rux-option>
+        <rux-option value="1.1" label="Option 1.1"></rux-option>
+        <rux-option value="1.2" label="Option 1.2"></rux-option>
+        <rux-option value="1.3" label="Option 1.3"></rux-option>
+        <rux-option value="1.4" label="Option 1.4"></rux-option>
+    </rux-select>
+</div>
     `
 }
 

--- a/packages/web-components/src/stories/slider.stories.mdx
+++ b/packages/web-components/src/stories/slider.stories.mdx
@@ -23,17 +23,17 @@ A Slider allows users to choose from a range of continuous and discrete values. 
 
 export const Default = (args) => {
     return html`
-        <div style="padding: 5%">
-            <rux-slider
-                .max="${args.max}"
-                .min="${args.min}"
-                .step="${args.step}"
-                .value="${args.value}"
-                .disabled="${args.disabled}"
-                .helpText="${args.helpText}"
-                .errorText="${args.errorText}"
-            ></rux-slider>
-        </div>
+<div style="padding: 5%">
+    <rux-slider
+        max="${args.max}"
+        min="${args.min}"
+        step="${args.step}"
+        value="${args.value}"
+        .disabled="${args.disabled}"
+        .help-text="${args.helpText}"
+        .error-text="${args.errorText}"
+    ></rux-slider>
+</div>
     `
 }
 
@@ -61,17 +61,17 @@ export const Default = (args) => {
 
 export const Disabled = (args) => {
     return html`
-        <div style="padding: 5%">
-            <rux-slider
-                .max="${args.max}"
-                .min="${args.min}"
-                .step="${args.step}"
-                .value="${args.value}"
-                .disabled="${args.disabled}"
-                .helpText="${args.helpText}"
-                .errorText="${args.errorText}"
-            ></rux-slider>
-        </div>
+<div style="padding: 5%">
+    <rux-slider
+        max="${args.max}"
+        min="${args.min}"
+        step="${args.step}"
+        .value="${args.value}"
+        ?disabled="${args.disabled}"
+        .help-text="${args.helpText}"
+        .error-text="${args.errorText}"
+    ></rux-slider>
+</div>
     `
 }
 
@@ -93,17 +93,17 @@ export const Disabled = (args) => {
 
 export const WithHelpText = (args) => {
     return html`
-        <div style="padding: 5%">
-            <rux-slider
-                .max="${args.max}"
-                .min="${args.min}"
-                .step="${args.step}"
-                .value="${args.value}"
-                .disabled="${args.disabled}"
-                .helpText="${args.helpText}"
-                .errorText="${args.errorText}"
-            ></rux-slider>
-        </div>
+<div style="padding: 5%">
+    <rux-slider
+        max="${args.max}"
+        min="${args.min}"
+        step="${args.step}"
+        .value="${args.value}"
+        ?disabled="${args.disabled}"
+        help-text="${args.helpText}"
+        .error-text="${args.errorText}"
+    ></rux-slider>
+</div>
     `
 }
 
@@ -125,17 +125,17 @@ export const WithHelpText = (args) => {
 
 export const WithErrorText = (args) => {
     return html`
-        <div style="padding: 5%">
-            <rux-slider
-                .max="${args.max}"
-                .min="${args.min}"
-                .step="${args.step}"
-                .value="${args.value}"
-                .disabled="${args.disabled}"
-                .helpText="${args.helpText}"
-                .errorText="${args.errorText}"
-            ></rux-slider>
-        </div>
+<div style="padding: 5%">
+    <rux-slider
+        max="${args.max}"
+        min="${args.min}"
+        step="${args.step}"
+        .value="${args.value}"
+        ?disabled="${args.disabled}"
+        .help-text="${args.helpText}"
+        error-text="${args.errorText}"
+    ></rux-slider>
+</div>
     `
 }
 
@@ -170,16 +170,16 @@ rux-slider::part(label) {
 
 export const HorizontalLabel = (args) => {
     return html`
-        <style>
-            #left-example::part(form-field) {
-                display: flex;
-                flex-direction: row;
-            }
-            #left-example::part(label) {
-                margin-right: var(--spacing-input-label-left);
-            }
-        </style>
-        <rux-slider id="left-example" label="Label"></rux-slider>
+<style>
+    #left-example::part(form-field) {
+        display: flex;
+        flex-direction: row;
+    }
+    #left-example::part(label) {
+        margin-right: var(--spacing-input-label-left);
+    }
+</style>
+<rux-slider id="left-example" label="Label"></rux-slider>
     `
 }
 

--- a/packages/web-components/src/stories/status.stories.mdx
+++ b/packages/web-components/src/stories/status.stories.mdx
@@ -18,12 +18,12 @@ The Status Symbol combines color and shape to create a standard and consistent w
 
 export const Default = (args) => {
     return html`
-        <div style="display: flex; margin-top: 1rem;">
-            <rux-status
-                status="${args.status}"
-                style="margin: auto;"
-            ></rux-status>
-        </div>
+<div style="display: flex; margin-top: 1rem;">
+    <rux-status
+        status="${args.status}"
+        style="margin: auto;"
+    ></rux-status>
+</div>
     `
 }
 
@@ -44,45 +44,45 @@ export const Default = (args) => {
 
 export const AllVariants = () => {
     return html`
-        <style>
-            ul {
-                display: flex;
-                list-style: none;
-                justify-content: space-around;
-                padding: 0 1rem;
-            }
-            ul li {
-                display: flex;
-                flex-direction: column;
-                align-items: center;
-            }
-        </style>
-        <ul>
-            <li>
-                <rux-status status="off"></rux-status>
-                <div class="label">Off</div>
-            </li>
-            <li>
-                <rux-status status="standby"></rux-status>
-                <div class="label">Standby</div>
-            </li>
-            <li>
-                <rux-status status="normal"></rux-status>
-                <div class="label">Normal</div>
-            </li>
-            <li>
-                <rux-status status="caution"></rux-status>
-                <div class="label">Caution</div>
-            </li>
-            <li>
-                <rux-status status="serious"></rux-status>
-                <div class="label">Serious</div>
-            </li>
-            <li>
-                <rux-status status="critical"></rux-status>
-                <div class="label">Critical</div>
-            </li>
-        </ul>
+<style>
+    ul {
+        display: flex;
+        list-style: none;
+        justify-content: space-around;
+        padding: 0 1rem;
+    }
+    ul li {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+</style>
+<ul>
+    <li>
+        <rux-status status="off"></rux-status>
+        <div class="label">Off</div>
+    </li>
+    <li>
+        <rux-status status="standby"></rux-status>
+        <div class="label">Standby</div>
+    </li>
+    <li>
+        <rux-status status="normal"></rux-status>
+        <div class="label">Normal</div>
+    </li>
+    <li>
+        <rux-status status="caution"></rux-status>
+        <div class="label">Caution</div>
+    </li>
+    <li>
+        <rux-status status="serious"></rux-status>
+        <div class="label">Serious</div>
+    </li>
+    <li>
+        <rux-status status="critical"></rux-status>
+        <div class="label">Critical</div>
+    </li>
+</ul>
     `
 }
 

--- a/packages/web-components/src/stories/switch.stories.mdx
+++ b/packages/web-components/src/stories/switch.stories.mdx
@@ -27,21 +27,17 @@ A Switch toggles between two mutually exclusive states such as "On" or "Off." Un
 
 export const Switch = (args) => {
     return html`
-        <div style="margin: 3rem auto; max-width: 5rem; text-align: center;">
-            <rux-switch
-                .disabled=${args.disabled}
-                .checked=${args.checked}
-                id="01"
-            ></rux-switch>
-        </div>
+<div style="margin: 3rem auto; max-width: 5rem; text-align: center;">
+    <rux-switch
+        ?disabled=${args.disabled}
+        ?checked=${args.checked}
+    ></rux-switch>
+</div>
     `
 }
 
 <Canvas>
     <Story
-        parameters={{
-            docs: { source: { code: '<rux-switch></rux-switch>' } },
-        }}
         name="Switch"
     >
         {Switch.bind()}
@@ -58,13 +54,12 @@ export const Switch = (args) => {
 
 export const Disabled = (args) => {
     return html`
-        <div style="margin: 3rem auto; max-width: 5rem; text-align: center;">
-            <rux-switch
-                .disabled=${args.disabled}
-                .checked=${args.checked}
-                id="01"
-            ></rux-switch>
-        </div>
+<div style="margin: 3rem auto; max-width: 5rem; text-align: center;">
+    <rux-switch
+        ?disabled=${args.disabled}
+        ?checked=${args.checked}
+    ></rux-switch>
+</div>
     `
 }
 
@@ -73,9 +68,6 @@ export const Disabled = (args) => {
         name="Disabled"
         args={{
             disabled: true,
-        }}
-        parameters={{
-            docs: { source: { code: '<rux-switch disabled></rux-switch>' } },
         }}
     >
         {Disabled.bind()}

--- a/packages/web-components/src/stories/tab.stories.mdx
+++ b/packages/web-components/src/stories/tab.stories.mdx
@@ -19,9 +19,9 @@ Tab belongs to the Tabs component.
 
 export const Default = (args) => {
     return html`
-        <rux-tab id="tab1" .disabled=${args.disabled} .selected=${args.selected}
-            >Tab 1</rux-tab
-        >
+<rux-tab id="tab1" ?disabled=${args.disabled} ?selected=${args.selected}
+    >Tab 1</rux-tab
+>
     `
 }
 
@@ -39,9 +39,9 @@ export const Default = (args) => {
 
 export const Disabled = (args) => {
     return html`
-        <rux-tab id="tab1" .disabled=${args.disabled} .selected=${args.selected}
-            >Tab 1</rux-tab
-        >
+<rux-tab id="tab1" ?disabled=${args.disabled} ?selected=${args.selected}
+    >Tab 1</rux-tab
+>
     `
 }
 
@@ -60,9 +60,9 @@ export const Disabled = (args) => {
 
 export const Selected = (args) => {
     return html`
-        <rux-tab id="tab1" .disabled=${args.disabled} .selected=${args.selected}
-            >Tab 1</rux-tab
-        >
+<rux-tab id="tab1" ?disabled=${args.disabled} ?selected=${args.selected}
+    >Tab 1</rux-tab
+>
     `
 }
 

--- a/packages/web-components/src/stories/table.stories.mdx
+++ b/packages/web-components/src/stories/table.stories.mdx
@@ -52,37 +52,37 @@ export const Default = (args) => {
         return item
     })
     return html`
-        <rux-table>
-            <rux-table-header>
-                <rux-table-header-row>
-                    ${columnData.map(
-                        (column) => html`
-                            <rux-table-header-cell
-                                >${column.headerName}</rux-table-header-cell
-                            >
-                        `
-                    )}
-                </rux-table-header-row>
-            </rux-table-header>
-            <rux-table-body>
-                ${rowData.map(
-                    (row) => html`
-                        <rux-table-row selected="${row.selected}">
-                            <rux-table-cell>${row.currentTag}</rux-table-cell>
-                            <rux-table-cell>${row.originalTag}</rux-table-cell>
-                            <rux-table-cell>${row.sensor}</rux-table-cell>
-                            <rux-table-cell>${row.astat}</rux-table-cell>
-                            <rux-table-cell>${row.obsTime}</rux-table-cell>
-                            <rux-table-cell>${row.obType}</rux-table-cell>
-                            <rux-table-cell>${row.azRtAsc}</rux-table-cell>
-                            <rux-table-cell>${row.elDec}</rux-table-cell>
-                            <rux-table-cell>${row.range}</rux-table-cell>
-                            <rux-table-cell>${row.rangeRate}</rux-table-cell>
-                        </rux-table-row>
-                    `
-                )}
-            </rux-table-body>
-        </rux-table>
+<rux-table>
+    <rux-table-header>
+        <rux-table-header-row>
+            ${columnData.map(
+                (column) => html`
+                    <rux-table-header-cell
+                        >${column.headerName}</rux-table-header-cell
+                    >
+                `
+            )}
+        </rux-table-header-row>
+    </rux-table-header>
+    <rux-table-body>
+        ${rowData.map(
+            (row) => html`
+                <rux-table-row selected="${row.selected}">
+                    <rux-table-cell>${row.currentTag}</rux-table-cell>
+                    <rux-table-cell>${row.originalTag}</rux-table-cell>
+                    <rux-table-cell>${row.sensor}</rux-table-cell>
+                    <rux-table-cell>${row.astat}</rux-table-cell>
+                    <rux-table-cell>${row.obsTime}</rux-table-cell>
+                    <rux-table-cell>${row.obType}</rux-table-cell>
+                    <rux-table-cell>${row.azRtAsc}</rux-table-cell>
+                    <rux-table-cell>${row.elDec}</rux-table-cell>
+                    <rux-table-cell>${row.range}</rux-table-cell>
+                    <rux-table-cell>${row.rangeRate}</rux-table-cell>
+                </rux-table-row>
+            `
+        )}
+    </rux-table-body>
+</rux-table>
     `
 }
 
@@ -153,57 +153,57 @@ export const WithSelectedRow = (args) => {
         return item
     })
     return html`
-        <rux-table>
-            <rux-table-header>
-                <rux-table-header-row>
-                    <rux-table-header-cell>Current Tag</rux-table-header-cell>
-                    <rux-table-header-cell>Original Tag</rux-table-header-cell>
-                    <rux-table-header-cell>Sensor</rux-table-header-cell>
-                    <rux-table-header-cell>ASTAT</rux-table-header-cell>
-                    <rux-table-header-cell>Obs time</rux-table-header-cell>
-                    <rux-table-header-cell>Ob type</rux-table-header-cell>
-                    <rux-table-header-cell>Az/Rt asc</rux-table-header-cell>
-                    <rux-table-header-cell>El/Dec</rux-table-header-cell>
-                    <rux-table-header-cell>Range</rux-table-header-cell>
-                    <rux-table-header-cell>Range rate</rux-table-header-cell>
-                </rux-table-header-row>
-            </rux-table-header>
-            <rux-table-body>
-                <rux-table-row>
-                    <rux-table-cell>19999999</rux-table-cell>
-                    <rux-table-cell>000011111</rux-table-cell>
-                    <rux-table-cell>450</rux-table-cell>
-                    <rux-table-cell>Full</rux-table-cell>
-                    <rux-table-cell>2020 158 01:23:45:678</rux-table-cell>
-                    <rux-table-cell>150</rux-table-cell>
-                    <rux-table-cell>3500</rux-table-cell>
-                    <rux-table-cell>7500</rux-table-cell>
-                    <rux-table-cell>100</rux-table-cell>
-                </rux-table-row>
-                <rux-table-row selected>
-                    <rux-table-cell>19999999</rux-table-cell>
-                    <rux-table-cell>000011111</rux-table-cell>
-                    <rux-table-cell>450</rux-table-cell>
-                    <rux-table-cell>Full</rux-table-cell>
-                    <rux-table-cell>2020 158 01:23:45:678</rux-table-cell>
-                    <rux-table-cell>150</rux-table-cell>
-                    <rux-table-cell>3500</rux-table-cell>
-                    <rux-table-cell>7500</rux-table-cell>
-                    <rux-table-cell>100</rux-table-cell>
-                </rux-table-row>
-                <rux-table-row>
-                    <rux-table-cell>19999999</rux-table-cell>
-                    <rux-table-cell>000011111</rux-table-cell>
-                    <rux-table-cell>450</rux-table-cell>
-                    <rux-table-cell>Full</rux-table-cell>
-                    <rux-table-cell>2020 158 01:23:45:678</rux-table-cell>
-                    <rux-table-cell>150</rux-table-cell>
-                    <rux-table-cell>3500</rux-table-cell>
-                    <rux-table-cell>7500</rux-table-cell>
-                    <rux-table-cell>100</rux-table-cell>
-                </rux-table-row>
-            </rux-table-body>
-        </rux-table>
+<rux-table>
+    <rux-table-header>
+        <rux-table-header-row>
+            <rux-table-header-cell>Current Tag</rux-table-header-cell>
+            <rux-table-header-cell>Original Tag</rux-table-header-cell>
+            <rux-table-header-cell>Sensor</rux-table-header-cell>
+            <rux-table-header-cell>ASTAT</rux-table-header-cell>
+            <rux-table-header-cell>Obs time</rux-table-header-cell>
+            <rux-table-header-cell>Ob type</rux-table-header-cell>
+            <rux-table-header-cell>Az/Rt asc</rux-table-header-cell>
+            <rux-table-header-cell>El/Dec</rux-table-header-cell>
+            <rux-table-header-cell>Range</rux-table-header-cell>
+            <rux-table-header-cell>Range rate</rux-table-header-cell>
+        </rux-table-header-row>
+    </rux-table-header>
+    <rux-table-body>
+        <rux-table-row>
+            <rux-table-cell>19999999</rux-table-cell>
+            <rux-table-cell>000011111</rux-table-cell>
+            <rux-table-cell>450</rux-table-cell>
+            <rux-table-cell>Full</rux-table-cell>
+            <rux-table-cell>2020 158 01:23:45:678</rux-table-cell>
+            <rux-table-cell>150</rux-table-cell>
+            <rux-table-cell>3500</rux-table-cell>
+            <rux-table-cell>7500</rux-table-cell>
+            <rux-table-cell>100</rux-table-cell>
+        </rux-table-row>
+        <rux-table-row selected>
+            <rux-table-cell>19999999</rux-table-cell>
+            <rux-table-cell>000011111</rux-table-cell>
+            <rux-table-cell>450</rux-table-cell>
+            <rux-table-cell>Full</rux-table-cell>
+            <rux-table-cell>2020 158 01:23:45:678</rux-table-cell>
+            <rux-table-cell>150</rux-table-cell>
+            <rux-table-cell>3500</rux-table-cell>
+            <rux-table-cell>7500</rux-table-cell>
+            <rux-table-cell>100</rux-table-cell>
+        </rux-table-row>
+        <rux-table-row>
+            <rux-table-cell>19999999</rux-table-cell>
+            <rux-table-cell>000011111</rux-table-cell>
+            <rux-table-cell>450</rux-table-cell>
+            <rux-table-cell>Full</rux-table-cell>
+            <rux-table-cell>2020 158 01:23:45:678</rux-table-cell>
+            <rux-table-cell>150</rux-table-cell>
+            <rux-table-cell>3500</rux-table-cell>
+            <rux-table-cell>7500</rux-table-cell>
+            <rux-table-cell>100</rux-table-cell>
+        </rux-table-row>
+    </rux-table-body>
+</rux-table>
     `
 }
 

--- a/packages/web-components/src/stories/tabs.stories.mdx
+++ b/packages/web-components/src/stories/tabs.stories.mdx
@@ -65,43 +65,43 @@ Astro UXDS Tab (child) properties are passed as simple attributes on the individ
 
 export const Default = (args) => {
     return html`
-        <style>
-            pre {
-                margin: 0;
-            }
-        </style>
-        <div style="display: flex; flex-flow: column;">
-            <rux-tabs ?small="${args.small}" id="tab-set-id-1">
-                <rux-tab id="tab-id-1">Tab 1</rux-tab>
-                <rux-tab id="tab-id-2">Tab 2</rux-tab>
-                <rux-tab ?disabled="${args.disabled}" id="tab-id-3"
-                    >Tab 3</rux-tab
-                >
-            </rux-tabs>
-            <rux-tab-panels aria-labelledby="tab-set-id-1">
-                <rux-tab-panel aria-labelledby="tab-id-1">
-                    <div
-                        style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; font-family: monospace;"
-                    >
-                        <pre><<span>!-- Tab 1 HTML content --</span>></pre>
-                    </div>
-                </rux-tab-panel>
-                <rux-tab-panel aria-labelledby="tab-id-2">
-                    <div
-                        style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; font-family: monospace;"
-                    >
-                        <pre><<span>!-- Tab 2 HTML content --</span>></pre>
-                    </div>
-                </rux-tab-panel>
-                <rux-tab-panel aria-labelledby="tab-id-3">
-                    <div
-                        style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; font-family: monospace;"
-                    >
-                        <pre><<span>!-- Tab 3 HTML content --</span>></pre>
-                    </div>
-                </rux-tab-panel>
-            </rux-tab-panels>
-        </div>
+<style>
+    pre {
+        margin: 0;
+    }
+</style>
+<div style="display: flex; flex-flow: column;">
+    <rux-tabs ?small="${args.small}" id="tab-set-id-1">
+        <rux-tab id="tab-id-1">Tab 1</rux-tab>
+        <rux-tab id="tab-id-2">Tab 2</rux-tab>
+        <rux-tab ?disabled="${args.disabled}" id="tab-id-3"
+            >Tab 3</rux-tab
+        >
+    </rux-tabs>
+    <rux-tab-panels aria-labelledby="tab-set-id-1">
+        <rux-tab-panel aria-labelledby="tab-id-1">
+            <div
+                style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; font-family: monospace;"
+            >
+                <pre><<span>!-- Tab 1 HTML content --</span>></pre>
+            </div>
+        </rux-tab-panel>
+        <rux-tab-panel aria-labelledby="tab-id-2">
+            <div
+                style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; font-family: monospace;"
+            >
+                <pre><<span>!-- Tab 2 HTML content --</span>></pre>
+            </div>
+        </rux-tab-panel>
+        <rux-tab-panel aria-labelledby="tab-id-3">
+            <div
+                style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; font-family: monospace;"
+            >
+                <pre><<span>!-- Tab 3 HTML content --</span>></pre>
+            </div>
+        </rux-tab-panel>
+    </rux-tab-panels>
+</div>
     `
 }
 
@@ -121,36 +121,36 @@ The small property may be passed as a simple attribute on the Astro UXDS Tabs co
 
 export const Small = (args) => {
     return html`
-        <div style="display: flex; flex-flow: column;">
-            <div
-                style="border: rgba(255,255,255, .25) dashed 1px; margin: 1vw 1vw 0; padding: 2px;"
-            >
-                <rux-tabs ?small="${args.small}" id="tab-set-id-2">
-                    <rux-tab id="tab-id-2-1">Tab 1</rux-tab>
-                    <rux-tab id="tab-id-2-2">Tab 2</rux-tab>
-                    <rux-tab id="tab-id-2-3" disabled
-                        >Tab 3 (disabled)
-                    </rux-tab>
-                </rux-tabs>
-                <rux-tab-panels aria-labelledby="tab-set-id-2">
-                    <rux-tab-panel aria-labelledby="tab-id-2-1">
-                        <pre
-                            style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; margin: 0;"
-                        ><<span>!-- Small tab 1 HTML content --</span>></pre>
-                    </rux-tab-panel>
-                    <rux-tab-panel aria-labelledby="tab-id-2-2">
-                        <pre
-                            style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; margin: 0;"
-                        ><<span>!-- Small tab 2 HTML content --</span>></pre>
-                    </rux-tab-panel>
-                    <rux-tab-panel aria-labelledby="tab-id-2-3">
-                        <pre
-                            style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; margin: 0;"
-                        ><<span>!-- Small tab 3 HTML content --</span>></pre>
-                    </rux-tab-panel>
-                </rux-tab-panels>
-            </div>
-        </div>
+<div style="display: flex; flex-flow: column;">
+    <div
+        style="border: rgba(255,255,255, .25) dashed 1px; margin: 1vw 1vw 0; padding: 2px;"
+    >
+        <rux-tabs ?small="${args.small}" id="tab-set-id-2">
+            <rux-tab id="tab-id-2-1">Tab 1</rux-tab>
+            <rux-tab id="tab-id-2-2">Tab 2</rux-tab>
+            <rux-tab id="tab-id-2-3" disabled
+                >Tab 3 (disabled)
+            </rux-tab>
+        </rux-tabs>
+        <rux-tab-panels aria-labelledby="tab-set-id-2">
+            <rux-tab-panel aria-labelledby="tab-id-2-1">
+                <pre
+                    style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; margin: 0;"
+                ><<span>!-- Small tab 1 HTML content --</span>></pre>
+            </rux-tab-panel>
+            <rux-tab-panel aria-labelledby="tab-id-2-2">
+                <pre
+                    style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; margin: 0;"
+                ><<span>!-- Small tab 2 HTML content --</span>></pre>
+            </rux-tab-panel>
+            <rux-tab-panel aria-labelledby="tab-id-2-3">
+                <pre
+                    style="padding: 1vw; border: rgba(255,255,255, .15) dashed 1px; margin: 0;"
+                ><<span>!-- Small tab 3 HTML content --</span>></pre>
+            </rux-tab-panel>
+        </rux-tab-panels>
+    </div>
+</div>
     `
 }
 

--- a/packages/web-components/src/stories/textarea.stories.mdx
+++ b/packages/web-components/src/stories/textarea.stories.mdx
@@ -25,20 +25,9 @@ import { html, render } from 'lit-html'
 
 export const Default = (args) => {
     return html`
-        <rux-textarea
-            .label="${args.label}"
-            .disabled="${args.disabled}"
-            .errorText="${args.errorText}"
-            .invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .min-length="${args.minLength}"
-            .maxLength="${args.maxLength}"
-            .rows="${args.rows}"
-            .name="${args.name}"
-            .placeholder="${args.placeholder}"
-            ?required="${args.required}"
-            .value="${args.value}"
-        ></rux-textarea>
+<rux-textarea
+    label="${args.label}"
+></rux-textarea>
     `
 }
 
@@ -63,20 +52,10 @@ export const Default = (args) => {
 
 export const Disabled = (args) => {
     return html`
-        <rux-textarea
-            .label="${args.label}"
-            .disabled="${args.disabled}"
-            .errorText="${args.errorText}"
-            .invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .minLength="${args.minLength}"
-            .maxLength="${args.maxLength}"
-            .rows="${args.rows}"
-            .name="${args.name}"
-            .placeholder="${args.placeholder}"
-            ?required="${args.required}"
-            .value="${args.value}"
-        ></rux-textarea>
+<rux-textarea
+    label="${args.label}"
+    disabled="${args.disabled}"
+></rux-textarea>
     `
 }
 
@@ -96,20 +75,11 @@ export const Disabled = (args) => {
 
 export const HelpText = (args) => {
     return html`
-        <rux-textarea
-            .label="${args.label}"
-            .disabled="${args.disabled}"
-            .errorText="${args.errorText}"
-            .invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .minLength="${args.minLength}"
-            .maxLength="${args.maxLength}"
-            .rows="${args.rows}"
-            .name="${args.name}"
-            .placeholder="${args.placeholder}"
-            ?required="${args.required}"
-            .value="${args.value}"
-        ></rux-textarea>
+<rux-textarea
+    label="${args.label}"
+    help-text="${args.helpText}"
+    type="${args.type}"
+></rux-textarea>
     `
 }
 
@@ -130,20 +100,11 @@ export const HelpText = (args) => {
 
 export const Invalid = (args) => {
     return html`
-        <rux-textarea
-            .label="${args.label}"
-            .disabled="${args.disabled}"
-            .errorText="${args.errorText}"
-            .invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .minLength="${args.minLength}"
-            .maxLength="${args.maxLength}"
-            .rows="${args.rows}"
-            .name="${args.name}"
-            .placeholder="${args.placeholder}"
-            ?required="${args.required}"
-            .value="${args.value}"
-        ></rux-textarea>
+<rux-textarea
+    label="${args.label}"
+    error-text="${args.errorText}"
+    invalid="${args.invalid}"
+></rux-textarea>
     `
 }
 
@@ -164,20 +125,10 @@ export const Invalid = (args) => {
 
 export const Placeholder = (args) => {
     return html`
-        <rux-textarea
-            .label="${args.label}"
-            .disabled="${args.disabled}"
-            .errorText="${args.errorText}"
-            .invalid="${args.invalid}"
-            .helpText="${args.helpText}"
-            .minLength="${args.minLength}"
-            .maxLength="${args.maxLength}"
-            .rows="${args.rows}"
-            .name="${args.name}"
-            .placeholder="${args.placeholder}"
-            ?required="${args.required}"
-            .value="${args.value}"
-        ></rux-textarea>
+<rux-textarea
+    label="${args.label}"
+    placeholder="${args.placeholder}"
+></rux-textarea>
     `
 }
 
@@ -210,20 +161,20 @@ rux-textarea::part(label) {
 
 export const HorizontalLabel = (args) => {
     return html`
-        <style>
-            #left-example::part(form-field) {
-                flex-direction: row;
-            }
-            #left-example::part(label) {
-                margin-right: var(--spacing-input-label-left);
-            }
-        </style>
-        <rux-textarea
-            id="left-example"
-            label="Label"
-            type="text"
-            placeholder="Text input"
-        ></rux-textarea>
+<style>
+    #left-example::part(form-field) {
+        flex-direction: row;
+    }
+    #left-example::part(label) {
+        margin-right: var(--spacing-input-label-left);
+    }
+</style>
+<rux-textarea
+    id="left-example"
+    label="Label"
+    type="text"
+    placeholder="Text input"
+></rux-textarea>
     `
 }
 

--- a/packages/web-components/src/stories/textarea.stories.mdx
+++ b/packages/web-components/src/stories/textarea.stories.mdx
@@ -27,6 +27,19 @@ export const Default = (args) => {
     return html`
 <rux-textarea
     label="${args.label}"
+    ?disabled="${args.disabled}"
+    .error-text="${args.errorText}"
+    .help-text="${args.helpText}"
+    ?invalid="${args.invalid}"
+    .max-length="${args.maxLength}"
+    .min-length="${args.minLength}"
+    .name="${args.name}"
+    .placeholder="${args.placeholder}"
+    ?required="${args.required}"
+    .rows="${args.rows}"
+    ?small="${args.small}"
+    .value="${args.value}"
+    type="${args.type}"
 ></rux-textarea>
     `
 }
@@ -36,6 +49,7 @@ export const Default = (args) => {
         name="Default"
         args={{
             label: 'Textarea label',
+            type: 'text'
         }}
     >
         {Default.bind()}
@@ -54,7 +68,19 @@ export const Disabled = (args) => {
     return html`
 <rux-textarea
     label="${args.label}"
-    disabled="${args.disabled}"
+    ?disabled="${args.disabled}"
+    .error-text="${args.errorText}"
+    .help-text="${args.helpText}"
+    ?invalid="${args.invalid}"
+    .max-length="${args.maxLength}"
+    .min-length="${args.minLength}"
+    .name="${args.name}"
+    .placeholder="${args.placeholder}"
+    ?required="${args.required}"
+    .rows="${args.rows}"
+    ?small="${args.small}"
+    .value="${args.value}"
+    .type="${args.type}"
 ></rux-textarea>
     `
 }
@@ -77,7 +103,18 @@ export const HelpText = (args) => {
     return html`
 <rux-textarea
     label="${args.label}"
+    ?disabled="${args.disabled}"
+    .error-text="${args.errorText}"
     help-text="${args.helpText}"
+    ?invalid="${args.invalid}"
+    .max-length="${args.maxLength}"
+    .min-length="${args.minLength}"
+    .name="${args.name}"
+    .placeholder="${args.placeholder}"
+    ?required="${args.required}"
+    .rows="${args.rows}"
+    ?small="${args.small}"
+    .value="${args.value}"
     type="${args.type}"
 ></rux-textarea>
     `
@@ -102,8 +139,19 @@ export const Invalid = (args) => {
     return html`
 <rux-textarea
     label="${args.label}"
+    ?disabled="${args.disabled}"
     error-text="${args.errorText}"
-    invalid="${args.invalid}"
+    .help-text="${args.helpText}"
+    ?invalid="${args.invalid}"
+    .max-length="${args.maxLength}"
+    .min-length="${args.minLength}"
+    .name="${args.name}"
+    .placeholder="${args.placeholder}"
+    ?required="${args.required}"
+    .rows="${args.rows}"
+    ?small="${args.small}"
+    .value="${args.value}"
+    type="${args.type}"
 ></rux-textarea>
     `
 }
@@ -115,6 +163,7 @@ export const Invalid = (args) => {
             invalid: true,
             errorText: 'Field is required',
             label: 'Textarea Field',
+            type: 'text'
         }}
     >
         {Invalid.bind()}
@@ -127,7 +176,19 @@ export const Placeholder = (args) => {
     return html`
 <rux-textarea
     label="${args.label}"
+    ?disabled="${args.disabled}"
+    .error-text="${args.errorText}"
+    .help-text="${args.helpText}"
+    ?invalid="${args.invalid}"
+    .max-length="${args.maxLength}"
+    .min-length="${args.minLength}"
+    .name="${args.name}"
     placeholder="${args.placeholder}"
+    ?required="${args.required}"
+    .rows="${args.rows}"
+    ?small="${args.small}"
+    .value="${args.value}"
+    type="${args.type}"
 ></rux-textarea>
     `
 }
@@ -138,6 +199,7 @@ export const Placeholder = (args) => {
         args={{
             label: 'Placeholder Text',
             placeholder: 'Placeholder',
+            type: 'text'
         }}
     >
         {Placeholder.bind()}

--- a/packages/web-components/src/stories/tree-node.stories.mdx
+++ b/packages/web-components/src/stories/tree-node.stories.mdx
@@ -23,19 +23,18 @@ Tree Node should be used with the [Tree](/?path=/story/components-tree--tree) co
 
 export const Default = (args) => {
     return html`
-        <rux-tree-node
-            ?selected="${args.selected}"
-            ?expanded="${args.expanded}"
-        >
-            Level 1
-            <rux-tree-node slot="node"> </rux-tree-node>
-        </rux-tree-node>
+<rux-tree-node
+    ?selected="${args.selected}"
+    ?expanded="${args.expanded}"
+>
+    Level 1
+    <rux-tree-node slot="node"></rux-tree-node>
+</rux-tree-node>
     `
 }
 
 <Canvas>
-    <Story
-        args={{ disabled: true }} // Set default args here
+    <Story // Set default args here
         name="Default"
     >
         {Default.bind()}
@@ -52,7 +51,7 @@ export const Default = (args) => {
 
 export const Selected = (args) => {
     return html`
-        <rux-tree-node ?selected="${args.selected}"> Level 1 </rux-tree-node>
+<rux-tree-node ?selected="${args.selected}"> Level 1 </rux-tree-node>
     `
 }
 
@@ -66,12 +65,13 @@ export const Selected = (args) => {
 
 export const Expanded = (args) => {
     return html`
-        <rux-tree-node
-            ?selected="${args.selected}"
-            ?expanded="${args.expanded}"
-        >
-            Level 1
-        </rux-tree-node>
+<rux-tree-node
+    ?selected="${args.selected}"
+    ?expanded="${args.expanded}"
+>
+    Level 1
+    <rux-tree-node slot="node"></rux-tree-node>
+</rux-tree-node>
     `
 }
 

--- a/packages/web-components/src/stories/tree.stories.mdx
+++ b/packages/web-components/src/stories/tree.stories.mdx
@@ -95,58 +95,58 @@ export const Default = (args) => {
         },
     ]
     return html`
-        <style>
-            .container {
-                padding: 1rem 10%;
-                display: flex;
-                justify-content: center;
-            }
-            rux-tree {
-                width: 18rem;
-                margin: 1rem;
-            }
-        </style>
-        <div class="container">
-            <rux-tree>
-                ${treeData.map(
-                    (node) => html`
-                        <rux-tree-node .expanded=${node.expanded}>
-                            ${node.label} ${node.children?.map(
-                                (child) => html`
-                                    <rux-tree-node
-                                        .expanded=${child.expanded}
-                                        .selected=${child.selected}
-                                        slot="node"
-                                    >
-                                        ${child.label} ${child.children?.map(
-                                            (grandchild) => html`
-                                                <rux-tree-node
-                                                    .expanded=${grandchild.expanded}
-                                                    .selected=${grandchild.selected}
-                                                    slot="node"
-                                                >
-                                                    ${grandchild.label} ${grandchild.children?.map(
-                                                        (grandchild) => html`
-                                                            <rux-tree-node
-                                                                .expanded=${grandchild.expanded}
-                                                                .selected=${grandchild.selected}
-                                                                slot="node"
-                                                            >
-                                                                ${grandchild.label}
-                                                            </rux-tree-node>
-                                                        `
-                                                    )}
-                                                </rux-tree-node>
-                                            `
-                                        )}
-                                    </rux-tree-node>
-                                `
-                            )}
-                        </rux-tree-node>
-                    `
-                )}
-            </rux-tree>
-        </div>
+<style>
+    .container {
+        padding: 1rem 10%;
+        display: flex;
+        justify-content: center;
+    }
+    rux-tree {
+        width: 18rem;
+        margin: 1rem;
+    }
+</style>
+<div class="container">
+    <rux-tree>
+        ${treeData.map(
+            (node) => html`
+                <rux-tree-node .expanded=${node.expanded}>
+                    ${node.label} ${node.children?.map(
+                        (child) => html`
+                            <rux-tree-node
+                                .expanded=${child.expanded}
+                                .selected=${child.selected}
+                                slot="node"
+                            >
+                                ${child.label} ${child.children?.map(
+                                    (grandchild) => html`
+                                        <rux-tree-node
+                                            .expanded=${grandchild.expanded}
+                                            .selected=${grandchild.selected}
+                                            slot="node"
+                                        >
+                                            ${grandchild.label} ${grandchild.children?.map(
+                                                (grandchild) => html`
+                                                    <rux-tree-node
+                                                        .expanded=${grandchild.expanded}
+                                                        .selected=${grandchild.selected}
+                                                        slot="node"
+                                                    >
+                                                        ${grandchild.label}
+                                                    </rux-tree-node>
+                                                `
+                                            )}
+                                        </rux-tree-node>
+                                    `
+                                )}
+                            </rux-tree-node>
+                        `
+                    )}
+                </rux-tree-node>
+            `
+        )}
+    </rux-tree>
+</div>
     `
 }
 
@@ -225,68 +225,68 @@ export const status = (args) => {
         },
     ]
     return html`
-        <style>
-            .container {
-                padding: 1rem 10%;
-                display: flex;
-                justify-content: center;
-            }
-            rux-tree {
-                width: 18rem;
-                margin: 1rem;
-            }
-        </style>
-        <div class="container">
-            <rux-tree>
-                ${treeData.map(
-                    (node) => html`
-                        <rux-tree-node>
-                            <rux-status status="${node.status}"></rux-status>
-                            ${node.label} ${node.children?.map(
-                                (child) => html`
-                                    <rux-tree-node
-                                        .expanded=${child.expanded}
-                                        .selected=${child.selected}
-                                        slot="node"
-                                    >
-                                        <rux-status
-                                            status="${child.status}"
-                                        ></rux-status>
-                                        ${child.label} ${child.children?.map(
-                                            (grandchild) => html`
-                                                <rux-tree-node
-                                                    .expanded=${grandchild.expanded}
-                                                    .selected=${grandchild.selected}
-                                                    slot="node"
-                                                >
-                                                    <rux-status
-                                                        status="${grandchild.status}"
-                                                    ></rux-status>
-                                                    ${grandchild.label} ${grandchild.children?.map(
-                                                        (grandchild) => html`
-                                                            <rux-tree-node
-                                                                .expanded=${grandchild.expanded}
-                                                                .selected=${grandchild.selected}
-                                                                slot="node"
-                                                            >
-                                                                <rux-status
-                                                                    status="${grandchild.status}"
-                                                                ></rux-status>
-                                                                ${grandchild.label}
-                                                            </rux-tree-node>
-                                                        `
-                                                    )}
-                                                </rux-tree-node>
-                                            `
-                                        )}
-                                    </rux-tree-node>
-                                `
-                            )}
-                        </rux-tree-node>
-                    `
-                )}
-            </rux-tree>
-        </div>
+<style>
+    .container {
+        padding: 1rem 10%;
+        display: flex;
+        justify-content: center;
+    }
+    rux-tree {
+        width: 18rem;
+        margin: 1rem;
+    }
+</style>
+<div class="container">
+    <rux-tree>
+        ${treeData.map(
+            (node) => html`
+                <rux-tree-node>
+                    <rux-status status="${node.status}"></rux-status>
+                    ${node.label} ${node.children?.map(
+                        (child) => html`
+                            <rux-tree-node
+                                .expanded=${child.expanded}
+                                .selected=${child.selected}
+                                slot="node"
+                            >
+                                <rux-status
+                                    status="${child.status}"
+                                ></rux-status>
+                                ${child.label} ${child.children?.map(
+                                    (grandchild) => html`
+                                        <rux-tree-node
+                                            .expanded=${grandchild.expanded}
+                                            .selected=${grandchild.selected}
+                                            slot="node"
+                                        >
+                                            <rux-status
+                                                status="${grandchild.status}"
+                                            ></rux-status>
+                                            ${grandchild.label} ${grandchild.children?.map(
+                                                (grandchild) => html`
+                                                    <rux-tree-node
+                                                        .expanded=${grandchild.expanded}
+                                                        .selected=${grandchild.selected}
+                                                        slot="node"
+                                                    >
+                                                        <rux-status
+                                                            status="${grandchild.status}"
+                                                        ></rux-status>
+                                                        ${grandchild.label}
+                                                    </rux-tree-node>
+                                                `
+                                            )}
+                                        </rux-tree-node>
+                                    `
+                                )}
+                            </rux-tree-node>
+                        `
+                    )}
+                </rux-tree-node>
+            `
+        )}
+    </rux-tree>
+</div>
     `
 }
 


### PR DESCRIPTION
## Brief Description

Fixes inconsistencies in code example blocks in Storybook. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2755

Pop up ellipsis change: https://rocketcom.atlassian.net/browse/ASTRO-2765

## Related Issue

## General Notes

Significant changes: 
- Tree node expanded variant now shows the expanded caret 
- Changed menu item text in pop up examples to have an action item with an ellipsis 

## Motivation and Context

Fixes code examples being incorrect/incomplete in storybook.

## Issues and Limitations

There is still the issue of boolean props showing up in the code examples as `disabled=""` which isn't ideal. This may be something we have to put an issue in with Storybook.

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
