### PR TITLE
Astro 2914 clock variants

### DIFF
--- a/.changeset/cool-bananas-impress.md
+++ b/.changeset/cool-bananas-impress.md
@@ -5,4 +5,4 @@
 "@astrouxds/react": patch
 ---
 
-Added other variants story to rux-clock, updated margin-left on AOS from 16px to 17px.
+Updated margin-left on AOS from 16px to 17px.

--- a/.changeset/cool-bananas-impress.md
+++ b/.changeset/cool-bananas-impress.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Added other variants story to rux-clock, updated margin-left on AOS from 16px to 17px.

--- a/packages/web-components/src/components/rux-clock/rux-clock.scss
+++ b/packages/web-components/src/components/rux-clock/rux-clock.scss
@@ -77,5 +77,5 @@
 }
 
 .rux-clock__aos {
-    margin-left: 1em;
+    margin-left: 1.063em;
 }

--- a/packages/web-components/src/stories/clock.stories.mdx
+++ b/packages/web-components/src/stories/clock.stories.mdx
@@ -108,6 +108,49 @@ export const Small = (args) => {
     </Story>
 </Canvas>
 
+### All Variants
+
+export const AllVariants = () => {
+    return html`
+    <style>
+        .clock-list {
+            list-style-type: none;
+            margin: 0 1rem 1rem 0;
+            display: flex;
+            flex-flow: column;
+        }
+        .clock-list li {
+            padding-bottom: 2rem;
+        }
+        span {
+            margin: 0 0 1rem 1rem;
+        }
+    </style>
+    <div
+    style="padding: 8vh 2vw; display: flex; flex-flow: row wrap; justify-content: space-evenly;"
+>
+    <ul class="clock-list">
+            <span>Hide Date</span>
+        <li>
+            <rux-clock hide-date></rux-clock>
+        </li>
+            <span>Hide Labels</span>
+        <li>
+            <rux-clock hide-labels></rux-clock>
+        </li>
+            <span>Hide Timezone</span>
+        <li>
+            <rux-clock hide-timezone></rux-clock>
+        </li>
+    </ul>
+</div>
+`
+}
+
+<Canvas>
+    <Story name="All Variants">{AllVariants.bind()}</Story>
+</Canvas>
+
 ## Military Timezones
 
 Clock's timezone parameter can accept any military timezone.

--- a/packages/web-components/src/stories/clock.stories.mdx
+++ b/packages/web-components/src/stories/clock.stories.mdx
@@ -108,9 +108,9 @@ export const Small = (args) => {
     </Story>
 </Canvas>
 
-### All Variants
+### Other Variants
 
-export const AllVariants = () => {
+export const OtherVariants = () => {
     return html`
     <style>
         .clock-list {
@@ -148,7 +148,7 @@ export const AllVariants = () => {
 }
 
 <Canvas>
-    <Story name="All Variants">{AllVariants.bind()}</Story>
+    <Story name="Other Variants">{OtherVariants.bind()}</Story>
 </Canvas>
 
 ## Military Timezones


### PR DESCRIPTION
## Brief Description

Adds an `Other Variants` story to clock that shows the remaining controls/props (hide-labels, hide-date, and hide-timezone). 
Bumps the margin-left on AOS from 16px to 17px as per Figma 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2914

## Related Issue

## General Notes

## Motivation and Context

All clock variants are now represented, clock better matches design.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
