### PR TITLE
fix(slider): dont render label if not present

### DIFF
--- a/.changeset/loud-humans-study.md
+++ b/.changeset/loud-humans-study.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Slider - hides label if none is present

--- a/packages/web-components/src/components/rux-slider/rux-slider.tsx
+++ b/packages/web-components/src/components/rux-slider/rux-slider.tsx
@@ -241,14 +241,15 @@ export class RuxSlider implements FormFieldInterface {
             <Host>
                 <div class="rux-form-field" part="form-field">
                     <label
-                        class="rux-input-label"
+                        class={{
+                            'rux-input-label': true,
+                            hidden: !this.hasLabel,
+                        }}
                         aria-hidden={this.hasLabel ? 'false' : 'true'}
                         htmlFor={sliderId}
                         part="label"
                     >
-                        <span class={{ hidden: !this.hasLabel }}>
-                            <slot name="label">{label}</slot>
-                        </span>
+                        <slot name="label">{label}</slot>
                     </label>
                     <div
                         class={{

--- a/packages/web-components/src/components/rux-slider/test/__snapshots__/rux-slider.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-slider/test/__snapshots__/rux-slider.spec.tsx.snap
@@ -4,10 +4,8 @@ exports[`rux-slider renders 1`] = `
 <rux-slider style="--slider-value-percent: 50%;">
   <mock:shadow-root>
     <div class="rux-form-field" part="form-field">
-      <label aria-hidden="true" class="rux-input-label" htmlfor="rux-slider-1" part="label">
-        <span class="hidden">
-          <slot name="label"></slot>
-        </span>
+      <label aria-hidden="true" class="hidden rux-input-label" htmlfor="rux-slider-1" part="label">
+        <slot name="label"></slot>
       </label>
       <div class="rux-slider">
         <input aria-disabled="false" aria-label="slider" class="rux-range" id="rux-slider-1" list="steplist" max="100" min="0" part="input" step="1" type="range" value="50">
@@ -23,11 +21,9 @@ exports[`rux-slider renders label prop 1`] = `
   <mock:shadow-root>
     <div class="rux-form-field" part="form-field">
       <label aria-hidden="false" class="rux-input-label" htmlfor="rux-slider-2" part="label">
-        <span>
-          <slot name="label">
-            hello
-          </slot>
-        </span>
+        <slot name="label">
+          hello
+        </slot>
       </label>
       <div class="rux-slider">
         <input aria-disabled="false" aria-label="slider" class="rux-range" id="rux-slider-2" list="steplist" max="100" min="0" part="input" step="1" type="range" value="50">
@@ -43,9 +39,7 @@ exports[`rux-slider renders label slot 1`] = `
   <mock:shadow-root>
     <div class="rux-form-field" part="form-field">
       <label aria-hidden="false" class="rux-input-label" htmlfor="rux-slider-3" part="label">
-        <span>
-          <slot name="label"></slot>
-        </span>
+        <slot name="label"></slot>
       </label>
       <div class="rux-slider">
         <input aria-disabled="false" aria-label="slider" class="rux-range" id="rux-slider-3" list="steplist" max="100" min="0" part="input" step="1" type="range" value="50">


### PR DESCRIPTION
## Brief Description

hides the slider label if none is present

## JIRA Link

ASTRO-3342

## Motivation and Context

If you have a slider without a label, the label still renders and adds unnecessary padding

## Issues and Limitations

Also removed the internal span inside label. I didnt see it being used for anything?

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
