### PR TITLE
fix(notification): watch closeAfter to close when updated

### DIFF
--- a/.changeset/shiny-yaks-hide.md
+++ b/.changeset/shiny-yaks-hide.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+fix(notification): Watch closeAfter to close when updated

--- a/packages/web-components/src/components/rux-notification/rux-notification.tsx
+++ b/packages/web-components/src/components/rux-notification/rux-notification.tsx
@@ -52,6 +52,7 @@ export class RuxNotification {
     private _timeoutRef: number | null = null
 
     @Watch('open')
+    @Watch('closeAfter')
     watchHandler() {
         this._updated()
         if (!this.open) {


### PR DESCRIPTION
## Brief Description

Notification would not close on default story when entering a value in the closeAfter prop in Storybook

  ## JIRA Link

[ASTRO-3101](https://rocketcom.atlassian.net/browse/ASTRO-3101)

## Related Issue

## General Notes

## Motivation and Context

## Issues and Limitations

## Types of changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
