### PR TITLE
style(status): updated size to match figma, updated bg positions

### DIFF
--- a/.changeset/ten-panthers-provide.md
+++ b/.changeset/ten-panthers-provide.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Changed the overall size of rux-status symbol to be 12px.

--- a/packages/web-components/src/components/rux-status/rux-status.scss
+++ b/packages/web-components/src/components/rux-status/rux-status.scss
@@ -1,11 +1,11 @@
 :host {
     display: block;
-    height: 1rem;
-    width: 1rem;
+    height: 0.75rem;
+    width: 0.75rem;
     margin: 0.125rem;
     background-size: cover;
     background-repeat: no-repeat;
-    background-position-x: 1rem;
+    background-position-x: 0.75rem;
     background-image: var(
         --status-symbols,
         url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAAAgCAMAAABzRoe3AAAAgVBMVEUAAAD/tQv/swL/OTn/PDzftl9W8QBW8AAtzP8v0P9Z9gD/tAP/uQb/tAItzf8tzf+eqK2ep60uzP9X8QCfqK4uzf8uzf9X8QAuzP9X8ACeqK4vzP9Y8QAuzv9Y8gCeqq4wz/8xzv9A1f9Y8QD/tAP86DpW8AD/swL/ODgtzP+ep63tgXPUAAAAJXRSTlMAGNfAQAv98/IdG8Io52zz8+DZ2dC9trabm4F+a05OQjAaDG6dAJcYcwAAAfdJREFUWMPtmNlygkAQRScyrBp3QTZFNBj8/w9MCGI3dBOHMg9jyvOmVFnn1HUSULx4LibjN/HMTN7Po2cu+PY/cwUfPYg2XhKsbHsVJJ5gcaf+cjZb+lN3qJjxyWIw/lAwNMALreKKFTIJh215Y3sYFiD5AEn9oWBowM4uEPau65A6JcJJ/2ACg/pDwdCAo1W0sI6ixbTsMH18Akn9oWBgwK7xh4LWBmlJSB+dwCD+pEA5wLMLgo3OwcGpvzhxludZfH1Bz4EZrefzdWSqTSCJPylQDggLhhA+oD6/G7d+5W7qk9yV3C8uPyz2KhMYxJ8UKAd4Fhdg3SZwa3/4wLrA7fhfbuwVJpDEnxQoByQFS9I6wQ7ydR16js0FBCzMuxMY1J8WqAYEfEDQXPcr3RjbxNU7vsBEF0R0dwJJ/LkCxYAVH7Bqri8r3QzbZNU7S4FZ44B1/ymgA4zPfZwUA2w+wG6uzyrdHMvk1TszgZnjgLmgyL4T8Dbq8R+bWgUIgw4ABby/Vl8hIckAUMD7a3WIYQIYgC0Af73+jOIJpKAF1F+vf2QwAQxAC7C/ZrcSeAIpegvAX7ObOZgABiAF2F+322mYAAagBeCv2wMNTEAGIAWVv3aPlDABDMAW1P7aPdQjDBiALaj89ftZBSGl+LXgZIoXL/4VXyptNwzuHR/QAAAAAElFTkSuQmCC')
@@ -22,24 +22,27 @@
     box-sizing: border-box;
 }
 
+//scale background-position-x for the new base of 12 px
+// ie, -5 rem would be -60px, find new rem for that
+
 :host([status='off']) {
-    background-position-x: -5rem;
+    background-position-x: -3.75rem;
 }
 
 :host([status='standby']) {
-    background-position-x: -4rem;
-}
-
-:host([status='normal']) {
     background-position-x: -3rem;
 }
 
+:host([status='normal']) {
+    background-position-x: -2.25rem;
+}
+
 :host([status='caution']) {
-    background-position-x: -2rem;
+    background-position-x: -1.5rem;
 }
 
 :host([status='serious']) {
-    background-position-x: -1rem;
+    background-position-x: -0.75rem;
 }
 
 :host([status='critical']) {


### PR DESCRIPTION
## Brief Description

Changes the height and width of rux-status to be 12 px like figma (down from 1rem) 
Also updates the background positions style to match the new 12px base. 


## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2961

## Related Issue

## General Notes

## Motivation and Context

Dev -> Design audit
## Issues and Limitations

If you change the height/width of a rux-status, you'll have some bleed through of the other statuses since we're just changing the background image position of a single image. This was the case with the 1rem based size rux-status as well, so if we want this to be changed we should move to having each status symbol be a separate svg.

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
