### PR TITLE
fix(slider): changed value to parseFloat

### DIFF
--- a/.changeset/six-carpets-rush.md
+++ b/.changeset/six-carpets-rush.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Changes the value logic on slider to accept float values.

--- a/packages/web-components/src/components/rux-slider/rux-slider.tsx
+++ b/packages/web-components/src/components/rux-slider/rux-slider.tsx
@@ -188,7 +188,7 @@ export class RuxSlider implements FormFieldInterface {
 
     private _onInput(e: Event) {
         const target = e.target as HTMLInputElement
-        this.value = parseInt(target.value)
+        this.value = parseFloat(target.value)
         this._setValuePercent()
         this.ruxInput.emit()
     }


### PR DESCRIPTION
## Brief Description

Changes the value equation from`parseInt` to `parseFloat` to allow float values.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-3171

## Related Issue

Brought up by ACME and Outside Analytics 

## General Notes

## Motivation and Context

Allows for value to be a float, now styling remains correct when using float values.

## Issues and Limitations

The default value should be a factor of the step still, otherwise the styling is broken when it first renders. For example, 
```
<rux-slider step=1.5></rux-slider>
```
will default to value = 50, which will screw up the styling.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
