### PR TITLE
docs(gsb): added an other variants story

### DIFF
--- a/packages/web-components/src/stories/global-status-bar.stories.mdx
+++ b/packages/web-components/src/stories/global-status-bar.stories.mdx
@@ -198,6 +198,72 @@ export const GlobalStatusBarWithTabs = (args) => {
     </Story>
 </Canvas>
 
+### Other Variants
+
+export const OtherVariants = () => {
+    return html`
+<style>
+h4 {
+    text-align: center;
+}
+</style>
+<h4>No Icon</h4>
+<div style="display: flex; justify-content: center;">
+    <rux-global-status-bar
+        app-state="Production"
+        username="Username"
+        app-name="Dashboard"
+        app-domain="Astro"
+        app-version="4.0 Alpha"
+    >
+    </rux-global-status-bar>
+</div>
+<br />
+<h4>No App Name</h4>
+<div style="display: flex; justify-content: center;">
+    <rux-global-status-bar
+        include-icon
+        app-domain="astro"
+        menu-icon="apps"
+        username="Username"
+        app-state="Production"
+        app-version="4.0 Alpha"
+    >
+    </rux-global-status-bar>
+</div>
+<br />
+<h4>No App Domain</h4>
+<div style="display: flex; justify-content: center;">
+    <rux-global-status-bar
+        include-icon
+        menu-icon="apps"
+        username="Username"
+        app-state="Production"
+        app-version="4.0 Alpha"
+        app-name="Dashboard"
+    >
+    </rux-global-status-bar>
+</div>
+<br />
+<h4>No App Version</h4>
+<div style="display: flex; justify-content: center;">
+    <rux-global-status-bar
+        include-icon
+        menu-icon="apps"
+        username="Username"
+        app-state="Production"
+        app-name="Dashboard"
+        app-domain="Astro"
+    >
+    </rux-global-status-bar>
+</div>
+`
+}
+
+<Canvas>
+    <Story name="Other Variants">{OtherVariants.bind()}</Story>
+</Canvas>
+
 ## Cherry Picking
 
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:


### PR DESCRIPTION
## Brief Description

Adds an 'Other Variants' page to the global-status-bar's story. The variants were chosen by props that didn't appear off/on in the other stories. Let me know if you want more/different variants. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2959

## Related Issue

## General Notes

## Motivation and Context

Came from dev -> design audit 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
