### PR TITLE
Astro 2977 switch audit

### DIFF
--- a/.changeset/curly-eggs-drum.md
+++ b/.changeset/curly-eggs-drum.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Updated Switch's thumb hover state color to align with design.

--- a/packages/web-components/src/components/rux-switch/rux-switch.scss
+++ b/packages/web-components/src/components/rux-switch/rux-switch.scss
@@ -110,7 +110,7 @@
                         border-color: var(--switch-hover-off-color);
                     }
                     &::after {
-                        border-color: var(--switch-hover-off-color);
+                        border-color: var(--color-hover);
                     }
                 }
             }

--- a/packages/web-components/src/stories/switch.stories.mdx
+++ b/packages/web-components/src/stories/switch.stories.mdx
@@ -51,6 +51,31 @@ export const Switch = (args) => {
 
 ## Variants
 
+### On
+
+export const On = (args) => {
+    return html`
+<div style="margin: 3rem auto; max-width: 5rem; text-align: center;">
+    <rux-switch
+        ?disabled=${args.disabled}
+        ?checked=${args.checked}
+        .label=${args.label}
+    ></rux-switch>
+</div>
+    `
+}
+
+<Canvas>
+    <Story
+        name="On"
+        args={{
+           checked: true
+        }}
+    >
+        {On.bind()}
+    </Story>
+</Canvas>
+
 ### Disabled
 
 export const Disabled = (args) => {
@@ -59,6 +84,7 @@ export const Disabled = (args) => {
     <rux-switch
         ?disabled=${args.disabled}
         ?checked=${args.checked}
+        .label=${args.label}
     ></rux-switch>
 </div>
     `

--- a/packages/web-components/src/stories/switch.stories.mdx
+++ b/packages/web-components/src/stories/switch.stories.mdx
@@ -75,6 +75,31 @@ export const Disabled = (args) => {
     </Story>
 </Canvas>
 
+### With Label 
+
+export const WithLabel = (args) => {
+    return html`
+<div style="margin: 3rem auto; max-width: 5rem; text-align: center;">
+    <rux-switch
+        ?disabled=${args.disabled}
+        ?checked=${args.checked}
+        .label=${args.label}
+    ></rux-switch>
+</div>
+    `
+}
+
+<Canvas>
+    <Story
+        name="With Label"
+        args={{
+            label: 'Switch Label'
+        }}
+    >
+        {WithLabel.bind()}
+    </Story>
+</Canvas>
+
 ## Cherry Picking
 
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:


### PR DESCRIPTION
## Brief Description

Updates the hover state of switch's thumb and adds `on` and `with label` variants to SB.
Updating regressions references, will push this to main since it's just a hover state and story addition change.

## JIRA Link

Variants -> https://rocketcom.atlassian.net/browse/ASTRO-2978
Hover state -> https://rocketcom.atlassian.net/browse/ASTRO-2977

## Related Issue

## General Notes

## Motivation and Context

Dev -> Design audit

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
