### PR TITLE
fix(switch): Fix label prop on Switch component not working in Storyb…

### DIFF
--- a/.changeset/three-readers-wave.md
+++ b/.changeset/three-readers-wave.md
@@ -1,9 +1,0 @@
----
-"@astrouxds/astro-web-components": minor
-"@astrouxds/ag-grid-theme": minor
-"@astrouxds/angular": minor
-"astro-website": minor
-"@astrouxds/react": minor
----
-
-Fixed label prop on Switch component not working in Storybook canvas

--- a/.changeset/three-readers-wave.md
+++ b/.changeset/three-readers-wave.md
@@ -1,0 +1,9 @@
+---
+"@astrouxds/astro-web-components": minor
+"@astrouxds/ag-grid-theme": minor
+"@astrouxds/angular": minor
+"astro-website": minor
+"@astrouxds/react": minor
+---
+
+Fixed label prop on Switch component not working in Storybook canvas

--- a/packages/web-components/src/stories/switch.stories.mdx
+++ b/packages/web-components/src/stories/switch.stories.mdx
@@ -31,6 +31,7 @@ export const Switch = (args) => {
     <rux-switch
         ?disabled=${args.disabled}
         ?checked=${args.checked}
+        label=${args.label}
     ></rux-switch>
 </div>
     `


### PR DESCRIPTION
## Brief Description

Fixed Switch component's label not rendering correct in Storybook canvas

## JIRA Link

[(https://rocketcom.atlassian.net/browse/ASTRO-2772)]

## Related Issue

## General Notes

## Motivation and Context

Currently broken on live site so needs to be completed for best experience for users

## Issues and Limitations

## Types of changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
