### PR TITLE
fix(segmented-button): remove overflow

### DIFF
--- a/.changeset/chilly-taxis-approve.md
+++ b/.changeset/chilly-taxis-approve.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Segmented Button - fixed issue where the bottom border was being clipped when inside a container element.

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
@@ -76,7 +76,6 @@
     display: inline-flex;
     // Default is small for 6.0 - will update default to be medium in 7.0
     height: 1.625rem;
-    overflow: hidden;
     padding: 0;
     margin: 0;
     list-style: none;


### PR DESCRIPTION
## Brief Description

This overflow hidden was clipping the bottom border when used inside a container.

## JIRA Link

ASTRO-3386

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
