### PR TITLE
fix(table): remove left/right borders

### DIFF
--- a/.changeset/eight-moons-allow.md
+++ b/.changeset/eight-moons-allow.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+table - removed left/right borders to align with design and work inside containers

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -11950,7 +11950,7 @@ export namespace Components {
          */
         "timezone": string;
     }
-    interface RuxLog {
+    interface RuxMenuItem {
         /**
           * Disables the item
          */
@@ -11980,21 +11980,9 @@ export namespace Components {
     }
     interface RuxModal {
         /**
-          * Text for confirmation button
+          * Allows modal to close by clicking off of it
          */
-        "confirmText": string;
-        /**
-          * Text for close button
-         */
-        "denyText": string;
-        /**
-          * Modal body message
-         */
-        "modalMessage"?: string;
-        /**
-          * Modal header title
-         */
-        "modalTitle"?: string;
+        "clickToClose": boolean;
         /**
           * Shows and hides modal
          */
@@ -32278,25 +32266,17 @@ declare namespace LocalJSX {
     }
     interface RuxModal {
         /**
-          * Text for confirmation button
+          * Allows modal to close by clicking off of it
          */
-        "confirmText"?: string;
-        /**
-          * Text for close button
-         */
-        "denyText"?: string;
-        /**
-          * Modal body message
-         */
-        "modalMessage"?: string;
-        /**
-          * Modal header title
-         */
-        "modalTitle"?: string;
+        "clickToClose"?: boolean;
         /**
           * Event that is fired when modal closes
          */
         "onRuxmodalclosed"?: (event: CustomEvent<boolean>) => void;
+        /**
+          * Event that is fired when modal opens
+         */
+        "onRuxmodalopened"?: (event: CustomEvent<boolean>) => void;
         /**
           * Shows and hides modal
          */

--- a/packages/web-components/src/components/rux-table/rux-table.scss
+++ b/packages/web-components/src/components/rux-table/rux-table.scss
@@ -4,9 +4,8 @@
     border-collapse: separate;
     border-spacing: 0;
     color: var(--table-row-text-color);
-    border-style: solid;
-    border-width: 1px;
-    border-color: var(--table-border-color);
+    border-top: 1px solid var(--table-border-color);
+    border-bottom: 1px solid var(--table-border-color);
     background: var(--table-row-background-color);
     text-align: left;
     overflow: scroll;


### PR DESCRIPTION
## Brief Description

tables in design don't have left/right borders. if you place them inside a container that does a border, its awkward. 

## JIRA Link

ASTRO-3345

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
