### PR TITLE
fix(notification): Watch closeAfter to close when updated

### DIFF
--- a/packages/web-components/src/components/rux-notification/rux-notification.tsx
+++ b/packages/web-components/src/components/rux-notification/rux-notification.tsx
@@ -52,6 +52,7 @@ export class RuxNotification {
     private _timeoutRef: number | null = null
 
     @Watch('open')
+    @Watch('closeAfter')
     watchHandler() {
         this._updated()
         if (!this.open) {


### PR DESCRIPTION
## Brief Description

the closeAfter prop on the Notification component did not update in Storybook when a value was entered on the first story

[ASTRO-3101](https://rocketcom.atlassian.net/browse/ASTRO-3101)


## Types of changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
