### PR TITLE
Astro 2934 gsb docs update

### DIFF
--- a/packages/web-components/src/components/rux-global-status-bar/readme.md
+++ b/packages/web-components/src/components/rux-global-status-bar/readme.md
@@ -131,7 +131,6 @@ There is one unnamed slot in the Global Status Bar. This slot is intended for an
 | `"app-meta"`   | Used to display the Application's metadata (Domain, Name, State, Version, etc.) |
 | `"left-side"`  | Used to prepend a RuxIcon or similar element                                    |
 | `"right-side"` | Used to append optional content                                                 |
-| `"username"`   | Used to display the username                                                    |
 
 
 ## Shadow Parts

--- a/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.tsx
+++ b/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.tsx
@@ -6,7 +6,6 @@ import { AppMeta } from './appMeta/appMeta'
  * @slot left-side - Used to prepend a RuxIcon or similar element
  * @slot app-meta - Used to display the Application's metadata (Domain, Name, State, Version, etc.)
  * @slot right-side - Used to append optional content
- * @slot username - Used to display the username
  *
  * @part app-state - The container for the applications state
  * @part container - The container for global-status-bar


### PR DESCRIPTION
## Brief Description

username was listed as a slot, is not a slot, no longer listed as slot, slot has gone away. slot.

won't need a changeset.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2934

## Related Issue

## General Notes

## Motivation and Context

came from audit

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
