### PR TITLE
Astro 2967 progress padding

### DIFF
--- a/packages/web-components/src/components/rux-progress/rux-progress.scss
+++ b/packages/web-components/src/components/rux-progress/rux-progress.scss
@@ -43,10 +43,14 @@
     --progress-label-color: var(--color-default-text);
 
     position: relative;
+    display: inline-block;
+    padding: 1.25rem; //20px
+}
+:host([value]) {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0.075rem 0;
+    padding: 0.125rem; //2px
 }
 
 :host([hidden]) {
@@ -95,8 +99,6 @@
     text-align: right;
     color: var(--progress-label-color);
 }
-
-/* Indeterminate */
 .rux-progress:indeterminate {
     -webkit-appearance: none;
     position: relative;

--- a/packages/web-components/src/global/tokens/_tokens.scss
+++ b/packages/web-components/src/global/tokens/_tokens.scss
@@ -6,7 +6,7 @@
 :root {
     --indeterminate-progress-radius-outer: 30px;
     --indeterminate-progress-radius-inner: 23px;
-    --progress-radius-outer: 9px;
+    --progress-radius-outer: 10px;
     --progress-radius-inner: 8px;
     --scrollbar-radius: 4px;
     --switch-radius-track: 4.7px;

--- a/packages/web-components/src/stories/progress.stories.mdx
+++ b/packages/web-components/src/stories/progress.stories.mdx
@@ -108,15 +108,30 @@ export const DeterminateProgressCustomMax = (args) => {
 export const IndeterminateProgress = (args) => html`
 <div style="margin: 3rem auto; max-width: 5rem; text-align: center;">
     <rux-progress
-        .value="${args.value}"
-        .max=${args.max}
-        ?hide-label="${args.hideLabel}"
     ></rux-progress>
 </div>
 `
 
 <Canvas>
-    <Story name="Indeterminate Progress">{IndeterminateProgress.bind()}</Story>
+    <Story name="Indeterminate Progress" 
+    argTypes={{
+        value: { 
+            table: {
+                disable: true 
+            },
+        },
+        max: {
+            table: {
+                disable: true
+            },
+        },
+        hideLabel: {
+            table: {
+                disable: true
+            }
+        }
+    }}
+    >{IndeterminateProgress.bind()}</Story>
 </Canvas>
 
 ### Cherry Picking


### PR DESCRIPTION
## Brief Description

Updates the display of progress depending on if it's indeterminate - (flex for regular, inline-block for spinner)
Updates padding on spinner to be 20px all around as it is in Figma
Updates padding of progress bar to 2px all around as it is in Figma
Removes controls from spinner story, as they aren't necessary. 

Figma has 
```
Radius
- The progress background is a fixed radius of 10 px.
- THe progress foreground is a fixed radius of 8 px. 
```
In dev we have tokens for: 
```
--progress-radius-outer: 9px;
    --progress-radius-inner: 8px;
```
This is a change that we can wait on for tokens to be refreshed, I think .

I ran regressions, and since the padding changed to 2px on all progress bars, they all failed. They're just a pixel off by the looks of it. I will update regressions once this is approved.

## JIRA Link
padding - https://rocketcom.atlassian.net/browse/ASTRO-2967
controls - https://rocketcom.atlassian.net/browse/ASTRO-2968
## Related Issue

## General Notes

## Motivation and Context

Design -> dev audit 

## Issues and Limitations
Radius tokens don't match
## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
