### PR TITLE
fix(clock): Astro 2871 3-digit julien date

### DIFF
--- a/.changeset/silver-radios-visit.md
+++ b/.changeset/silver-radios-visit.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": minor
+"@astrouxds/angular": minor
+"astro-website": minor
+"@astrouxds/react": minor
+---
+
+rux-clock now displays the julien date as always 3 digits

--- a/packages/web-components/src/components/rux-clock/rux-clock.tsx
+++ b/packages/web-components/src/components/rux-clock/rux-clock.tsx
@@ -26,7 +26,7 @@ export class RuxClock {
     private tzFormat: string = 'z'
     private convertedAos?: string
     private convertedLos?: string
-    private dayOfYearStr: string = this.dayOfYear.toString()
+    private dayOfYearStr!: string
 
     @State() _time!: string
     /**

--- a/packages/web-components/src/components/rux-clock/rux-clock.tsx
+++ b/packages/web-components/src/components/rux-clock/rux-clock.tsx
@@ -26,7 +26,6 @@ export class RuxClock {
     private tzFormat: string = 'z'
     private convertedAos?: string
     private convertedLos?: string
-    private dayOfYearStr!: string
 
     @State() _time!: string
     /**
@@ -131,7 +130,6 @@ export class RuxClock {
         const localDate = new Date(Date.now())
         const clockDate = utcToZonedTime(localDate, this._timezone)
         this.dayOfYear = getDayOfYear(clockDate)
-        this.dayOfYearStr = this.dayOfYear.toString()
     }
 
     /**
@@ -169,7 +167,7 @@ export class RuxClock {
                             aria-labelledby="rux-clock__day-of-year-label"
                             part="date"
                         >
-                            {this.dayOfYearStr.padStart(3, '0')}
+                            {this.dayOfYear.toString().padStart(3, '0')}
                         </div>
                         {!this.hideLabels && (
                             <div

--- a/packages/web-components/src/components/rux-clock/rux-clock.tsx
+++ b/packages/web-components/src/components/rux-clock/rux-clock.tsx
@@ -26,6 +26,7 @@ export class RuxClock {
     private tzFormat: string = 'z'
     private convertedAos?: string
     private convertedLos?: string
+    private dayOfYearStr: string = this.dayOfYear.toString()
 
     @State() _time!: string
     /**
@@ -130,6 +131,7 @@ export class RuxClock {
         const localDate = new Date(Date.now())
         const clockDate = utcToZonedTime(localDate, this._timezone)
         this.dayOfYear = getDayOfYear(clockDate)
+        this.dayOfYearStr = this.dayOfYear.toString()
     }
 
     /**
@@ -167,7 +169,7 @@ export class RuxClock {
                             aria-labelledby="rux-clock__day-of-year-label"
                             part="date"
                         >
-                            {this.dayOfYear}
+                            {this.dayOfYearStr.padStart(3, '0')}
                         </div>
                         {!this.hideLabels && (
                             <div

--- a/packages/web-components/src/components/rux-clock/test/__snapshots__/rux-clock.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-clock/test/__snapshots__/rux-clock.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`rux-clock converts all military timezones 1`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -28,7 +28,7 @@ exports[`rux-clock converts all military timezones 2`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -51,7 +51,7 @@ exports[`rux-clock converts all military timezones 3`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -74,7 +74,7 @@ exports[`rux-clock converts all military timezones 4`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -97,7 +97,7 @@ exports[`rux-clock converts all military timezones 5`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -120,7 +120,7 @@ exports[`rux-clock converts all military timezones 6`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -143,7 +143,7 @@ exports[`rux-clock converts all military timezones 7`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -166,7 +166,7 @@ exports[`rux-clock converts all military timezones 8`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -189,7 +189,7 @@ exports[`rux-clock converts all military timezones 9`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -212,7 +212,7 @@ exports[`rux-clock converts all military timezones 10`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -235,7 +235,7 @@ exports[`rux-clock converts all military timezones 11`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -258,7 +258,7 @@ exports[`rux-clock converts all military timezones 12`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -281,7 +281,7 @@ exports[`rux-clock converts all military timezones 13`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -557,7 +557,7 @@ exports[`rux-clock converts all military timezones 25`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -580,7 +580,7 @@ exports[`rux-clock converts aos/los unix timestamps when timezone is changed 1`]
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -681,7 +681,7 @@ exports[`rux-clock converts time to timezone on the fly 1`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -742,7 +742,7 @@ exports[`rux-clock hides the labels 1`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
     </div>
     <div class="rux-clock__segment">
@@ -759,7 +759,7 @@ exports[`rux-clock hides the timezone 1`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -782,7 +782,7 @@ exports[`rux-clock shows and updates aos 1`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -813,7 +813,7 @@ exports[`rux-clock shows and updates aos 2`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -844,7 +844,7 @@ exports[`rux-clock shows and updates los 1`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -875,7 +875,7 @@ exports[`rux-clock shows and updates los 2`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date
@@ -906,7 +906,7 @@ exports[`rux-clock shows the current time 1`] = `
   <mock:shadow-root>
     <div class="rux-clock__segment">
       <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        1
+        001
       </div>
       <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
         Date


### PR DESCRIPTION
## Brief Description
Date now displays ` {this.dayOfYear.toString().padStart(3, '0')}` so that the julien date is always 3 digits, padded with leading zeros. 
Updated snapshots.

A following PR will be made with the same change to the lit repo. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2871

## Related Issue

https://github.com/RocketCommunicationsInc/astro-components/issues/186

## General Notes

## Motivation and Context

Fixes julien date in rux-clock to always be 3 digits. 

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
