### PR TITLE
fix(angular-starter): move style import to angular.json

### DIFF
--- a/packages/starter-kits/angular-starter/angular.json
+++ b/packages/starter-kits/angular-starter/angular.json
@@ -27,7 +27,10 @@
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["src/styles.scss"],
+            "styles": [
+              "src/styles.scss",
+              "./node_modules/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
+            ],
             "scripts": []
           },
           "configurations": {

--- a/packages/starter-kits/angular-starter/src/styles.scss
+++ b/packages/starter-kits/angular-starter/src/styles.scss
@@ -1,2 +1,1 @@
 /* You can add global styles to this file, and also import other style files */
-@import "@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css";


### PR DESCRIPTION
## Brief Description

angular starter kit wasn't showing styles 
if you put the css import in styles.scss, it worked locally but not in codesandbox
if you put it in the main.ts, it worked in codesandbox but not locally. 
so I just moved it to angular.json.
I'm still keeping the docs the way they are because I still believe that its the easiest way for running locally

## JIRA Link

ASTRO-3215

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
