### PR TITLE
style(tabs): Astro 2980 tabs aduit

### DIFF
--- a/.changeset/olive-flies-march.md
+++ b/.changeset/olive-flies-march.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Updates Tabs to align with design

--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
@@ -28,7 +28,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0 2rem;
+    padding: 1.875rem 1rem; //30 16
     margin: 0;
     min-width: 5rem;
     text-decoration: none;
@@ -47,6 +47,7 @@
 }
 :host([small]) {
     min-width: 2rem;
+    padding: 1.25rem 1rem; //20 16
     border-bottom: 3px solid var(--tab-border-color);
 }
 :host([small][selected]) {

--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
@@ -57,7 +57,7 @@
     border-bottom: 5px solid var(--tab-selected-border-color);
 }
 :host(:hover) {
-    color: var(--tab-hover-text-color);
+    color: var(--color-hover);
 }
 :host([disabled]) {
     color: var(--tab-text-color);

--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
@@ -56,6 +56,9 @@
     color: var(--tab-selected-text-color);
     border-bottom: 5px solid var(--tab-selected-border-color);
 }
+:host([selected]:hover) {
+    color: var(--tab-selected-text-color);
+}
 :host(:hover) {
     color: var(--color-hover);
 }

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.scss
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.scss
@@ -32,5 +32,5 @@
     font-size: var(--font-heading-5-font-size);
     letter-spacing: var(--font-heading-5-letter-spacing);
     font-weight: var(--font-heading-5-font-weight);
-    min-height: 3.125rem;
+    min-height: 4.125rem; //66px
 }

--- a/packages/web-components/src/stories/tab.stories.mdx
+++ b/packages/web-components/src/stories/tab.stories.mdx
@@ -3,7 +3,7 @@ import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks'
 import { html, render } from 'lit-html'
 
 <Meta
-    title="Components/Tab"
+    title="Components/Tabs/Tab"
     component="rux-tab"
     subcomponents={{ 'Rux Tabs': 'rux-tabs' }}
     argTypes={extractArgTypes('rux-tab')}


### PR DESCRIPTION
## Brief Description

Changes:
- adds 1rem left/right padding for large and small rux-tab, as per figma
- adds 30px top/bottom padding for large, 20px for small
- changes text hover color from white to `var(--color-hover)` when tab is not selected
- Nests rux-tab story inside of rux-tabs 

Will have a backstop PR open to update references.

## JIRA Link

Hover color -> https://rocketcom.atlassian.net/browse/ASTRO-2979
padding -> https://rocketcom.atlassian.net/browse/ASTRO-2980
tab nested in tabs -> https://rocketcom.atlassian.net/browse/ASTRO-2981

## Related Issue

## General Notes

On [figma](https://www.figma.com/file/ZtHeSWpISd8hJjN46uY9pm/Astro-UXDS-6.0---Dark-Theme?node-id=2189%3A9014), it states that all tab sizes have a default left/right padding of 16px, but when you inspect it it looks like it's only 10. I've done 16, but wanted to make that known.
As for the move of tab into tabs on SB, that was just a thought I had so let me know if you don't want that, it's not a big deal at all.

## Motivation and Context

dev -> design audit 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
