### PR TITLE
fix(astro-uxds): added Astro Icons links

### DIFF
--- a/packages/astro-uxds/_content/downloads.md
+++ b/packages/astro-uxds/_content/downloads.md
@@ -12,7 +12,7 @@ title: Downloads
 
 - Astro Component Source Code ([Git Repository](https://github.com/RocketCommunicationsInc/astro-components))
 - Astro UXDS Figma Page ([Figma](https://www.figma.com/community/file/1014254163928270411))
-- Astro Icons ([SVG](https://github.com/RocketCommunicationsInc/astro/tree/main/packages/web-components/src/icons) | [Figma](https://www.figma.com/community/file/1022883566772542677))
+- Astro Icons ([SVG](https://github.com/RocketCommunicationsInc/astro/tree/main/packages/web-components/src/icons) | [Figma](https://www.figma.com/community/file/1022883566772542677)
 - Astro React Wrapper ([Git Repository](https://github.com/RocketCommunicationsInc/astro/tree/main/packages/react))
 - Astro React Starter Kit ([Git Repository](https://github.com/RocketCommunicationsInc/astro/blob/main/packages/starter-kits/react-starter/README.md))
 - Astro Svelte Starter Kit ([Git Repository](https://github.com/RocketCommunicationsInc/astro/blob/main/packages/starter-kits/svelte-starter/README.md))

--- a/packages/astro-uxds/_content/downloads.md
+++ b/packages/astro-uxds/_content/downloads.md
@@ -12,7 +12,7 @@ title: Downloads
 
 - Astro Component Source Code ([Git Repository](https://github.com/RocketCommunicationsInc/astro-components))
 - Astro UXDS Figma Page ([Figma](https://www.figma.com/community/file/1014254163928270411))
-- Astro Icons ([SVG]() | [Figma]())
+- Astro Icons ([SVG](https://github.com/RocketCommunicationsInc/astro/tree/main/packages/web-components/src/icons) | [Figma](https://www.figma.com/community/file/1022883566772542677))
 - Astro React Wrapper ([Git Repository](https://github.com/RocketCommunicationsInc/astro/tree/main/packages/react))
 - Astro React Starter Kit ([Git Repository](https://github.com/RocketCommunicationsInc/astro/blob/main/packages/starter-kits/react-starter/README.md))
 - Astro Svelte Starter Kit ([Git Repository](https://github.com/RocketCommunicationsInc/astro/blob/main/packages/starter-kits/svelte-starter/README.md))


### PR DESCRIPTION
## Brief Description

Links were missing from the Downloads -> Astro Icons hrefs. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-3300
## Related Issue

## General Notes

Links were talked over with Amalya

## Motivation and Context

Links work as expected. 

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
