### PR TITLE
docs(checkbox): added a without labels variant to SB

### DIFF
--- a/packages/web-components/src/stories/checkbox.stories.mdx
+++ b/packages/web-components/src/stories/checkbox.stories.mdx
@@ -172,6 +172,26 @@ export const Indeterminate = (args) => {
     </Story>
 </Canvas>
 
+### Without Labels
+
+export const NoLabels = (args) => {
+    return html`
+<div style="display: flex; flex-direction: column;">
+    <rux-checkbox></rux-checkbox>
+    <br />
+    <rux-checkbox checked></rux-checkbox>
+    <br />
+    <rux-checkbox indeterminate></rux-checkbox>
+    <br />
+    <rux-checkbox disabled></rux-checkbox>
+</div>
+    `
+}
+
+<Canvas>
+    <Story name="Without Lables">{NoLabels.bind()}</Story>
+</Canvas>
+
 ### With Help Text
 
 export const WithHelpText = (args) => {


### PR DESCRIPTION
## Brief Description

Adds a without labels variant to checkbox that shows regular, checked, indeterminate and disabled checkboxes without labels.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2995

## Related Issue

## General Notes

## Motivation and Context

Dev -> Design audit. Figma has these variants explicitly created 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
