### PR TITLE
style(button): width can now be stlyed without shadow part

### DIFF
--- a/.changeset/kind-rabbits-press.md
+++ b/.changeset/kind-rabbits-press.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Moves width attribute out of shadow dom, can now be styled without CSS parts.

--- a/packages/web-components/src/components/rux-button/rux-button.scss
+++ b/packages/web-components/src/components/rux-button/rux-button.scss
@@ -76,6 +76,7 @@
     --button-borderless-hover-color: var(--color-hover);
 
     display: inline-block;
+    width: auto;
 }
 
 :host([hidden]) {
@@ -89,6 +90,7 @@
     display: flex;
     position: relative;
     margin: 0;
+    width: inherit;
     padding: 0 1rem;
     height: 2.125rem;
     min-width: 2.25rem;


### PR DESCRIPTION
## Brief Description

Adds `width: auto` to the host styling of rux-button, allowing the width to be changed without the shadow part.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-3218

## Related Issue

## General Notes

## Motivation and Context

Astro Monday's

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
