### PR TITLE
fix(pop-up-menu): set docs to use iframe in sb to fix modal positioni…

### DIFF
--- a/packages/web-components/src/stories/popup.stories.mdx
+++ b/packages/web-components/src/stories/popup.stories.mdx
@@ -19,6 +19,9 @@ import { html, render } from 'lit-html'
                 'ruxmenuwillopen rux-pop-up-menu',
             ],
         },
+        docs: {
+            inlineStories: false,
+        },
     }}
 />
 


### PR DESCRIPTION


## Brief Description

The positioning of the modal on Storybook's docs tab is messed up

## JIRA Link

[ASTRO-2756](https://rocketcom.atlassian.net/jira/software/c/projects/ASTRO/issues/ASTRO-2756)

## Related Issue

## General Notes

## Motivation and Context

## Issues and Limitations

## Types of changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
