### PR TITLE
docs(progress): fixed hide label prop not working on default story

### DIFF
--- a/packages/web-components/src/stories/progress.stories.mdx
+++ b/packages/web-components/src/stories/progress.stories.mdx
@@ -22,6 +22,7 @@ export const Default = (args) => {
     <rux-progress
         value="${args.value}"
         .max=${args.max}
+        ?hide-label="${args.hideLabel}"
     ></rux-progress>
 </div>
     `


### PR DESCRIPTION
## Brief Description

Just adds the hide-label arg to the default progress story so that the control works.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2966

## Related Issue

## General Notes

## Motivation and Context

dev -> design audit

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
