### PR TITLE
feat(rux-select): add multiple support

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -12262,6 +12262,10 @@ export namespace Components {
          */
         "labelId"?: string;
         /**
+          * Enables multiselect
+         */
+        "multiple": boolean;
+        /**
           * Sets the Name of the Input Element
          */
         "name": string;
@@ -12270,9 +12274,9 @@ export namespace Components {
          */
         "required": boolean;
         /**
-          * The value of the selected option
+          * The value of the selected option. If multiple is true, this is an array.
          */
-        "value"?: string;
+        "value"?: string | string[];
     }
     interface RuxSlider {
         /**
@@ -32456,6 +32460,10 @@ declare namespace LocalJSX {
          */
         "labelId"?: string;
         /**
+          * Enables multiselect
+         */
+        "multiple"?: boolean;
+        /**
           * Sets the Name of the Input Element
          */
         "name"?: string;
@@ -32472,9 +32480,9 @@ declare namespace LocalJSX {
          */
         "required"?: boolean;
         /**
-          * The value of the selected option
+          * The value of the selected option. If multiple is true, this is an array.
          */
-        "value"?: string;
+        "value"?: string | string[];
     }
     interface RuxSlider {
         /**

--- a/packages/web-components/src/components/rux-select/rux-select.scss
+++ b/packages/web-components/src/components/rux-select/rux-select.scss
@@ -2,6 +2,46 @@
 
 :host {
     display: block;
+    ::-webkit-scrollbar {
+        width: 16px;
+        height: 16px;
+        background-color: transparent;
+    }
+
+    ::-webkit-scrollbar-thumb {
+        background-color: var(--color-active, rgb(43, 101, 155));
+        border-radius: 8px;
+        border: 3px solid transparent;
+        background-clip: padding-box;
+    }
+
+    /* visually "centers" because the dark edge of the shadow gives the illusion this is offset */
+    ::-webkit-scrollbar-thumb:vertical {
+        border-left-width: 4px;
+    }
+
+    ::-webkit-scrollbar-thumb:horizontal {
+        border-top-width: 4px;
+    }
+
+    ::-webkit-scrollbar-thumb:active,
+    ::-webkit-scrollbar-thumb:hover {
+        background-color: var(--color-primary, rgb(58, 129, 191));
+    }
+
+    ::-webkit-scrollbar-track,
+    ::-webkit-scrollbar-corner {
+        background-color: var(--color-surface, rgb(27, 45, 62));
+        box-shadow: inset 3px 3px 3px rgba(0, 0, 0, 0.5);
+    }
+
+    ::-webkit-scrollbar-track:vertical {
+        box-shadow: inset 3px 3px 3px 0px rgba(0, 0, 0, 0.5);
+    }
+
+    ::-webkit-scrollbar-track:horizontal {
+        box-shadow: inset 1px 3px 3px 0px rgba(0, 0, 0, 0.5);
+    }
 
     /** @prop --select-menu-border-radius: Border radius for Select Menu */
     --select-menu-border-radius: var(--radius-base);
@@ -65,6 +105,22 @@ label {
     }
 }
 
+.rux-select:not(.rux-select--multiple) {
+    background-image: var(--select-menu-inactive-caret),
+        var(--select-menu-background-color);
+    background-position: center right 0.625rem, center left 0;
+    background-repeat: no-repeat;
+    padding: 0.438rem 3.125rem 0.438rem 0.5rem;
+    box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.5);
+    &:active:not(:disabled) {
+        background-image: var(--select-menu-active-caret),
+            var(--select-menu-background-color);
+    }
+    &:hover {
+        cursor: pointer;
+    }
+}
+
 .rux-select {
     position: relative;
     appearance: none;
@@ -78,21 +134,11 @@ label {
     font-size: var(--font-body-1-font-size);
     font-weight: var(--font-body-1-font-weight);
     letter-spacing: var(--font-body-1-letter-spacing);
-    padding: 0.438rem 3.125rem 0.438rem 0.5rem;
-    background-image: var(--select-menu-inactive-caret),
-        var(--select-menu-background-color);
-    background-position: center right 0.625rem, center left 0;
-    background-repeat: no-repeat;
+
     user-select: none;
 
     &:hover {
-        cursor: pointer;
         border: 1px solid var(--select-menu-border-hover-color);
-    }
-
-    &:active:not(:disabled) {
-        background-image: var(--select-menu-active-caret),
-            var(--select-menu-background-color);
     }
 
     &:focus {
@@ -124,7 +170,6 @@ label {
         opacity: 1;
         color: var(--select-menu-text-color);
         border-radius: 0;
-        box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.5);
 
         &:hover {
             color: var(--select-menu-option-text-hover-color);
@@ -137,5 +182,30 @@ label {
                 --select-menu-option-selected-background-color
             );
         }
+    }
+}
+
+.rux-select--multiple {
+    background: var(--color-background);
+    option {
+        padding: 0.438rem 0 0.438rem 1rem; // 7px 0px 7px 16px
+
+        &:hover {
+            color: var(--color-hover);
+            background-color: var(--color-list-hover);
+            cursor: pointer;
+        }
+        &:checked {
+            background: var(--color-selected);
+            color: var(--color-default-text);
+        }
+    }
+    optgroup {
+        padding-left: 1rem; // 16px
+        color: var(--color-default-text);
+        font-family: var(--font-body-1-font-family);
+        font-size: var(--font-body-1-font-size);
+        font-weight: var(--font-body-1-font-weight);
+        letter-spacing: var(--font-body-1-letter-spacing);
     }
 }

--- a/packages/web-components/src/components/rux-select/rux-select.tsx
+++ b/packages/web-components/src/components/rux-select/rux-select.tsx
@@ -13,7 +13,7 @@ import {
 } from '@stencil/core'
 import FormFieldMessage from '../../common/functional-components/FormFieldMessage/FormFieldMessage'
 import { FormFieldInterface } from '../../common/interfaces.module'
-import { hasSlot, renderHiddenInput } from '../../utils/utils'
+import { hasSlot, renderHiddenSelect } from '../../utils/utils'
 
 /**
  * @slot (default) - The select options
@@ -68,14 +68,19 @@ export class RuxSelect implements FormFieldInterface {
     @Prop({ reflect: true }) invalid: boolean = false
 
     /**
+     * Enables multiselect
+     */
+    @Prop({ reflect: true }) multiple: boolean = false
+
+    /**
      * Sets the Name of the Input Element
      */
     @Prop({ reflect: true }) name = ''
 
     /**
-     * The value of the selected option
+     * The value of the selected option. If multiple is true, this is an array.
      */
-    @Prop({ mutable: true, reflect: true }) value?: string
+    @Prop({ mutable: true }) value?: string | string[]
 
     /**
      * The help or explanation text
@@ -224,15 +229,33 @@ export class RuxSelect implements FormFieldInterface {
                 ...Array.from(this.selectEl.querySelectorAll('option')),
             ]
             options.map((option: HTMLOptionElement) => {
-                option.selected = option.value === this.value
+                if (Array.isArray(this.value)) {
+                    option.selected = this.value.includes(option.value)
+                } else {
+                    option.selected = option.value === this.value
+                }
             })
         }
         return Promise.resolve()
     }
 
     private _onChange(e: Event) {
-        const target = e.target as HTMLOptionElement
-        this.value = target.value
+        const target = e.target as HTMLSelectElement
+
+        const values = [...target.options]
+            .filter((option) => {
+                return option.selected
+            })
+            .map((option) => {
+                return option.value
+            })
+
+        if (values.length === 1) {
+            this.value = values[0]
+        } else {
+            this.value = values
+        }
+
         this.ruxSelectChanged.emit()
     }
 
@@ -245,9 +268,9 @@ export class RuxSelect implements FormFieldInterface {
             labelId,
             invalid,
             name,
+            multiple,
         } = this
-
-        renderHiddenInput(true, this.el, this.name, this.value, this.disabled)
+        renderHiddenSelect(true, this.el, this.name, this.value, this.disabled)
         return (
             <Host>
                 <label
@@ -274,13 +297,16 @@ export class RuxSelect implements FormFieldInterface {
                     </span>
                 </label>
                 <select
-                    class={
-                        'rux-select ' + (invalid ? 'rux-select-invalid' : '')
-                    }
+                    class={{
+                        'rux-select': true,
+                        'rux-select-invalid': invalid,
+                        'rux-select--multiple': multiple,
+                    }}
                     ref={(el) => (this.selectEl = el as HTMLSelectElement)}
                     id={inputId}
                     disabled={disabled}
                     required={required}
+                    multiple={multiple}
                     name={name}
                     onChange={(e) => this._onChange(e)}
                     onBlur={this._onBlur}

--- a/packages/web-components/src/components/rux-select/test/__snapshots__/rux-select.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-select/test/__snapshots__/rux-select.spec.tsx.snap
@@ -17,7 +17,7 @@ exports[`rux-select renders 1`] = `
   </mock:shadow-root>
   <rux-option label="one"></rux-option>
   <rux-option label="two"></rux-option>
-  <input class="aux-input" type="hidden" value="">
+  <input class="aux-select aux-select-0" type="hidden">
 </rux-select>
 `;
 
@@ -39,6 +39,6 @@ exports[`rux-select renders option groups 1`] = `
     <rux-option label="inside option"></rux-option>
   </rux-option-group>
   <rux-option label="outside option"></rux-option>
-  <input class="aux-input" type="hidden" value="">
+  <input class="aux-select aux-select-0" type="hidden">
 </rux-select>
 `;

--- a/packages/web-components/src/components/rux-select/test/index.html
+++ b/packages/web-components/src/components/rux-select/test/index.html
@@ -17,11 +17,32 @@
         <script nomodule src="/build/astro-web-components.esm.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
+        <style>
+            body {
+                padding-left: 2rem;
+                padding-right: 2rem;
+            }
+
+            h2 {
+                margin: 0;
+                margin-bottom: 1rem;
+            }
+
+            button {
+                margin-top: 1rem;
+            }
+
+            section {
+                margin-bottom: 1rem;
+            }
+        </style>
     </head>
 
     <body class="dark-theme">
-        <div style="padding: 10%; display: flex; justify-content: center">
-            <form id="form">
+        <section>
+            <h2>Single Select</h2>
+
+            <form id="form" method="POST" action="/form">
                 <rux-select id="ruxSelect" label="Best Thing?" name="bestThing">
                     <rux-option label="" value="" selected></rux-option>
                     <rux-option label="Red" value="red"></rux-option>
@@ -30,27 +51,27 @@
                 </rux-select>
                 <button id="formSubmitBtn" type="submit">submit</button>
             </form>
-            <ul id="log"></ul>
-            <script>
-                const log = document.getElementById('log')
-                const form = document.getElementById('form')
-                form.addEventListener('submit', (e) => {
-                    event.preventDefault()
-                    // trigger formdata event
-                    new FormData(form)
-                })
-                form.addEventListener('formdata', (e) => {
-                    log.innerHTML = ''
-                    // Get the form data from the event object
-                    let data = e.formData
-                    const values = data.values()
-                    for (var value of data.entries()) {
-                        const item = document.createElement('li')
-                        item.innerHTML = `<strong>${value[0]}:</strong>${value[1]}`
-                        log.appendChild(item)
-                    }
-                })
-            </script>
-        </div>
+        </section>
+        <hr />
+
+        <section>
+            <h2>Multi Select</h2>
+
+            <form id="multiSelectForm" method="POST" action="/form">
+                <rux-select
+                    id="ruxMultiSelect"
+                    label="Best Thing?"
+                    name="bestThing"
+                    multiple
+                >
+                    <rux-option value="red" label="Red"></rux-option>
+                    <rux-option value="blue" label="Blue"></rux-option>
+                    <rux-option value="green" label="Green"></rux-option>
+                    <rux-option value="purple" label="Purple"></rux-option>
+                    <rux-option value="yellow" label="Yellow"></rux-option>
+                </rux-select>
+                <button id="multiSelectSubmitBtn" type="submit">submit</button>
+            </form>
+        </section>
     </body>
 </html>

--- a/packages/web-components/src/components/rux-select/test/rux-select.e2e.js
+++ b/packages/web-components/src/components/rux-select/test/rux-select.e2e.js
@@ -4,29 +4,158 @@ describe('Select with Form', () => {
     })
 
     it('renders', () => {
-        cy.get('rux-select').should('have.class', 'hydrated')
+        cy.get('#ruxSelect').should('have.class', 'hydrated')
     })
 
     it('syncs value to select element', () => {
-        cy.get('rux-select').invoke('prop', 'value', 'blue')
-        cy.get('rux-select')
+        cy.get('#ruxSelect').invoke('prop', 'value', 'blue')
+        cy.get('#ruxSelect')
             .shadow()
             .find('select')
             .should('have.value', 'blue')
     })
 
     it('syncs value from select element', () => {
-        cy.get('rux-select').shadow().find('select').select('green')
-        cy.get('rux-select').should('have.value', 'green')
+        cy.get('#ruxSelect').shadow().find('select').select('green')
+        cy.get('#ruxSelect').should('have.value', 'green')
     })
+
     it('should submit the correct value when selecting an option', () => {
         cy.get('#ruxSelect')
             .shadow()
             .find('select')
             .select('blue')
             .should('have.value', 'blue')
+
+        /**
+         * https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/stubbing-spying__intercept/cypress/integration/form-spec.js
+         * https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/stubbing-spying__intercept/form.html
+         * Intercept the form submission
+         */
+        cy.intercept(
+            {
+                method: 'POST',
+                pathname: '/form',
+            },
+            (req) => {
+                req.redirect('/test')
+            }
+        ).as('submitForm')
+
         cy.get('#formSubmitBtn').click()
-        cy.get('#log').contains('bestThing:blue')
+        cy.location('pathname').should('equal', '/test')
+
+        cy.wait('@submitForm')
+            .its('request')
+            .then(({ headers, body }) => {
+                expect(body, 'request body').to.be.a('string')
+                expect(body).to.equal('bestThing=blue')
+            })
+    })
+
+    it('should default to the option with no value', () => {
+        cy.get('#ruxSelect').shadow().find('select').should('have.value', '')
+    })
+
+    it('should be disabled if disabled attribute is true', () => {
+        cy.get('#ruxSelect')
+            .get('rux-select')
+            .then(($select) => {
+                $select[0].setAttribute('disabled', true)
+            })
+        cy.get('#ruxSelect').shadow().find('select').should('be.disabled')
+    })
+
+    it('should not submit a value if disabled', () => {
+        cy.get('#ruxSelect')
+            .get('rux-select')
+            .then(($select) => {
+                $select[0].setAttribute('disabled', true)
+            })
+        cy.get('#ruxSelect')
+            .shadow()
+            .find('select')
+            .select('green', { force: true })
+
+        cy.intercept(
+            {
+                method: 'POST',
+                pathname: '/form',
+            },
+            (req) => {
+                req.redirect('/test')
+            }
+        ).as('submitForm')
+
+        cy.get('#formSubmitBtn').click()
+
+        cy.wait('@submitForm')
+            .its('request')
+            .then(({ headers, body }) => {
+                expect(body, 'request body').to.be.a('string')
+                expect(body).to.equal('')
+            })
+    })
+
+    /**
+     * Multi Select
+     */
+
+    it('syncs multiple values from select element', () => {
+        cy.get('#ruxMultiSelect')
+            .shadow()
+            .find('select')
+            .select(['green', 'red'])
+        cy.get('#ruxMultiSelect')
+            .invoke('val')
+            .should(($els) => {
+                expect($els).to.deep.eq(['red', 'green'])
+            })
+    })
+
+    it('syncs multiple values to select element', () => {
+        cy.get('#ruxMultiSelect').invoke('prop', 'value', ['red', 'blue'])
+        cy.get('#ruxMultiSelect')
+            .shadow()
+            .find('select')
+            .should(($el) => {
+                const options = [...$el[0].selectedOptions].map(
+                    (el) => el.value
+                )
+                expect(options).to.deep.eq(['red', 'blue'])
+            })
+    })
+
+    it('should submit the correct value when selecting multiple options', () => {
+        cy.get('#ruxMultiSelect')
+            .shadow()
+            .find('select')
+            .select(['red', 'blue'])
+
+        /**
+         * https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/stubbing-spying__intercept/cypress/integration/form-spec.js
+         * https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/stubbing-spying__intercept/form.html
+         * Intercept the form submission
+         */
+        cy.intercept(
+            {
+                method: 'POST',
+                pathname: '/form',
+            },
+            (req) => {
+                req.redirect('/test')
+            }
+        ).as('submitForm')
+
+        cy.get('#multiSelectSubmitBtn').click()
+        cy.location('pathname').should('equal', '/test')
+
+        cy.wait('@submitForm')
+            .its('request')
+            .then(({ headers, body }) => {
+                expect(body, 'request body').to.be.a('string')
+                expect(body).to.equal('bestThing=red&bestThing=blue')
+            })
     })
 
     // #TODO this test causes tons of flake when run in CI/CD. Fix as part of ASTRO-2235
@@ -54,31 +183,4 @@ describe('Select with Form', () => {
     //     cy.get('#formSubmitBtn').click()
     //     cy.get('#log').should('contain', 'bestThing:blue')
     // })
-
-    it('should default to the option with no value', () => {
-        cy.get('#ruxSelect').shadow().find('select').should('have.value', '')
-    })
-
-    it('should be disabled if disabled attribute is true', () => {
-        cy.get('#ruxSelect')
-            .get('rux-select')
-            .then(($select) => {
-                $select[0].setAttribute('disabled', true)
-            })
-        cy.get('#ruxSelect').shadow().find('select').should('be.disabled')
-    })
-
-    it('should not submit a value if disabled', () => {
-        cy.get('#ruxSelect')
-            .get('rux-select')
-            .then(($select) => {
-                $select[0].setAttribute('disabled', true)
-            })
-        cy.get('#ruxSelect')
-            .shadow()
-            .find('select')
-            .select('green', { force: true })
-        cy.get('#formSubmitBtn').click()
-        cy.get('#log').should('not.contain', 'bestThing:green')
-    })
 })

--- a/packages/web-components/src/stories/select.stories.mdx
+++ b/packages/web-components/src/stories/select.stories.mdx
@@ -274,7 +274,7 @@ export const WithHelpText = (args) => {
         label="${args.label}"
         input-id="${args.inputId}"
         label-id="${args.labelId}"
-        .errot-text="${args.errorText}"
+        .error-text="${args.errorText}"
         help-text="${args.helpText}"
     >
         <rux-option
@@ -345,6 +345,98 @@ export const WithErrorText = (args) => {
         name="With Error Text"
     >
         {WithErrorText.bind()}
+    </Story>
+</Canvas>
+
+### Multiple
+
+export const Multiple = (args) => {
+    return html`
+<div style="width: 200px; margin: 0 auto;">
+    <rux-select
+        ?disabled="${args.disabled}"
+        ?required="${args.required}"
+        ?invalid="${args.invalid}"
+        label="${args.label}"
+        input-id="${args.inputId}"
+        label-id="${args.labelId}"
+        .error-text="${args.errorText}"
+        help-text="${args.helpText}"
+        .multiple="${args.multiple}"
+    >
+        <rux-option value="1.1" label="Option 1.1"></rux-option>
+        <rux-option value="1.2" label="Option 1.2"></rux-option>
+        <rux-option value="1.3" label="Option 1.3"></rux-option>
+        <rux-option value="1.4" label="Option 1.4"></rux-option>
+        <rux-option value="1.5" label="Option 1.5"></rux-option>
+    </rux-select>
+</div>
+    `
+}
+
+<Canvas>
+    <Story
+        args={{
+            label: 'Select menu',
+            inputId: 1,
+            labelId: 1,
+            helpText: '',
+            multiple: true
+        }}
+        name="Multiple"
+    >
+        {Multiple.bind()}
+    </Story>
+</Canvas>
+
+### Multiple With Option Groups
+
+export const MultipleWithOptionGroups = (args) => {
+    return html`
+<div style="width: 200px; margin: 0 auto;">
+    <rux-select
+        ?disabled="${args.disabled}"
+        ?required="${args.required}"
+        ?invalid="${args.invalid}"
+        label="${args.label}"
+        input-id="${args.inputId}"
+        label-id="${args.labelId}"
+        .error-text="${args.errorText}"
+        help-text="${args.helpText}"
+        .multiple="${args.multiple}"
+    >
+        <rux-option value="" label="Select Option"></rux-option>
+        <rux-option-group label="Option 1">
+            <rux-option value="1.1" label="Option 1.1"></rux-option>
+            <rux-option value="1.2" label="Option 1.2"></rux-option>
+            <rux-option value="1.3" label="Option 1.3"></rux-option>
+            <rux-option value="1.4" label="Option 1.4"></rux-option>
+            <rux-option value="1.5" label="Option 1.5"></rux-option>
+        </rux-option-group>
+        <rux-option-group label="Option 2">
+            <rux-option value="2.1" label="Option 2.1"></rux-option>
+            <rux-option value="2.2" label="Option 2.2"></rux-option>
+            <rux-option value="2.3" label="Option 2.3"></rux-option>
+            <rux-option value="2.4" label="Option 2.4"></rux-option>
+            <rux-option value="2.5" label="Option 2.5"></rux-option>
+        </rux-option-group> 
+    </rux-select>
+</div>
+    `
+}
+
+<Canvas>
+    <Story
+        args={{
+            label: 'Select menu',
+            inputId: 1,
+            labelId: 1,
+            helpText: '',
+            multiple: true
+        }}
+        name="Multiple With Option Groups"
+    >
+        {MultipleWithOptionGroups.bind()}
     </Story>
 </Canvas>
 

--- a/packages/web-components/src/utils/utils.ts
+++ b/packages/web-components/src/utils/utils.ts
@@ -74,3 +74,59 @@ export const renderHiddenInput = (
         }
     }
 }
+
+/**
+ * Renders multiple hidden inputs from an array of values
+ * Used in multiselect
+ * @param always
+ * @param container
+ * @param name
+ * @param value
+ * @param disabled
+ */
+export const renderHiddenSelect = (
+    always: boolean,
+    container: HTMLElement,
+    name: string,
+    value: string | undefined | null | string[],
+    disabled: boolean
+) => {
+    // Clear any existing hidden options. May be more performant to edit their values instead though.
+    let inputs = container.querySelectorAll(
+        'input.aux-select'
+    ) as NodeListOf<HTMLInputElement>
+    if (inputs) {
+        for (const elem of inputs) {
+            elem.remove()
+        }
+    }
+
+    if (always || hasShadowDom(container)) {
+        if (Array.isArray(value)) {
+            for (const el in value) {
+                let input = container.ownerDocument!.createElement('input')
+                input.type = 'hidden'
+                input.classList.add('aux-select')
+                input.classList.add(`aux-select-${el}`)
+                input.disabled = disabled
+                input.name = name
+
+                if (value[el]) {
+                    input.value = value[el]
+                }
+                container.appendChild(input)
+            }
+        } else {
+            let input = container.ownerDocument!.createElement('input')
+            input.type = 'hidden'
+            input.classList.add('aux-select')
+            input.classList.add(`aux-select-0`)
+            input.disabled = disabled
+            input.name = name
+            if (value) {
+                input.value = value
+            }
+            container.appendChild(input)
+        }
+    }
+}


### PR DESCRIPTION
## Brief Description

Adds `multiple` support to Select
Refactored form integration test to use cypress's interceptor instead of the janky formdata event we were using.

## JIRA Link

ASTRO-3092

## Motivation and Context

https://github.com/RocketCommunicationsInc/astro/issues/263

## Issues and Limitations

* Styling optgroup labels has some limitations and our design currently does not account for them.

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [x] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
