### PR TITLE
Astro 2996 input icons

### DIFF
--- a/.changeset/tall-pears-lay.md
+++ b/.changeset/tall-pears-lay.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": minor
+"@astrouxds/angular": minor
+"astro-website": minor
+"@astrouxds/react": minor
+---
+
+Added a prefix and suffix named slots to input, refactored password input types.

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -32152,6 +32152,10 @@ declare namespace LocalJSX {
          */
         "onRuxchange"?: (event: CustomEvent<any>) => void;
         /**
+          * Fired when an element has gained focus - [link here dummy]
+         */
+        "onRuxfocus"?: (event: CustomEvent<any>) => void;
+        /**
           * Fired when an alteration to the input's value is committed by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
          */
         "onRuxinput"?: (event: CustomEvent<any>) => void;

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -32152,7 +32152,7 @@ declare namespace LocalJSX {
          */
         "onRuxchange"?: (event: CustomEvent<any>) => void;
         /**
-          * Fired when an element has gained focus - [link here dummy]
+          * Fired when an element has gained focus - [HTMLElement/focus_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)
          */
         "onRuxfocus"?: (event: CustomEvent<any>) => void;
         /**

--- a/packages/web-components/src/components/rux-input/rux-input.scss
+++ b/packages/web-components/src/components/rux-input/rux-input.scss
@@ -114,7 +114,7 @@
         &--search {
             -webkit-appearance: none;
             -moz-appearance: none;
-            padding-left: 2rem;
+            padding-left: 2.25rem; //36px
             background: var(--input-background-color)
                 url("data:image/svg+xml,%3Csvg width='40' height='40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M35.37 26.457a15.282 15.282 0 000-21.918c-6.176-6.052-16.187-6.052-22.361 0a15.274 15.274 0 00-1.541 20.166c-.367.147-.713.37-1.014.665L.926 34.709a3.056 3.056 0 000 4.383 3.208 3.208 0 004.472 0l9.528-9.339c.352-.345.604-.753.756-1.186 6.137 3.831 14.347 3.124 19.687-2.11zM24.193 4.043c6.454 0 11.686 5.129 11.686 11.455 0 6.326-5.232 11.455-11.686 11.455-6.455 0-11.687-5.129-11.687-11.455 0-6.326 5.232-11.455 11.687-11.455z' fill='%234dacff' fill-rule='evenodd'/%3E%3C/svg%3E")
                 10px/0.975rem no-repeat;
@@ -123,10 +123,6 @@
             border-color: var(--input-focus-border-color);
             outline: none;
         }
-        // &:focus {
-        //     border-color: var(--input-focus-border-color);
-        //     outline: none;
-        // }
         &:hover {
             border-color: var(--input-focus-border-color);
             outline: none;
@@ -159,7 +155,6 @@
             }
         }
     }
-
     .rux-input-label {
         font-family: var(--font-body-1-font-family);
         font-size: var(--font-body-1-font-size);

--- a/packages/web-components/src/components/rux-input/rux-input.scss
+++ b/packages/web-components/src/components/rux-input/rux-input.scss
@@ -170,6 +170,16 @@
         background-color: var(--input-selection-background-color);
     }
 }
+.pw-button {
+    padding-top: 1px;
+}
+.pw-button::part(container) {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: center;
+    height: 1rem;
+}
 
 .hidden,
 :host([hidden]) {

--- a/packages/web-components/src/components/rux-input/rux-input.scss
+++ b/packages/web-components/src/components/rux-input/rux-input.scss
@@ -61,9 +61,28 @@
     }
 
     .rux-input {
+        input {
+            border: none;
+            background: none;
+            box-shadow: none;
+            padding: 0;
+            margin: 0;
+            color: inherit;
+            font-family: inherit;
+            font-size: inherit;
+            font-weight: inherit;
+            -webkit-appearance: none;
+            appearance: none;
+            outline: none;
+        }
+
+        flex: 1 1 auto;
+        display: inline-flex;
+        align-items: stretch;
+        justify-content: start;
+        position: relative;
         box-sizing: border-box;
         order: 2;
-        width: 100%;
         border: 1px solid var(--input-border-color);
         border-radius: var(--radius-base);
         font-family: var(--font-body-1-font-family);
@@ -72,6 +91,7 @@
         letter-spacing: var(--font-body-1-letter-spacing);
         color: var(--input-text-color);
         background-color: var(--input-background-color);
+
         &--invalid {
             border: 1px solid var(--input-invalid-border-color);
         }
@@ -97,10 +117,14 @@
                 url("data:image/svg+xml,%3Csvg width='40' height='40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M35.37 26.457a15.282 15.282 0 000-21.918c-6.176-6.052-16.187-6.052-22.361 0a15.274 15.274 0 00-1.541 20.166c-.367.147-.713.37-1.014.665L.926 34.709a3.056 3.056 0 000 4.383 3.208 3.208 0 004.472 0l9.528-9.339c.352-.345.604-.753.756-1.186 6.137 3.831 14.347 3.124 19.687-2.11zM24.193 4.043c6.454 0 11.686 5.129 11.686 11.455 0 6.326-5.232 11.455-11.686 11.455-6.455 0-11.687-5.129-11.687-11.455 0-6.326 5.232-11.455 11.687-11.455z' fill='%234dacff' fill-rule='evenodd'/%3E%3C/svg%3E")
                 10px/0.975rem no-repeat;
         }
-        &:focus {
+        &--focused {
             border-color: var(--input-focus-border-color);
             outline: none;
         }
+        // &:focus {
+        //     border-color: var(--input-focus-border-color);
+        //     outline: none;
+        // }
         &:hover {
             border-color: var(--input-focus-border-color);
             outline: none;
@@ -126,6 +150,30 @@
         &__asterisk {
             margin-left: 4px;
         }
+    }
+
+    .test {
+        flex: 1 1 auto;
+        display: inline-flex;
+        align-items: stretch;
+        justify-content: start;
+        position: relative;
+        width: 100%;
+        border: 1px solid var(--input-border-color);
+        border-radius: var(--radius-base);
+        font-family: var(--font-body-1-font-family);
+        font-size: var(--font-body-1-font-size);
+        font-weight: var(--font-body-1-font-weight);
+        letter-spacing: var(--font-body-1-letter-spacing);
+        color: var(--input-text-color);
+        background-color: var(--input-background-color);
+    }
+
+    .rux-input-prefix {
+        display: inline-flex;
+        flex: 0 0 auto;
+        align-items: center;
+        cursor: default;
     }
 
     ::selection {

--- a/packages/web-components/src/components/rux-input/rux-input.scss
+++ b/packages/web-components/src/components/rux-input/rux-input.scss
@@ -76,6 +76,7 @@
             outline: none;
         }
 
+        overflow: hidden;
         flex: 1 1 auto;
         display: inline-flex;
         align-items: stretch;
@@ -174,6 +175,14 @@
         flex: 0 0 auto;
         align-items: center;
         cursor: default;
+        padding-right: 12px; //!probs just for med?
+    }
+    .rux-input-suffix {
+        display: inline-flex;
+        flex: 0 0 auto;
+        align-items: center;
+        cursor: default;
+        padding: 0;
     }
 
     ::selection {

--- a/packages/web-components/src/components/rux-input/rux-input.scss
+++ b/packages/web-components/src/components/rux-input/rux-input.scss
@@ -41,21 +41,21 @@
         justify-content: center;
         color: var(--color-default-text);
     }
-    .icon-container {
-        background-color: #101923;
-        align-self: flex-end;
-        position: absolute;
-        width: 1.188rem;
-        height: 1.313rem;
-        padding-left: 0.5rem;
-    }
-    .show-password {
-        margin-top: 0.6rem;
-        margin-right: 0.5rem;
-    }
-    .with-label {
-        margin-top: 1.7rem;
-    }
+    // .icon-container {
+    //     background-color: #101923;
+    //     align-self: flex-end;
+    //     position: absolute;
+    //     width: 1.188rem;
+    //     height: 1.313rem;
+    //     padding-left: 0.5rem;
+    // }
+    // .show-password {
+    //     margin-top: 0.6rem;
+    //     margin-right: 0.5rem;
+    // }
+    // .with-label {
+    //     margin-top: 1.7rem;
+    // }
     rux-icon {
         cursor: pointer;
     }
@@ -74,12 +74,13 @@
             -webkit-appearance: none;
             appearance: none;
             outline: none;
+            width: 100%;
         }
-
+        width: 100%;
         overflow: hidden;
         flex: 1 1 auto;
         display: inline-flex;
-        align-items: stretch;
+        align-items: center;
         justify-content: start;
         position: relative;
         box-sizing: border-box;
@@ -102,13 +103,13 @@
             cursor: not-allowed;
         }
         &--small {
-            padding: 0.25rem 0.5rem 0.188rem 0.5rem; // 4px 8px 3px 8px;
+            padding: 0.219rem 0.5rem; // 3.5px 8px;
         }
         &--medium {
-            padding: 0.5rem 0.5rem 0.438rem 0.5rem; // 8px 8px 7px 8px;
+            padding: 0.469rem 0.5rem; // 7.5px 8px;
         }
         &--large {
-            padding: 0.813rem 0.5rem 0.875rem 0.5rem; //13px 8px 14px 8px;
+            padding: 0.844rem 0.5rem; //13.5px 8px;
         }
         &--search {
             -webkit-appearance: none;
@@ -140,6 +141,23 @@
         &::placeholder {
             color: var(--color-placeholder-text);
         }
+        .rux-input-prefix,
+        .rux-input-suffix {
+            display: inline-flex;
+            flex: 0 0 auto;
+            align-items: center;
+            cursor: default;
+        }
+        .rux-input-prefix {
+            ::slotted(*) {
+                padding-right: 10px;
+            }
+        }
+        .rux-input-suffix {
+            ::slotted(*) {
+                padding-left: 10px;
+            }
+        }
     }
 
     .rux-input-label {
@@ -151,38 +169,6 @@
         &__asterisk {
             margin-left: 4px;
         }
-    }
-
-    .test {
-        flex: 1 1 auto;
-        display: inline-flex;
-        align-items: stretch;
-        justify-content: start;
-        position: relative;
-        width: 100%;
-        border: 1px solid var(--input-border-color);
-        border-radius: var(--radius-base);
-        font-family: var(--font-body-1-font-family);
-        font-size: var(--font-body-1-font-size);
-        font-weight: var(--font-body-1-font-weight);
-        letter-spacing: var(--font-body-1-letter-spacing);
-        color: var(--input-text-color);
-        background-color: var(--input-background-color);
-    }
-
-    .rux-input-prefix {
-        display: inline-flex;
-        flex: 0 0 auto;
-        align-items: center;
-        cursor: default;
-        padding-right: 12px; //!probs just for med?
-    }
-    .rux-input-suffix {
-        display: inline-flex;
-        flex: 0 0 auto;
-        align-items: center;
-        cursor: default;
-        padding: 0;
     }
 
     ::selection {

--- a/packages/web-components/src/components/rux-input/rux-input.scss
+++ b/packages/web-components/src/components/rux-input/rux-input.scss
@@ -75,6 +75,9 @@
             appearance: none;
             outline: none;
             width: 100%;
+            &:disabled {
+                cursor: not-allowed;
+            }
         }
         width: 100%;
         overflow: hidden;

--- a/packages/web-components/src/components/rux-input/rux-input.scss
+++ b/packages/web-components/src/components/rux-input/rux-input.scss
@@ -41,21 +41,6 @@
         justify-content: center;
         color: var(--color-default-text);
     }
-    // .icon-container {
-    //     background-color: #101923;
-    //     align-self: flex-end;
-    //     position: absolute;
-    //     width: 1.188rem;
-    //     height: 1.313rem;
-    //     padding-left: 0.5rem;
-    // }
-    // .show-password {
-    //     margin-top: 0.6rem;
-    //     margin-right: 0.5rem;
-    // }
-    // .with-label {
-    //     margin-top: 1.7rem;
-    // }
     rux-icon {
         cursor: pointer;
     }
@@ -177,7 +162,7 @@
     }
 }
 .pw-button {
-    padding-top: 1px;
+    padding-top: 1px; //icon looked like half a px off from being centered.
 }
 .pw-button::part(container) {
     display: flex;

--- a/packages/web-components/src/components/rux-input/rux-input.scss
+++ b/packages/web-components/src/components/rux-input/rux-input.scss
@@ -104,12 +104,15 @@
         }
         &--small {
             padding: 0.219rem 0.5rem; // 3.5px 8px;
+            min-height: 1.625rem; //26px
         }
         &--medium {
             padding: 0.469rem 0.5rem; // 7.5px 8px;
+            min-height: 2.25rem; //36px
         }
         &--large {
             padding: 0.844rem 0.5rem; //13.5px 8px;
+            min-height: 2.875rem; //46px
         }
         &--search {
             -webkit-appearance: none;

--- a/packages/web-components/src/components/rux-input/rux-input.tsx
+++ b/packages/web-components/src/components/rux-input/rux-input.tsx
@@ -44,7 +44,7 @@ export class RuxInput implements FormFieldInterface {
 
     @State() hasFocus = false
 
-    // @State() iconName = 'visibility'
+    @State() iconName = 'visibility'
 
     /**
      * The input label text. For HTML content, use the `label` slot instead.
@@ -173,7 +173,7 @@ export class RuxInput implements FormFieldInterface {
         this._onInput = this._onInput.bind(this)
         this._handleSlotChange = this._handleSlotChange.bind(this)
         this._handleType = this._handleType.bind(this)
-        // this._handleTogglePassword = this._handleTogglePassword.bind(this)
+        this._handleTogglePassword = this._handleTogglePassword.bind(this)
     }
 
     disconnectedCallback() {
@@ -219,14 +219,14 @@ export class RuxInput implements FormFieldInterface {
         }
     }
 
-    // private _handleTogglePassword() {
-    //     this.isPasswordVisible = !this.isPasswordVisible
-    //     if (this.isPasswordVisible) {
-    //         this.iconName = 'visibility-off'
-    //     } else {
-    //         this.iconName = 'visibility'
-    //     }
-    // }
+    private _handleTogglePassword() {
+        this.isPasswordVisible = !this.isPasswordVisible
+        if (this.isPasswordVisible) {
+            this.iconName = 'visibility-off'
+        } else {
+            this.iconName = 'visibility'
+        }
+    }
 
     private _handleType() {
         let realType = ''
@@ -237,11 +237,6 @@ export class RuxInput implements FormFieldInterface {
             : (realType = this.type)
         return realType
     }
-
-    // private _handleFocus() {
-    //     this.hasFocus = true;
-    //     console.log('Handle focus')
-    // }
 
     render() {
         const {
@@ -258,16 +253,15 @@ export class RuxInput implements FormFieldInterface {
             _onChange,
             _onInput,
             _onBlur,
-            _handleType,
             _handleSlotChange,
-            // _handleTogglePassword,
+            _handleTogglePassword,
             placeholder,
             required,
             step,
             type,
             value,
             hasLabel,
-            // iconName,
+            iconName,
             size,
             autocomplete,
             spellcheck,
@@ -323,7 +317,11 @@ export class RuxInput implements FormFieldInterface {
                         <input
                             name={name}
                             disabled={disabled}
-                            type={_handleType()}
+                            type={
+                                type === 'password' && this.isPasswordVisible
+                                    ? 'text'
+                                    : type
+                            }
                             aria-invalid={invalid ? 'true' : 'false'}
                             placeholder={placeholder}
                             required={required}
@@ -345,6 +343,14 @@ export class RuxInput implements FormFieldInterface {
                             }
                             part="input"
                         ></input>
+                        {this.togglePassword ? (
+                            <rux-icon
+                                exportparts="icon"
+                                onClick={_handleTogglePassword}
+                                icon={iconName}
+                                size="extra-small"
+                            />
+                        ) : null}
                         <span part="suffix" class="rux-input-suffix">
                             <slot name="suffix"></slot>
                         </span>

--- a/packages/web-components/src/components/rux-input/rux-input.tsx
+++ b/packages/web-components/src/components/rux-input/rux-input.tsx
@@ -339,9 +339,15 @@ export class RuxInput implements FormFieldInterface {
                             onChange={_onChange}
                             onInput={_onInput}
                             onBlur={_onBlur}
-                            onFocus={() => (this.hasFocus = true)}
+                            onFocus={
+                                () =>
+                                    (this.hasFocus = true) /*! probs a better way, focus event?*/
+                            }
                             part="input"
                         ></input>
+                        <span part="suffix" class="rux-input-suffix">
+                            <slot name="suffix"></slot>
+                        </span>
                     </div>
                 </div>
 

--- a/packages/web-components/src/components/rux-input/rux-input.tsx
+++ b/packages/web-components/src/components/rux-input/rux-input.tsx
@@ -42,7 +42,9 @@ export class RuxInput implements FormFieldInterface {
 
     @State() isPasswordVisible = false
 
-    @State() iconName = 'visibility'
+    @State() hasFocus = false
+
+    // @State() iconName = 'visibility'
 
     /**
      * The input label text. For HTML content, use the `label` slot instead.
@@ -155,6 +157,12 @@ export class RuxInput implements FormFieldInterface {
         this._handleSlotChange()
     }
 
+    // @Watch('hasFocus')
+    // handleFocusChange() {
+    //     // this._handleFocus()
+    //     console.log('watch')
+    // }
+
     @Watch('type')
     handleTypeChange() {
         this._setTogglePassword()
@@ -165,7 +173,7 @@ export class RuxInput implements FormFieldInterface {
         this._onInput = this._onInput.bind(this)
         this._handleSlotChange = this._handleSlotChange.bind(this)
         this._handleType = this._handleType.bind(this)
-        this._handleTogglePassword = this._handleTogglePassword.bind(this)
+        // this._handleTogglePassword = this._handleTogglePassword.bind(this)
     }
 
     disconnectedCallback() {
@@ -198,6 +206,7 @@ export class RuxInput implements FormFieldInterface {
 
     private _onBlur = () => {
         this.ruxBlur.emit()
+        this.hasFocus = false
     }
 
     private _handleSlotChange() {
@@ -210,14 +219,14 @@ export class RuxInput implements FormFieldInterface {
         }
     }
 
-    private _handleTogglePassword() {
-        this.isPasswordVisible = !this.isPasswordVisible
-        if (this.isPasswordVisible) {
-            this.iconName = 'visibility-off'
-        } else {
-            this.iconName = 'visibility'
-        }
-    }
+    // private _handleTogglePassword() {
+    //     this.isPasswordVisible = !this.isPasswordVisible
+    //     if (this.isPasswordVisible) {
+    //         this.iconName = 'visibility-off'
+    //     } else {
+    //         this.iconName = 'visibility'
+    //     }
+    // }
 
     private _handleType() {
         let realType = ''
@@ -228,6 +237,11 @@ export class RuxInput implements FormFieldInterface {
             : (realType = this.type)
         return realType
     }
+
+    // private _handleFocus() {
+    //     this.hasFocus = true;
+    //     console.log('Handle focus')
+    // }
 
     render() {
         const {
@@ -246,14 +260,14 @@ export class RuxInput implements FormFieldInterface {
             _onBlur,
             _handleType,
             _handleSlotChange,
-            _handleTogglePassword,
+            // _handleTogglePassword,
             placeholder,
             required,
             step,
             type,
             value,
             hasLabel,
-            iconName,
+            // iconName,
             size,
             autocomplete,
             spellcheck,
@@ -291,19 +305,10 @@ export class RuxInput implements FormFieldInterface {
                             </slot>
                         </span>
                     </label>
-                    <input
-                        name={name}
-                        disabled={disabled}
-                        type={_handleType()}
-                        aria-invalid={invalid ? 'true' : 'false'}
-                        placeholder={placeholder}
-                        required={required}
-                        step={step}
-                        min={min}
-                        max={max}
-                        value={value}
+                    <div
                         class={{
                             'rux-input': true,
+                            'rux-input--focused': this.hasFocus,
                             'rux-input--disabled': disabled,
                             'rux-input--invalid': invalid,
                             'rux-input--search': type === 'search',
@@ -311,32 +316,35 @@ export class RuxInput implements FormFieldInterface {
                             'rux-input--medium': size === 'medium',
                             'rux-input--large': size === 'large',
                         }}
-                        id={this.inputId}
-                        spellcheck={spellcheck}
-                        autocomplete={togglePassword ? 'off' : autocomplete}
-                        readonly={readonly}
-                        onChange={_onChange}
-                        onInput={_onInput}
-                        onBlur={_onBlur}
-                        part="input"
-                    ></input>
-                    {togglePassword && (
-                        <div
-                            class={{
-                                'icon-container': true,
-                                'show-password': true,
-                                'with-label': hasLabel,
-                            }}
-                        >
-                            <rux-icon
-                                exportparts="icon"
-                                onClick={_handleTogglePassword}
-                                icon={iconName}
-                                size="extra-small"
-                            />
-                        </div>
-                    )}
+                    >
+                        <span part="prefix" class="rux-input-prefix">
+                            <slot name="prefix"></slot>
+                        </span>
+                        <input
+                            name={name}
+                            disabled={disabled}
+                            type={_handleType()}
+                            aria-invalid={invalid ? 'true' : 'false'}
+                            placeholder={placeholder}
+                            required={required}
+                            step={step}
+                            min={min}
+                            max={max}
+                            value={value}
+                            class="native-input"
+                            id={this.inputId}
+                            spellcheck={spellcheck}
+                            autocomplete={togglePassword ? 'off' : autocomplete}
+                            readonly={readonly}
+                            onChange={_onChange}
+                            onInput={_onInput}
+                            onBlur={_onBlur}
+                            onFocus={() => (this.hasFocus = true)}
+                            part="input"
+                        ></input>
+                    </div>
                 </div>
+
                 <FormFieldMessage
                     errorText={errorText}
                     helpText={helpText}

--- a/packages/web-components/src/components/rux-input/rux-input.tsx
+++ b/packages/web-components/src/components/rux-input/rux-input.tsx
@@ -17,6 +17,8 @@ let id = 0
 
 /**
  * @slot label - The input label
+ * @slot prefix - Left side input icon
+ * @slot suffix - Right side input icon
  * @part error-text - The error text element
  * @part form-field - The form-field wrapper container
  * @part help-text - The help text element

--- a/packages/web-components/src/components/rux-input/rux-input.tsx
+++ b/packages/web-components/src/components/rux-input/rux-input.tsx
@@ -150,6 +150,11 @@ export class RuxInput implements FormFieldInterface {
      */
     @Event({ eventName: 'ruxblur' }) ruxBlur!: EventEmitter
 
+    /**
+     * Fired when an element has gained focus - [link here dummy]
+     */
+    @Event({ eventName: 'ruxfocus' }) ruxFocus!: EventEmitter
+
     @Watch('label')
     handleLabelChange() {
         this._handleSlotChange()
@@ -200,6 +205,11 @@ export class RuxInput implements FormFieldInterface {
         this.hasFocus = false
     }
 
+    private _onFocus = () => {
+        this.ruxFocus.emit()
+        this.hasFocus = true
+    }
+
     private _handleSlotChange() {
         this.hasLabelSlot = hasSlot(this.el, 'label')
     }
@@ -227,6 +237,7 @@ export class RuxInput implements FormFieldInterface {
             _onChange,
             _onInput,
             _onBlur,
+            _onFocus,
             _handleSlotChange,
             _handleTogglePassword,
             placeholder,
@@ -310,10 +321,7 @@ export class RuxInput implements FormFieldInterface {
                             onChange={_onChange}
                             onInput={_onInput}
                             onBlur={_onBlur}
-                            onFocus={
-                                () =>
-                                    (this.hasFocus = true) /*! probs a better way, focus event?*/
-                            }
+                            onFocus={_onFocus}
                             part="input"
                         ></input>
                         {this.togglePassword ? (

--- a/packages/web-components/src/components/rux-input/rux-input.tsx
+++ b/packages/web-components/src/components/rux-input/rux-input.tsx
@@ -153,7 +153,7 @@ export class RuxInput implements FormFieldInterface {
     @Event({ eventName: 'ruxblur' }) ruxBlur!: EventEmitter
 
     /**
-     * Fired when an element has gained focus - [link here dummy]
+     * Fired when an element has gained focus - [HTMLElement/focus_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)
      */
     @Event({ eventName: 'ruxfocus' }) ruxFocus!: EventEmitter
 

--- a/packages/web-components/src/components/rux-input/rux-input.tsx
+++ b/packages/web-components/src/components/rux-input/rux-input.tsx
@@ -44,8 +44,6 @@ export class RuxInput implements FormFieldInterface {
 
     @State() hasFocus = false
 
-    @State() iconName = 'visibility'
-
     /**
      * The input label text. For HTML content, use the `label` slot instead.
      */
@@ -157,12 +155,6 @@ export class RuxInput implements FormFieldInterface {
         this._handleSlotChange()
     }
 
-    // @Watch('hasFocus')
-    // handleFocusChange() {
-    //     // this._handleFocus()
-    //     console.log('watch')
-    // }
-
     @Watch('type')
     handleTypeChange() {
         this._setTogglePassword()
@@ -172,7 +164,6 @@ export class RuxInput implements FormFieldInterface {
         this._onChange = this._onChange.bind(this)
         this._onInput = this._onInput.bind(this)
         this._handleSlotChange = this._handleSlotChange.bind(this)
-        this._handleType = this._handleType.bind(this)
         this._handleTogglePassword = this._handleTogglePassword.bind(this)
     }
 
@@ -214,28 +205,11 @@ export class RuxInput implements FormFieldInterface {
     }
 
     private _setTogglePassword() {
-        if (this.type === 'password') {
-            this.togglePassword = true
-        }
+        this.type === 'password' ? (this.togglePassword = true) : false
     }
 
     private _handleTogglePassword() {
         this.isPasswordVisible = !this.isPasswordVisible
-        if (this.isPasswordVisible) {
-            this.iconName = 'visibility-off'
-        } else {
-            this.iconName = 'visibility'
-        }
-    }
-
-    private _handleType() {
-        let realType = ''
-        !this.togglePassword
-            ? (realType = this.type)
-            : this.togglePassword && this.isPasswordVisible
-            ? (realType = 'text')
-            : (realType = this.type)
-        return realType
     }
 
     render() {
@@ -261,7 +235,6 @@ export class RuxInput implements FormFieldInterface {
             type,
             value,
             hasLabel,
-            iconName,
             size,
             autocomplete,
             spellcheck,
@@ -344,12 +317,23 @@ export class RuxInput implements FormFieldInterface {
                             part="input"
                         ></input>
                         {this.togglePassword ? (
-                            <rux-icon
-                                exportparts="icon"
+                            <rux-button
+                                borderless
+                                iconOnly
+                                size="small"
                                 onClick={_handleTogglePassword}
-                                icon={iconName}
-                                size="extra-small"
-                            />
+                                class="pw-button"
+                            >
+                                <rux-icon
+                                    exportparts="icon"
+                                    icon={
+                                        this.isPasswordVisible
+                                            ? 'visibility-off'
+                                            : 'visibility'
+                                    }
+                                    size="extra-small"
+                                />
+                            </rux-button>
                         ) : null}
                         <span part="suffix" class="rux-input-suffix">
                             <slot name="suffix"></slot>

--- a/packages/web-components/src/components/rux-input/test/__snapshots__/rux-input.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-input/test/__snapshots__/rux-input.spec.tsx.snap
@@ -9,7 +9,15 @@ exports[`rux-input renders 1`] = `
           <slot name="label"></slot>
         </span>
       </label>
-      <input aria-invalid="false" class="rux-input rux-input--medium" id="rux-input-1" part="input" type="text" value="">
+      <div class="rux-input rux-input--medium">
+        <span class="rux-input-prefix" part="prefix">
+          <slot name="prefix"></slot>
+        </span>
+        <input aria-invalid="false" class="native-input" id="rux-input-1" part="input" type="text" value="">
+        <span class="rux-input-suffix" part="suffix">
+          <slot name="suffix"></slot>
+        </span>
+      </div>
     </div>
   </mock:shadow-root>
   <input class="aux-input" type="hidden" value="">
@@ -27,7 +35,15 @@ exports[`rux-input renders label prop 1`] = `
           </slot>
         </span>
       </label>
-      <input aria-invalid="false" class="rux-input rux-input--medium" id="rux-input-2" part="input" type="text" value="">
+      <div class="rux-input rux-input--medium">
+        <span class="rux-input-prefix" part="prefix">
+          <slot name="prefix"></slot>
+        </span>
+        <input aria-invalid="false" class="native-input" id="rux-input-2" part="input" type="text" value="">
+        <span class="rux-input-suffix" part="suffix">
+          <slot name="suffix"></slot>
+        </span>
+      </div>
     </div>
   </mock:shadow-root>
   <input class="aux-input" type="hidden" value="">
@@ -43,7 +59,15 @@ exports[`rux-input renders label slot 1`] = `
           <slot name="label"></slot>
         </span>
       </label>
-      <input aria-invalid="false" class="rux-input rux-input--medium" id="rux-input-3" part="input" type="text" value="">
+      <div class="rux-input rux-input--medium">
+        <span class="rux-input-prefix" part="prefix">
+          <slot name="prefix"></slot>
+        </span>
+        <input aria-invalid="false" class="native-input" id="rux-input-3" part="input" type="text" value="">
+        <span class="rux-input-suffix" part="suffix">
+          <slot name="suffix"></slot>
+        </span>
+      </div>
     </div>
   </mock:shadow-root>
   <div slot="label">
@@ -62,9 +86,17 @@ exports[`rux-input renders rux-icon if type is password 1`] = `
           <slot name="label"></slot>
         </span>
       </label>
-      <input aria-invalid="false" autocomplete="off" class="rux-input rux-input--medium" id="rux-input-4" part="input" type="password" value="">
-      <div class="icon-container show-password">
-        <rux-icon exportparts="icon" icon="visibility" size="extra-small"></rux-icon>
+      <div class="rux-input rux-input--medium">
+        <span class="rux-input-prefix" part="prefix">
+          <slot name="prefix"></slot>
+        </span>
+        <input aria-invalid="false" autocomplete="off" class="native-input" id="rux-input-4" part="input" type="password" value="">
+        <rux-button borderless="" class="pw-button" icononly="" size="small">
+          <rux-icon exportparts="icon" icon="visibility" size="extra-small"></rux-icon>
+        </rux-button>
+        <span class="rux-input-suffix" part="suffix">
+          <slot name="suffix"></slot>
+        </span>
       </div>
     </div>
   </mock:shadow-root>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -24,6 +24,7 @@
             <rux-input
                 name="text"
                 error-text="Error Text"
+                disabled
                 type="text"
                 placeholder="Text"
                 label="Medium Input"
@@ -39,56 +40,7 @@
                     size="extra-small"
                 ></rux-icon>
             </rux-input>
-            <br />
-            <rux-input
-                name="text"
-                error-text="Error Text"
-                type="text"
-                placeholder="Text"
-                size="large"
-                label="Large Input"
-            >
-                <rux-icon
-                    icon="altitude"
-                    slot="prefix"
-                    size="extra-small"
-                ></rux-icon>
-                <rux-icon
-                    icon="close"
-                    slot="suffix"
-                    size="extra-small"
-                ></rux-icon>
-            </rux-input>
-            <br />
-            <rux-input
-                name="text"
-                error-text="Error Text"
-                type="text"
-                placeholder="Text"
-                size="small"
-                label="Small Input"
-            >
-                <rux-icon
-                    icon="border-clear"
-                    slot="prefix"
-                    size="extra-small"
-                ></rux-icon>
-                <rux-icon
-                    icon="border-clear"
-                    slot="suffix"
-                    size="extra-small"
-                ></rux-icon>
-            </rux-input>
-            <br />
-            <rux-input
-                name="pw"
-                error-text="Error Text"
-                type="password"
-                placeholder="PW"
-                label="PW Label"
-                size="small"
-            >
-            </rux-input>
+
             <rux-input
                 name="pw"
                 error-text="Error Text"
@@ -96,15 +48,6 @@
                 placeholder="PW"
                 label="PW Label"
                 size="medium"
-            >
-            </rux-input>
-            <rux-input
-                name="pw"
-                error-text="Error Text"
-                type="password"
-                placeholder="PW"
-                label="PW Label"
-                size="large"
             >
             </rux-input>
             <br />

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -19,52 +19,5 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body>
-        <div style="padding-left: 1%; width: 300px">
-            <rux-input
-                name="text"
-                error-text="Error Text"
-                disabled
-                type="text"
-                placeholder="Text"
-                label="Medium Input"
-            >
-                <rux-icon
-                    icon="border-clear"
-                    slot="prefix"
-                    size="extra-small"
-                ></rux-icon>
-                <rux-icon
-                    icon="border-clear"
-                    slot="suffix"
-                    size="extra-small"
-                ></rux-icon>
-            </rux-input>
-
-            <rux-input
-                name="pw"
-                error-text="Error Text"
-                type="password"
-                placeholder="PW"
-                label="PW Label"
-                size="medium"
-            >
-            </rux-input>
-            <br />
-            <rux-input
-                name="search"
-                error-text="Error Text"
-                type="search"
-                placeholder="Search"
-                label="Search Label"
-            >
-            </rux-input>
-        </div>
-    </body>
-    <script>
-        const test = document.querySelector('rux-input')
-        test.addEventListener('ruxfocus', () => {
-            console.log('heard focus')
-        })
-    </script>
+    <body></body>
 </html>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -26,7 +26,7 @@
                 error-text="Error Text"
                 type="text"
                 placeholder="Text"
-                label="Text Label"
+                label="Medium Input"
             >
                 <rux-icon
                     icon="border-clear"
@@ -46,7 +46,7 @@
                 type="text"
                 placeholder="Text"
                 size="large"
-                label="Text Label"
+                label="Large Input"
             >
                 <rux-icon
                     icon="altitude"
@@ -65,8 +65,8 @@
                 error-text="Error Text"
                 type="text"
                 placeholder="Text"
-                size="extra-small"
-                label="Text Label"
+                size="small"
+                label="Small Input"
             >
                 <rux-icon
                     icon="border-clear"
@@ -76,7 +76,7 @@
                 <rux-icon
                     icon="border-clear"
                     slot="suffix"
-                    size="small"
+                    size="extra-small"
                 ></rux-icon>
             </rux-input>
             <br />
@@ -86,7 +86,27 @@
                 type="password"
                 placeholder="PW"
                 label="PW Label"
-            ></rux-input>
+                size="small"
+            >
+            </rux-input>
+            <rux-input
+                name="pw"
+                error-text="Error Text"
+                type="password"
+                placeholder="PW"
+                label="PW Label"
+                size="medium"
+            >
+            </rux-input>
+            <rux-input
+                name="pw"
+                error-text="Error Text"
+                type="password"
+                placeholder="PW"
+                label="PW Label"
+                size="large"
+            >
+            </rux-input>
             <br />
             <rux-input
                 name="search"

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -20,7 +20,7 @@
     </head>
 
     <body>
-        <div style="padding-left: 5%; width: 300px">
+        <div style="padding-left: 1%; width: 300px">
             <rux-input
                 name="text"
                 error-text="Error Text"
@@ -28,8 +28,16 @@
                 placeholder="Text"
                 label="Text Label"
             >
-                <rux-icon icon="altitude" slot="prefix" size="small"></rux-icon>
-                <rux-icon icon="close" slot="suffix" size="small"></rux-icon>
+                <rux-icon
+                    icon="border-clear"
+                    slot="prefix"
+                    size="extra-small"
+                ></rux-icon>
+                <rux-icon
+                    icon="border-clear"
+                    slot="suffix"
+                    size="extra-small"
+                ></rux-icon>
             </rux-input>
             <br />
             <rux-input
@@ -52,8 +60,16 @@
                 size="small"
                 label="Text Label"
             >
-                <rux-icon icon="close" slot="prefix" size="small"></rux-icon>
-                <rux-icon icon="close" slot="suffix" size="small"></rux-icon>
+                <rux-icon
+                    icon="border-clear"
+                    slot="prefix"
+                    size="small"
+                ></rux-icon>
+                <rux-icon
+                    icon="border-clear"
+                    slot="suffix"
+                    size="small"
+                ></rux-icon>
             </rux-input>
             <br />
             <rux-input
@@ -74,4 +90,12 @@
             </rux-input>
         </div>
     </body>
+    <script>
+        const test = document.getElementById('test')
+        test.addEventListener('click', () => {
+            if (test.icon === 'border-clear') {
+                test.icon = 'close'
+            } else test.icon = 'border-clear'
+        })
+    </script>
 </html>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -28,7 +28,7 @@
                 placeholder="Text"
                 label="Text Label"
             >
-                <rux-icon icon="close" slot="prefix" size="small"></rux-icon>
+                <rux-icon icon="altitude" slot="prefix" size="small"></rux-icon>
                 <rux-icon icon="close" slot="suffix" size="small"></rux-icon>
             </rux-input>
             <br />

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -20,18 +20,36 @@
     </head>
 
     <body>
-        <style>
-            rux-input::part(icon) {
-                height: 1rem;
-                width: 1rem;
-            }
-        </style>
-        <div style="padding: 5%; width: 300px">
+        <div style="padding-left: 5%; width: 300px">
             <rux-input
                 name="text"
                 error-text="Error Text"
                 type="text"
                 placeholder="Text"
+                label="Text Label"
+            >
+                <rux-icon icon="close" slot="prefix" size="small"></rux-icon>
+                <rux-icon icon="close" slot="suffix" size="small"></rux-icon>
+            </rux-input>
+            <br />
+            <rux-input
+                name="text"
+                error-text="Error Text"
+                type="text"
+                placeholder="Text"
+                size="large"
+                label="Text Label"
+            >
+                <rux-icon icon="altitude" slot="prefix" size="small"></rux-icon>
+                <rux-icon icon="close" slot="suffix" size="small"></rux-icon>
+            </rux-input>
+            <br />
+            <rux-input
+                name="text"
+                error-text="Error Text"
+                type="text"
+                placeholder="Text"
+                size="small"
                 label="Text Label"
             >
                 <rux-icon icon="close" slot="prefix" size="small"></rux-icon>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -48,8 +48,16 @@
                 size="large"
                 label="Text Label"
             >
-                <rux-icon icon="altitude" slot="prefix" size="small"></rux-icon>
-                <rux-icon icon="close" slot="suffix" size="small"></rux-icon>
+                <rux-icon
+                    icon="altitude"
+                    slot="prefix"
+                    size="extra-small"
+                ></rux-icon>
+                <rux-icon
+                    icon="close"
+                    slot="suffix"
+                    size="extra-small"
+                ></rux-icon>
             </rux-input>
             <br />
             <rux-input
@@ -57,13 +65,13 @@
                 error-text="Error Text"
                 type="text"
                 placeholder="Text"
-                size="small"
+                size="extra-small"
                 label="Text Label"
             >
                 <rux-icon
                     icon="border-clear"
                     slot="prefix"
-                    size="small"
+                    size="extra-small"
                 ></rux-icon>
                 <rux-icon
                     icon="border-clear"
@@ -91,11 +99,9 @@
         </div>
     </body>
     <script>
-        const test = document.getElementById('test')
-        test.addEventListener('click', () => {
-            if (test.icon === 'border-clear') {
-                test.icon = 'close'
-            } else test.icon = 'border-clear'
+        const test = document.querySelector('rux-input')
+        test.addEventListener('ruxfocus', () => {
+            console.log('heard focus')
         })
     </script>
 </html>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -19,5 +19,34 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body></body>
+    <body>
+        <div style="padding: 5%; width: 300px">
+            <rux-input
+                name="text"
+                error-text="Error Text"
+                type="text"
+                placeholder="Text"
+                label="Text Label"
+            >
+                <rux-icon icon="close" slot="prefix"></rux-icon>
+            </rux-input>
+            <br />
+            <rux-input
+                name="pw"
+                error-text="Error Text"
+                type="password"
+                placeholder="PW"
+                label="PW Label"
+            ></rux-input>
+            <br />
+            <rux-input
+                name="search"
+                error-text="Error Text"
+                type="search"
+                placeholder="Search"
+                label="Search Label"
+            >
+            </rux-input>
+        </div>
+    </body>
 </html>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -20,6 +20,12 @@
     </head>
 
     <body>
+        <style>
+            rux-input::part(icon) {
+                height: 1rem;
+                width: 1rem;
+            }
+        </style>
         <div style="padding: 5%; width: 300px">
             <rux-input
                 name="text"
@@ -28,7 +34,8 @@
                 placeholder="Text"
                 label="Text Label"
             >
-                <rux-icon icon="close" slot="prefix"></rux-icon>
+                <rux-icon icon="close" slot="prefix" size="small"></rux-icon>
+                <rux-icon icon="close" slot="suffix" size="small"></rux-icon>
             </rux-input>
             <br />
             <rux-input

--- a/packages/web-components/src/stories/input.stories.mdx
+++ b/packages/web-components/src/stories/input.stories.mdx
@@ -144,6 +144,12 @@ export const Required = (args) => {
 
 ### With Icons
 
+Icons on either the left or right can be accomplished using the named slots `prefix` or `suffix`.
+For example,
+```html
+<rux-icon icon="apps" slot="prefix"></rux-icon>
+```
+
 export const WithIcons = (args) => {
     return html`
 <rux-input

--- a/packages/web-components/src/stories/input.stories.mdx
+++ b/packages/web-components/src/stories/input.stories.mdx
@@ -142,6 +142,91 @@ export const Required = (args) => {
     </Story>
 </Canvas>
 
+### With Icons
+
+export const WithIcons = (args) => {
+    return html`
+<rux-input
+    label="With Prefix"
+    ?disabled="${args.disabled}"
+    .errorText="${args.errorText}"
+    ?invalid="${args.invalid}"
+    .helpText="${args.helpText}"
+    .min="${args.min}"
+    .max="${args.max}"
+    .name="${args.name}"
+    .placeholder="${args.placeholder}"
+    ?required="${args.required}"
+    .size="${args.size}"
+    .value="${args.value}"
+    type=${args.type}
+    .step="${args.step}"
+    ?readonly="${args.readonly}"
+    ?autocomplete="${args.autocomplete}"
+    ?spellcheck="${args.spellcheck}"
+>
+    <rux-icon slot="prefix" icon="border-clear" size="extra-small"></rux-icon>
+</rux-input>
+<br />
+<rux-input
+    label="With Suffix"
+    ?disabled="${args.disabled}"
+    .errorText="${args.errorText}"
+    ?invalid="${args.invalid}"
+    .helpText="${args.helpText}"
+    .min="${args.min}"
+    .max="${args.max}"
+    .name="${args.name}"
+    .placeholder="${args.placeholder}"
+    ?required="${args.required}"
+    .size="${args.size}"
+    .value="${args.value}"
+    type=${args.type}
+    .step="${args.step}"
+    ?readonly="${args.readonly}"
+    ?autocomplete="${args.autocomplete}"
+    ?spellcheck="${args.spellcheck}"
+>
+    <rux-icon slot="suffix" icon="border-clear" size="extra-small"></rux-icon>
+</rux-input>
+<br />
+<rux-input
+    label="With Prefix and Suffix"
+    ?disabled="${args.disabled}"
+    .errorText="${args.errorText}"
+    ?invalid="${args.invalid}"
+    .helpText="${args.helpText}"
+    .min="${args.min}"
+    .max="${args.max}"
+    .name="${args.name}"
+    .placeholder="${args.placeholder}"
+    ?required="${args.required}"
+    .size="${args.size}"
+    .value="${args.value}"
+    type=${args.type}
+    .step="${args.step}"
+    ?readonly="${args.readonly}"
+    ?autocomplete="${args.autocomplete}"
+    ?spellcheck="${args.spellcheck}"
+>
+    <rux-icon slot="prefix" icon="border-clear" size="extra-small"></rux-icon>
+    <rux-icon slot="suffix" icon="border-clear" size="extra-small"></rux-icon>
+</rux-input>
+    `
+}
+
+<Canvas>
+    <Story
+        name="With Icons"
+        args={{
+            type: 'text',
+            size: "medium"
+        }}
+    >
+        {WithIcons.bind()}
+    </Story>
+</Canvas>
+
 ### Sizes
 
 export const Sizes = (args) => {


### PR DESCRIPTION
## Brief Description

Additions:
- Two new named slots, prefix/suffix used to render html on the left and right of input. Open to name change.
- Refactored how show/hide of PW input types visibility icon worked - now using a rux-button with a slotted icon.
- Refactored some markup in order to accomplish styling 
- Added a new event, `ruxfocus` that emits on blur. Just kidding, focus. Added this as I've seen it's a common event, and this allowed me to style the entirety of `rux-input` while it's focused.
- Adds a `With Icons` story to rux-input's stories. This includes a blurb about using the named slots to render the icons
- Updated rux-icon snapshots. 
- Updates padding for each input size, adds a min height for each as well.

Will have a backstop PR open with the reference updates and will merge it once this is merged.

## JIRA Link

New slots -> https://rocketcom.atlassian.net/browse/ASTRO-2996
Padding -> https://rocketcom.atlassian.net/browse/ASTRO-2997
PW Icon -> https://rocketcom.atlassian.net/browse/ASTRO-2998

## Related Issue

## General Notes


## Motivation and Context

Matches design, allows devs to easily use icons within our inputs. Updates the way that pw inputs are rendered to improve accessibility 

## Issues and Limitations

The visibility on/off icon is still the slightest bit off center, so I added some specific padding to it. I will comment on it for ease of location, but let me know if there is a better way/I'm missing something.

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [x] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
