### PR TITLE
Astro 2956 monitoring icon

### DIFF
--- a/.changeset/tasty-spiders-check.md
+++ b/.changeset/tasty-spiders-check.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Updates the min height and width on rux-monitiong-icon to match design.

--- a/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
+++ b/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
@@ -1,7 +1,8 @@
 :host {
     display: inline-block;
     padding: 0;
-    margin-top: 1.125rem;
+    min-height: 5.188rem; //83px;
+    min-width: 4.938rem; //79px;
 }
 
 :host([hidden]) {

--- a/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
+++ b/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
@@ -1,6 +1,7 @@
 :host {
     display: inline-block;
     padding: 0;
+    margin-top: 1.125rem;
 }
 
 :host([hidden]) {


### PR DESCRIPTION
## Brief Description

Updates the min height/width as per figma design.
Regressions fail due to the status icon size change previously implemented. Ticket out to update the critical size status icon when we get the svg's.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2956

## Related Issue

## General Notes

## Motivation and Context

Dev -> Design audit

## Issues and Limitations



## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
