### PR TITLE
chore(react): turned off source maps due to warning in react

### DIFF
--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -15,7 +15,7 @@
     "noUnusedParameters": true,
     "outDir": "dist",
     "removeComments": false,
-    "sourceMap": true,
+    "sourceMap": false,
     "jsx": "react",
     "target": "es2015"
   },


### PR DESCRIPTION
## Brief Description

Sets `source-maps: false` in the `ts.config` of `/react` due to the source maps not working properly and producing a warning.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2777

## Related Issue

## General Notes

## Motivation and Context

Gets rid of a massive error when using `@astrouxds/react` 

## Issues and Limitations

Source maps are now disabled 

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
