### PR TITLE
Astro 2993 remove commitlint

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,22 +24,3 @@ jobs:
 
       - name: Test
         run: npm run test
-
-  commit-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.1
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node
-        uses: actions/setup-node@v2.3.0
-        with:
-          node-version: "16"
-
-      - name: Install Modules
-        run: npm i
-
-      - name: Commit Lint
-        run: npx commitlint --from HEAD~${{ github.event.pull_request.commits }}

--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "private": true,
   "devDependencies": {
     "@changesets/cli": "^2.19.0",
-    "@commitlint/cli": "^13.1.0",
-    "@commitlint/config-conventional": "^13.1.0",
     "husky": "^7.0.2",
     "lerna": "^4.0.0",
     "prettier": "~2.2.1",


### PR DESCRIPTION
## Brief Description

Removes commitlint from the repo. 
We should still follow conventional commits, but commit lint was just too much. The beast has been silenced. 

## JIRA Link
https://rocketcom.atlassian.net/browse/ASTRO-2993

## Related Issue

## General Notes

## Motivation and Context

Pain and anger release.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
