### PR TITLE
Astro 3115 switch checked

### DIFF
--- a/packages/web-components/src/components/rux-switch/readme.md
+++ b/packages/web-components/src/components/rux-switch/readme.md
@@ -44,6 +44,9 @@ Pass properties as attributes of the Astro Switch custom element:
 <rux-switch disabled="false" checked="false"></rux-switch>
 ```
 
+### 4. Listening for Events
+
+In order to get the correct value of rux-switch's `checked` attribute, use the event listener `ruxchange`. 
 ### Properties
 
 | Property   | Type    | Default | Required | Description                                                                                                                                                                                 |

--- a/packages/web-components/src/components/rux-switch/rux-switch.scss
+++ b/packages/web-components/src/components/rux-switch/rux-switch.scss
@@ -32,6 +32,7 @@
     display: flex;
     height: 22px;
     width: 42px;
+    white-space: nowrap;
 
     // Default Styling
     &__button {


### PR DESCRIPTION
## Brief Description

Adds `white-space: nowrap` to rux-switch in order for labels with spaces to be rendered correctly.
Adds a `Listening to events` blurb in the readme that mentions using the ruxchange event to listen for the value of switch's `checked` attribute.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-3112 -> label spaces
https://rocketcom.atlassian.net/browse/ASTRO-3115 -> checked issue

## Related Issue

## General Notes

onClick is not the correct event to listen for since it fires twice - ruxchange contains the correct checked value. Listening to onclick was the reason the checked value seemed backwards. 

## Motivation and Context

Label can now use spaces, docs updated to accommodate correct event listening 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
