### PR TITLE
style(button): added hover color to secondary text, slotted icon styling

### DIFF
--- a/.changeset/old-buckets-teach.md
+++ b/.changeset/old-buckets-teach.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Secondary button now has the correct text color on hover.

--- a/packages/web-components/src/components/rux-button/rux-button.scss
+++ b/packages/web-components/src/components/rux-button/rux-button.scss
@@ -41,6 +41,11 @@
     --button-secondary-text-color: var(--color-primary);
 
     /**
+    * @prop --button-secondary-hover-text-color: Secondary button hover text color
+    */
+    --button-secondary-hover-text-color: var(--color-hover);
+
+    /**
      * @prop --button-secondary-background-color: Button secondary background color
      */
     --button-secondary-background-color: transparent;
@@ -141,14 +146,23 @@
         border: 1px solid var(--button-secondary-border-color);
 
         &:hover:not([disabled]) {
-            color: var(--button-secondary-text-color);
+            color: var(--button-secondary-hover-text-color);
             background-color: var(--button-secondary-hover-background-color);
             border-color: var(--button-secondary-hover-border-color);
+            rux-icon,
+            ::slotted(rux-icon) {
+                color: var(--button-secondary-hover-text-color);
+            }
         }
 
         &:active:not([disabled]) {
             border-color: var(--button-secondary-border-color);
             background-color: var(--button-secondary-background-color);
+            color: var(--button-secondary-text-color);
+            rux-icon,
+            ::slotted(rux-icon) {
+                color: var(--button-secondary-text-color);
+            }
         }
         rux-icon,
         ::slotted(rux-icon) {
@@ -162,13 +176,15 @@
         &:hover:not([disabled]) {
             color: var(--button-borderless-hover-color);
             background: none;
-            rux-icon {
+            rux-icon,
+            ::slotted(rux-icon) {
                 color: var(--button-borderless-hover-color);
             }
         }
         &:active:not([disabled]) {
             color: var(--button-borderless-color);
-            rux-icon {
+            rux-icon,
+            ::slotted(rux-icon) {
                 color: var(--button-borderless-color);
             }
         }


### PR DESCRIPTION
## Brief Description

Updates secondary button to have correct text color on hover and when pressed. 
Adds `::slotted(rux-icon)` to instances of `rux-icon` styling to ensure correct colors. 

## JIRA Link
https://rocketcom.atlassian.net/browse/ASTRO-2984

## Related Issue

## General Notes

Regressions failed where expected and have since had the references updated with the new additions. 

## Motivation and Context

Secondary button now matches figma.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
