### PR TITLE
style(class-markings): removed line-height from tag, updated padding

### DIFF
--- a/.changeset/cuddly-lemons-behave.md
+++ b/.changeset/cuddly-lemons-behave.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Updated the overall height of classification-tags to match Figma designs. Overall height has gone from 20px -> 22px

--- a/packages/web-components/src/components/rux-classification-marking/rux-classification-marking.scss
+++ b/packages/web-components/src/components/rux-classification-marking/rux-classification-marking.scss
@@ -49,8 +49,7 @@
 
 .rux-classification--tag {
     width: fit-content;
-    line-height: 1;
-    padding: 0.25rem 0.9375rem;
+    padding: 0.1875rem 0.625rem;
     border-radius: var(--radius-base);
     font-family: var(--font-body-2-bold-font-family);
     font-size: var(--font-body-2-bold-font-size);


### PR DESCRIPTION
## Brief Description

Small changes that came out of the audit. 
Updated tag padding to be 10px 3px (in rem's tho) and removed line-height in order to get the height correct (is 22px in figma)

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2924

## Related Issue

## General Notes

## Motivation and Context

Found during audit

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
