### PR TITLE
Astro 2986 table selected

### DIFF
--- a/.changeset/four-shirts-relax.md
+++ b/.changeset/four-shirts-relax.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Updated the selected row styling on rux-table and added data to empty column in storybook.

--- a/packages/web-components/src/components/rux-table/rux-table-header-cell/rux-table-header-cell.scss
+++ b/packages/web-components/src/components/rux-table/rux-table-header-cell/rux-table-header-cell.scss
@@ -5,7 +5,7 @@
     border-top-style: solid;
     border-top-color: var(--table-header-border-color);
     background: var(--table-header-background-color);
-    color: var(--table-header-text-color);
+    color: var(--color-text-primary);
     font-family: var(--font-heading-5-font-family);
     font-size: var(--font-heading-5-font-size);
     font-weight: var(--font-heading-5-font-weight);

--- a/packages/web-components/src/components/rux-table/rux-table-row/rux-table-row.scss
+++ b/packages/web-components/src/components/rux-table/rux-table-row/rux-table-row.scss
@@ -7,9 +7,9 @@
 }
 
 :host(.is-selected) {
-    background: var(--table-row-selected-background-color);
+    background: var(--color-background-surface-selected);
     ::slotted(rux-table-cell) {
-        border-color: var(--table-row-selected-border-color);
+        border-color: var(--color-background-base-default);
     }
 }
 

--- a/packages/web-components/src/stories/table.stories.mdx
+++ b/packages/web-components/src/stories/table.stories.mdx
@@ -175,6 +175,7 @@ export const WithSelectedRow = (args) => {
             <rux-table-cell>450</rux-table-cell>
             <rux-table-cell>Full</rux-table-cell>
             <rux-table-cell>2020 158 01:23:45:678</rux-table-cell>
+            <rux-table-cell>OBTYPE_5</rux-table-cell>
             <rux-table-cell>150</rux-table-cell>
             <rux-table-cell>3500</rux-table-cell>
             <rux-table-cell>7500</rux-table-cell>
@@ -186,6 +187,7 @@ export const WithSelectedRow = (args) => {
             <rux-table-cell>450</rux-table-cell>
             <rux-table-cell>Full</rux-table-cell>
             <rux-table-cell>2020 158 01:23:45:678</rux-table-cell>
+            <rux-table-cell>OBTYPE_5</rux-table-cell>
             <rux-table-cell>150</rux-table-cell>
             <rux-table-cell>3500</rux-table-cell>
             <rux-table-cell>7500</rux-table-cell>
@@ -197,6 +199,7 @@ export const WithSelectedRow = (args) => {
             <rux-table-cell>450</rux-table-cell>
             <rux-table-cell>Full</rux-table-cell>
             <rux-table-cell>2020 158 01:23:45:678</rux-table-cell>
+            <rux-table-cell>OBTYPE_5</rux-table-cell>
             <rux-table-cell>150</rux-table-cell>
             <rux-table-cell>3500</rux-table-cell>
             <rux-table-cell>7500</rux-table-cell>


### PR DESCRIPTION
## Brief Description

Changes the selected cell color to match figma and updates the table w/ selected row story to have the correct amount of columns. 
Also changes the color on rux-table-header-cell to be `var(--color-text-primary)` so that is is correct in light theme.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-2986

## Related Issue

## General Notes

## Motivation and Context

Dev -> design audit 

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
