### PR TITLE
Astro 3153 clock labels color

### DIFF
--- a/.changeset/many-phones-explain.md
+++ b/.changeset/many-phones-explain.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Updates the clock labels to match design.

--- a/packages/web-components/src/components/rux-clock/rux-clock.scss
+++ b/packages/web-components/src/components/rux-clock/rux-clock.scss
@@ -74,7 +74,7 @@
     letter-spacing: var(--font-body-2-letter-spacing);
     color: var(--clock-label-color);
     background: var(--clock-label-background-color);
-    padding: 1.5px 10px;
+    padding: 0.094rem 0.625rem;
     width: -moz-available;
     width: -webkit-fill-available;
     width: fill-available;

--- a/packages/web-components/src/components/rux-clock/rux-clock.scss
+++ b/packages/web-components/src/components/rux-clock/rux-clock.scss
@@ -12,12 +12,17 @@
     /**
     * @prop --clock-border-color: the border color for the clock
     */
-    --clock-border-color: var(--color-global-snowflakes-dark-surface);
+    --clock-border-color: var(--color-surface);
 
     /**
     * @prop --clock-label-color: the label color for the clock
     */
     --clock-label-color: var(--color-global-basics-white);
+
+    /**
+    * @prop --clock-label-background-color: the background color for clocks date, time, aos, and los labels.
+    */
+    --clock-label-background-color: var(--color-gsb-global-status-bar);
 
     display: flex;
     margin: 0 1rem;
@@ -68,8 +73,8 @@
     font-weight: var(--font-body-2-font-weight);
     letter-spacing: var(--font-body-2-letter-spacing);
     color: var(--clock-label-color);
-    background: var(--clock-border-color);
-    border: 1px solid var(--clock-border-color);
+    background: var(--clock-label-background-color);
+    padding: 1.5px 10px;
     width: -moz-available;
     width: -webkit-fill-available;
     width: fill-available;

--- a/packages/web-components/src/components/rux-clock/rux-clock.scss
+++ b/packages/web-components/src/components/rux-clock/rux-clock.scss
@@ -19,11 +19,6 @@
     */
     --clock-label-color: var(--color-global-basics-white);
 
-    /**
-    * @prop --clock-label-background-color: the background color for clocks date, time, aos, and los labels.
-    */
-    --clock-label-background-color: var(--color-gsb-global-status-bar);
-
     display: flex;
     margin: 0 1rem;
     color: var(--clock-text-color);
@@ -73,7 +68,7 @@
     font-weight: var(--font-body-2-font-weight);
     letter-spacing: var(--font-body-2-letter-spacing);
     color: var(--clock-label-color);
-    background: var(--clock-label-background-color);
+    background: var(--color-gsb-global-status-bar);
     padding: 0.094rem 0.625rem;
     width: -moz-available;
     width: -webkit-fill-available;

--- a/packages/web-components/src/global/tokens/_colors-dark.scss
+++ b/packages/web-components/src/global/tokens/_colors-dark.scss
@@ -1,2 +1,2 @@
-@forward '../../../node_modules/@astrouxds/design-tokens/dist/internal/css/colors-dark.scss';
-@use '../../../node_modules/@astrouxds/design-tokens/dist/internal/css/colors-dark.scss';
+@forward '../../../node_modules/@astrouxds/design-tokens/dist/internal/css/_colors-dark.scss';
+@use '../../../node_modules/@astrouxds/design-tokens/dist/internal/css/_colors-dark.scss';


### PR DESCRIPTION
## Brief Description

Updates the clock labels to match Figma. 
 - removed the border around label
 - created new css custom prop `    --clock-label-background-color: var(--color-gsb-global-status-bar);`
 - added `padding: 0.094rem 0.625rem; //1.5px 10px ` to label
 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-3153

## Related Issue

Noticed by a dev team in #astro channel 

## General Notes

Regressions all fail (obv) so I will update them once this is merged.

## Motivation and Context

Update to match figma 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
