### PR TITLE
feat(timeline): add support for timezones

### DIFF
--- a/.changeset/happy-foxes-bathe.md
+++ b/.changeset/happy-foxes-bathe.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": minor
+"@astrouxds/angular": minor
+"astro-website": minor
+"@astrouxds/react": minor
+---
+
+[timeline] - add timezone property

--- a/packages/angular/src/directives/proxies.ts
+++ b/packages/angular/src/directives/proxies.ts
@@ -22132,13 +22132,13 @@ export class RuxTimeRegion {
 export declare interface RuxTimeline extends Components.RuxTimeline {}
 
 @ProxyCmp({
-  inputs: ['end', 'interval', 'playhead', 'start', 'zoom']
+  inputs: ['end', 'interval', 'playhead', 'start', 'timezone', 'zoom']
 })
 @Component({
   selector: 'rux-timeline',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['end', 'interval', 'playhead', 'start', 'zoom']
+  inputs: ['end', 'interval', 'playhead', 'start', 'timezone', 'zoom']
 })
 export class RuxTimeline {
   protected el: HTMLElement;

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@astrouxds/astro-web-components",
-    "version": "6.5.0",
+    "version": "6.5.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@astrouxds/astro-web-components",
-            "version": "6.5.0",
+            "version": "6.5.1",
             "license": "MIT",
             "dependencies": {
                 "@stencil/core": "~2.5.2",
                 "date-fns": "~2.21.1",
-                "date-fns-tz": "~1.1.7"
+                "date-fns-tz": "~1.3.3"
             },
             "devDependencies": {
                 "@astrouxds/astro-figma-export": "~1.0.1",
@@ -9741,11 +9741,11 @@
             }
         },
         "node_modules/date-fns-tz": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.1.7.tgz",
-            "integrity": "sha512-xfL918kXO528DJ17Sao60H07rYv5L/X0Bp6zojDssuZAR/acYETDS9PaICKAnodcO9XVHL/0bpLRGKd7kNnvcQ==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.3.tgz",
+            "integrity": "sha512-Gks46gwbSauBQnV3Oofluj1wTm8J0tM7sbSJ9P+cJq/ZnTCpMohTKmmO5Tn+jQ7dyn0+b8G7cY4O2DZ5P/LXcA==",
             "peerDependencies": {
-                "date-fns": ">=2.0.0-alpha.13"
+                "date-fns": ">=2.0.0"
             }
         },
         "node_modules/dayjs": {
@@ -55285,9 +55285,9 @@
             "integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw=="
         },
         "date-fns-tz": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.1.7.tgz",
-            "integrity": "sha512-xfL918kXO528DJ17Sao60H07rYv5L/X0Bp6zojDssuZAR/acYETDS9PaICKAnodcO9XVHL/0bpLRGKd7kNnvcQ==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.3.tgz",
+            "integrity": "sha512-Gks46gwbSauBQnV3Oofluj1wTm8J0tM7sbSJ9P+cJq/ZnTCpMohTKmmO5Tn+jQ7dyn0+b8G7cY4O2DZ5P/LXcA==",
             "requires": {}
         },
         "dayjs": {

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -41,7 +41,7 @@
     "dependencies": {
         "@stencil/core": "~2.5.2",
         "date-fns": "~2.21.1",
-        "date-fns-tz": "~1.1.7"
+        "date-fns-tz": "~1.3.3"
     },
     "license": "MIT",
     "devDependencies": {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -12228,6 +12228,7 @@ export namespace Components {
         "end": string;
         "interval": any;
         "start": string;
+        "timezone": string;
     }
     interface RuxSegmentedButton {
         /**
@@ -12490,6 +12491,7 @@ export namespace Components {
           * Short hand attribute for displaying a Status icon and appropriate border color.
          */
         "status"?: 'normal' | 'critical' | 'serious' | 'caution' | 'standby';
+        "timezone": string;
     }
     interface RuxTimeline {
         /**
@@ -12509,6 +12511,10 @@ export namespace Components {
          */
         "start": string;
         /**
+          * Controls the timezone that the timeline is localized to. Must be an IANA time zone name ("America/New_York") or an offset string.
+         */
+        "timezone": string;
+        /**
           * The timeline's zoom level.
          */
         "zoom": number;
@@ -12518,6 +12524,7 @@ export namespace Components {
         "end": string;
         "interval": any;
         "start": string;
+        "timezone": string;
         "width": number;
     }
     interface RuxTree {
@@ -32545,6 +32552,7 @@ declare namespace LocalJSX {
         "end"?: string;
         "interval"?: any;
         "start"?: string;
+        "timezone"?: string;
     }
     interface RuxSegmentedButton {
         /**
@@ -32859,6 +32867,7 @@ declare namespace LocalJSX {
           * Short hand attribute for displaying a Status icon and appropriate border color.
          */
         "status"?: 'normal' | 'critical' | 'serious' | 'caution' | 'standby';
+        "timezone"?: string;
     }
     interface RuxTimeline {
         /**
@@ -32878,6 +32887,10 @@ declare namespace LocalJSX {
          */
         "start"?: string;
         /**
+          * Controls the timezone that the timeline is localized to. Must be an IANA time zone name ("America/New_York") or an offset string.
+         */
+        "timezone"?: string;
+        /**
           * The timeline's zoom level.
          */
         "zoom"?: number;
@@ -32887,6 +32900,7 @@ declare namespace LocalJSX {
         "end"?: string;
         "interval"?: any;
         "start"?: string;
+        "timezone"?: string;
         "width"?: number;
     }
     interface RuxTree {

--- a/packages/web-components/src/components/rux-timeline/helpers.ts
+++ b/packages/web-components/src/components/rux-timeline/helpers.ts
@@ -1,18 +1,27 @@
 import {
-    format,
     addHours,
     differenceInHours,
     addDays,
-    addMonths,
     differenceInDays,
-    differenceInMonths,
 } from 'date-fns'
+import { formatInTimeZone } from 'date-fns-tz'
 
+export async function validateTimezone(timezone: string) {
+    return new Promise((resolve, reject) => {
+        try {
+            formatInTimeZone(new Date(), timezone, 'MM/dd')
+            resolve(true)
+        } catch (e) {
+            reject(false)
+        }
+    })
+}
 export function dateRange(
     start: any,
     end: any,
     interval: any,
-    intervalValue: any = 1
+    intervalValue: any = 1,
+    timezone: any = 'UTC'
 ) {
     const startDate = new Date(start)
     const endDate = new Date(end)
@@ -20,12 +29,14 @@ export function dateRange(
     if (interval === 'day') {
         const days = differenceInDays(endDate, startDate)
 
-        return [...Array(days).keys()].map((i) => {
+        const output = [...Array(days).keys()].map((i) => {
             const time = addDays(startDate, i)
-            const formattedTime = format(time, 'MM/dd')
+            const formattedTime = formatInTimeZone(time, timezone, 'MM/dd')
 
             return formattedTime
         })
+
+        return output
     }
 
     if (interval === 'hour') {
@@ -34,17 +45,13 @@ export function dateRange(
 
         const output = [...Array(days).keys()].map((i) => {
             const time = addHours(startDate, i)
-            const formattedTime = format(time, 'HH:mm')
+
+            const formattedTime = formatInTimeZone(time, timezone, 'HH:mm')
             return formattedTime
         })
 
         return output
     }
 
-    if (interval === 'month') {
-        const months = differenceInMonths(endDate, startDate)
-
-        return [...Array(months).keys()].map((i) => addMonths(startDate, i))
-    }
     return []
 }

--- a/packages/web-components/src/components/rux-timeline/readme.md
+++ b/packages/web-components/src/components/rux-timeline/readme.md
@@ -5,13 +5,14 @@
 
 ## Properties
 
-| Property   | Attribute  | Description                                                                     | Type                  | Default     |
-| ---------- | ---------- | ------------------------------------------------------------------------------- | --------------------- | ----------- |
-| `end`      | `end`      | The timeline's end date. Must be an ISO string "2021-02-02T05:00:00Z"           | `string`              | `''`        |
-| `interval` | `interval` | The timeline's date time interval                                               | `"day" \| "hour"`     | `'hour'`    |
-| `playhead` | `playhead` | The timeline's playhead date time. Must be an ISO string "2021-02-02T05:00:00Z" | `string \| undefined` | `undefined` |
-| `start`    | `start`    | The timeline's start date. Must be an ISO string "2021-02-02T05:00:00Z"         | `string`              | `''`        |
-| `zoom`     | `zoom`     | The timeline's zoom level.                                                      | `number`              | `1`         |
+| Property   | Attribute  | Description                                                                                                                       | Type                  | Default     |
+| ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------- | ----------- |
+| `end`      | `end`      | The timeline's end date. Must be an ISO string "2021-02-02T05:00:00Z"                                                             | `string`              | `''`        |
+| `interval` | `interval` | The timeline's date time interval                                                                                                 | `"day" \| "hour"`     | `'hour'`    |
+| `playhead` | `playhead` | The timeline's playhead date time. Must be an ISO string "2021-02-02T05:00:00Z"                                                   | `string \| undefined` | `undefined` |
+| `start`    | `start`    | The timeline's start date. Must be an ISO string "2021-02-02T05:00:00Z"                                                           | `string`              | `''`        |
+| `timezone` | `timezone` | Controls the timezone that the timeline is localized to. Must be an IANA time zone name ("America/New_York") or an offset string. | `string`              | `'UTC'`     |
+| `zoom`     | `zoom`     | The timeline's zoom level.                                                                                                        | `number`              | `1`         |
 
 
 ## Shadow Parts

--- a/packages/web-components/src/components/rux-timeline/rux-ruler/rux-ruler.tsx
+++ b/packages/web-components/src/components/rux-timeline/rux-ruler/rux-ruler.tsx
@@ -21,12 +21,18 @@ export class RuxRuler {
      */
     @Prop() end: string = ''
 
+    /**
+     * @internal - The Ruler's time zone. Set automatically from the parent Timeline component.
+     */
+    @Prop({ reflect: true }) timezone = 'UTC'
+
     get dateRange() {
         return getRange(
             new Date(this.start),
             new Date(this.end),
             this.interval,
-            1
+            1,
+            this.timezone
         )
     }
 

--- a/packages/web-components/src/components/rux-timeline/rux-ruler/test/__snapshots__/rux-ruler.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-timeline/rux-ruler/test/__snapshots__/rux-ruler.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`rux-ruler renders 1`] = `
-<rux-ruler>
+<rux-ruler timezone="UTC">
   <mock:shadow-root>
     <div class="rux-ruler rux-track"></div>
   </mock:shadow-root>

--- a/packages/web-components/src/components/rux-timeline/rux-time-region/rux-time-region.tsx
+++ b/packages/web-components/src/components/rux-timeline/rux-time-region/rux-time-region.tsx
@@ -1,5 +1,5 @@
 import { Element, Prop, Component, Host, h } from '@stencil/core'
-import { format } from 'date-fns'
+import { formatInTimeZone } from 'date-fns-tz'
 
 /**
  * @slot (default) - The content of the Time Region
@@ -36,6 +36,11 @@ export class RuxTimeRegion {
      */
     @Prop() selected = false
 
+    /**
+     * @internal - The Time Regions's time zone. Set automatically from the parent Track component.
+     */
+    @Prop() timezone = 'UTC'
+
     get formattedTime() {
         if (!this.start || !this.end) {
             return false
@@ -43,9 +48,9 @@ export class RuxTimeRegion {
 
         try {
             return (
-                format(new Date(this.start), 'HH:mm') +
+                formatInTimeZone(new Date(this.start), this.timezone, 'HH:mm') +
                 '-' +
-                format(new Date(this.end), 'HH:mm')
+                formatInTimeZone(new Date(this.end), this.timezone, 'HH:mm')
             )
         } catch (e) {
             return false

--- a/packages/web-components/src/components/rux-timeline/rux-time-region/test/__snapshots__/rux-time-region.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-timeline/rux-time-region/test/__snapshots__/rux-time-region.spec.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rux-time-region renders 1`] = `
+<rux-time-region end="" start="">
+  <mock:shadow-root>
+    <div class="rux-time-region" part="container">
+      <div class="rux-time-region__content">
+        <slot></slot>
+      </div>
+      <div class="rux-time-region__datetime" part="timestamp"></div>
+    </div>
+  </mock:shadow-root>
+</rux-time-region>
+`;

--- a/packages/web-components/src/components/rux-timeline/rux-time-region/test/rux-time-region.spec.tsx
+++ b/packages/web-components/src/components/rux-timeline/rux-time-region/test/rux-time-region.spec.tsx
@@ -3,13 +3,11 @@ import { RuxTimeRegion } from '../rux-time-region'
 
 describe('rux-time-region', () => {
     it('renders', async () => {
-        // const page = await newSpecPage({
-        //     components: [RuxTimeRegion],
-        //     html: `<rux-time-region></rux-time-region>`,
-        // })
+        const page = await newSpecPage({
+            components: [RuxTimeRegion],
+            html: `<rux-time-region></rux-time-region>`,
+        })
 
-        // expect(page.root).toMatchSnapshot()
-
-        expect(1).toBe(1)
+        expect(page.root).toMatchSnapshot()
     })
 })

--- a/packages/web-components/src/components/rux-timeline/rux-timeline.tsx
+++ b/packages/web-components/src/components/rux-timeline/rux-timeline.tsx
@@ -8,6 +8,7 @@ import {
     format,
 } from 'date-fns'
 import { dateRange } from './helpers'
+import { validateTimezone } from './helpers'
 
 /**
  * @part playhead - The timeline's playhead
@@ -55,6 +56,11 @@ export class RuxTimeline {
      */
     @Prop() interval: 'hour' | 'day' = 'hour'
 
+    /**
+     * Controls the timezone that the timeline is localized to. Must be an IANA time zone name ("America/New_York") or an offset string.
+     */
+    @Prop() timezone = 'UTC'
+
     @Watch('playhead')
     syncPlayhead() {
         if (this.playhead) {
@@ -75,6 +81,7 @@ export class RuxTimeline {
     @Watch('start')
     @Watch('end')
     @Watch('interval')
+    @Watch('timezone')
     handleChange() {
         this._updateRegions()
     }
@@ -257,6 +264,7 @@ export class RuxTimeline {
             el.interval = this.interval
             el.start = this.start
             el.end = this.end
+            el.timezone = this.timezone
         })
 
         const rulerSlot = this.rulerContainer?.querySelector(
@@ -279,7 +287,12 @@ export class RuxTimeline {
             const rulerEl = [...rulerTrack.children].find(
                 (el: any) => el.tagName.toLowerCase() === 'rux-ruler'
             ) as HTMLRuxRulerElement
+
             if (rulerEl) {
+                validateTimezone(this.timezone).then(() => {
+                    rulerEl.timezone = this.timezone
+                })
+
                 rulerEl.start = this.start
                 rulerEl.end = this.end
                 rulerEl.interval = this.interval

--- a/packages/web-components/src/components/rux-timeline/rux-track/rux-track.tsx
+++ b/packages/web-components/src/components/rux-timeline/rux-track/rux-track.tsx
@@ -28,17 +28,22 @@ export class RuxTrack {
     @Prop({ reflect: true }) columns = 0
 
     /**
-     * @internal - The Timeline's interval. Set automatically from the parent Timeline component.
+     * @internal - The Track's interval. Set automatically from the parent Timeline component.
      */
     @Prop({ reflect: true }) interval: any
     /**
-     * @internal - The Timeline's start date. Set automatically from the parent Timeline component.
+     * @internal - The Track's start date. Set automatically from the parent Timeline component.
      */
     @Prop({ reflect: true }) start = ''
     /**
-     * @internal - The Timeline's end date. Set automatically from the parent Timeline component.
+     * @internal - The Track's end date. Set automatically from the parent Timeline component.
      */
     @Prop({ reflect: true }) end = ''
+
+    /**
+     * @internal - The Track's time zone. Set automatically from the parent Timeline component.
+     */
+    @Prop({ reflect: true }) timezone = 'UTC'
 
     @Watch('start')
     @Watch('end')
@@ -47,6 +52,11 @@ export class RuxTrack {
         if (old) {
             this.initializeRows()
         }
+    }
+
+    @Watch('timezone')
+    handleTimezoneUpdate() {
+        this.initializeRows()
     }
 
     connectedCallback() {
@@ -141,6 +151,7 @@ export class RuxTrack {
             const isValid = this._validateTimeRegion(el.start, el.end)
 
             if (isValid.success) {
+                el.timezone = this.timezone
                 el.style.gridRow = '1'
                 el.style.visibility = 'inherit'
                 const gridColumn = `${this.calculateGridColumnFromTime(

--- a/packages/web-components/src/components/rux-timeline/rux-track/test/__snapshots__/rux-track.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-timeline/rux-track/test/__snapshots__/rux-track.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`rux-track renders 1`] = `
-<rux-track columns="0" end="" start="" width="0">
+<rux-track columns="0" end="" start="" timezone="UTC" width="0">
   <mock:shadow-root>
     <div class="rux-timeline rux-track" part="container" style="grid-template-columns: [header] 200px repeat(0, 0px);">
       <div class="rux-track__header" part="track-header" style="grid-row: 1;">

--- a/packages/web-components/src/stories/timeline.stories.mdx
+++ b/packages/web-components/src/stories/timeline.stories.mdx
@@ -55,6 +55,29 @@ export const BetaTag = styled.div`
                 }
             }
         },
+        "timezone": {
+            "name": "timezone",
+            "description": "The timeline's timezone",
+            "type": {
+                "name": "string",
+                "required": false
+            },
+            "control": {
+                "type": "text"
+            },
+            "table": {
+                "category": "props",
+                "type": {
+                    "summary": "string"
+                },
+                "defaultValue": {
+                    "summary": "'UTC'"
+                }
+            },
+            "options": [
+                null
+            ]
+        },
         "interval": {
             "name": "interval",
             "description": "The timeline's date time interval",
@@ -184,7 +207,7 @@ export const Default = (args) => {
     }
     return html`
         <div style="width: 1050px; margin: auto">
-            <rux-timeline start="${start}" end="${end}" playhead="${position}" interval="${args.interval}" zoom="${args.zoom}">
+            <rux-timeline timezone="${args.timezone}" start="${start}" end="${end}" playhead="${position}" interval="${args.interval}" zoom="${args.zoom}">
                 <rux-track>
                     <div slot="label">Region 1</div>
                     <rux-time-region start="2021-02-01T01:00:00Z" end="2021-02-01T02:00:00Z">
@@ -250,7 +273,8 @@ export const Default = (args) => {
             interval: 'hour',
             start: '2021-02-01T00:00:00Z',
             end: '2021-02-03T00:00:00Z',
-            playhead: '2021-02-01T04:00:00Z'
+            playhead: '2021-02-01T04:00:00Z',
+            timezone: 'America/New_York'
         }}
     >
         {Default.bind()}
@@ -274,7 +298,12 @@ It is composed of the following subcomponents:
 -  Time Region
 -  Ruler
 
-## Zoom
+### Date Formats and Timezones
+
+When passing in a date to either the timeline, playhead, or time regions, you must specify a time and timezone in your date string, otherwise it will default to the local user's timezone. 
+For example: If you wanted to show "2021-01-01" in UTC, you would pass in `2021-01-01**T00:00:00Z**`. 
+
+### Zoom
 
 The width between each time interval can be controlled by the `zoom` property. By default, it starts at 1 and can be incremented. 
 The column width is automatically calculated based off of the timeline's current interval (days/hours/etc).


### PR DESCRIPTION
## Brief Description

* Adds timezone prop to timeline
* VRT fails because the timezone now defaults to UTC. 

## JIRA Link

ASTRO-3326

## Related Issue

## General Notes

## Motivation and Context

The timeline ruler was displaying in the user's local timezone

## Issues and Limitations

Does the documentation make sense?

## Types of changes

- [x] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
