### PR TITLE
docs(segmented-button): remove form element mention

### DIFF
--- a/packages/astro-uxds/_content/components/segmented-button.md
+++ b/packages/astro-uxds/_content/components/segmented-button.md
@@ -24,7 +24,7 @@ Segmented Buttons allow users to select one item at a time from two to four opti
 
 ## Appearance and Behavior
 
-To learn more about adding Help Text to form elements like Segmented Buttons, see the [Forms and Validation](/patterns/forms-and-validation) guidance.
+To learn more about adding Help Text to Segmented Buttons, see the [Forms and Validation](/patterns/forms-and-validation) guidance.
 
 ## Examples
 


### PR DESCRIPTION
## Brief Description

Quick fix to remove the mention of form elements in the Help Text sentence on the Segmented Buttons page.

## JIRA Link

No Jira link

## Related Issue

## General Notes

## Motivation and Context

Segmented buttons are not form elements.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
