### PR TITLE
Astro 3389 input top space

### DIFF
--- a/.changeset/orange-onions-serve.md
+++ b/.changeset/orange-onions-serve.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+Removed extra margin on form elements (checkbox, radio, slider, select, input, textarea) that didn't have a label.

--- a/packages/angular/package-lock.json
+++ b/packages/angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astrouxds/angular",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@astrouxds/angular",
-      "version": "6.5.0",
+      "version": "6.5.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "^1.9.3"

--- a/packages/astro-uxds/package-lock.json
+++ b/packages/astro-uxds/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-website",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-website",
-      "version": "6.5.0",
+      "version": "6.5.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@astrouxds/astro-figma-export": "^1.4.0",

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astrouxds/react",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@astrouxds/react",
-      "version": "6.5.0",
+      "version": "6.5.1",
       "devDependencies": {
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.1.0",

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
@@ -80,10 +80,17 @@
                 align-self: start;
                 height: 1.125rem;
                 width: 1.125rem;
+
                 margin: 0 0.625rem 0 0;
                 background-color: var(--checkbox-background-color);
                 border: 1px solid var(--checkbox-border-color);
                 border-radius: var(--radius-checkbox);
+            }
+        }
+        //If no label is passed in we don't want the margin
+        + .rux-checkbox--no-label {
+            &::before {
+                margin: 0;
             }
         }
 

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
@@ -53,10 +53,6 @@ export class RuxCheckbox implements FormFieldInterface {
      * The checkbox label text. For HTML content, use the default slot instead.
      */
     @Prop() label?: string
-    @Watch('label')
-    handleLabelChange() {
-        this._handleSlotChange()
-    }
 
     /**
      * Toggles checked state of a checkbox
@@ -107,11 +103,10 @@ export class RuxCheckbox implements FormFieldInterface {
     connectedCallback() {
         this._onClick = this._onClick.bind(this)
         this._onInput = this._onInput.bind(this)
-        this._handleSlotChange = this._handleSlotChange.bind(this)
     }
 
     componentWillLoad() {
-        this._handleSlotChange()
+        this.hasLabelSlot = hasSlot(this.el)
     }
     componentDidLoad() {
         if (this._inputEl && this.indeterminate) {
@@ -143,10 +138,6 @@ export class RuxCheckbox implements FormFieldInterface {
         this.ruxBlur.emit()
     }
 
-    private _handleSlotChange() {
-        this.hasLabelSlot = hasSlot(this.el)
-    }
-
     render() {
         const {
             checkboxId,
@@ -157,8 +148,8 @@ export class RuxCheckbox implements FormFieldInterface {
             value,
             indeterminate,
             label,
-            _handleSlotChange,
             hasLabel,
+            hasLabelSlot,
         } = this
 
         if (!this.indeterminate) {
@@ -203,13 +194,13 @@ export class RuxCheckbox implements FormFieldInterface {
                                 'rux-checkbox--no-label': !hasLabel,
                             }}
                         >
-                            {label}
+                            {hasLabelSlot ? null : label}
                             <span
                                 class={{
                                     hidden: !hasLabel,
                                 }}
                             >
-                                <slot onSlotchange={_handleSlotChange}></slot>
+                                <slot></slot>
                             </span>
                         </label>
                     </div>

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
@@ -103,10 +103,11 @@ export class RuxCheckbox implements FormFieldInterface {
     connectedCallback() {
         this._onClick = this._onClick.bind(this)
         this._onInput = this._onInput.bind(this)
+        this._checkForLabelSlot = this._checkForLabelSlot.bind(this)
     }
 
     componentWillLoad() {
-        this.hasLabelSlot = hasSlot(this.el)
+        this._checkForLabelSlot()
     }
     componentDidLoad() {
         if (this._inputEl && this.indeterminate) {
@@ -117,6 +118,10 @@ export class RuxCheckbox implements FormFieldInterface {
 
     get hasLabel() {
         return this.label ? true : this.hasLabelSlot
+    }
+
+    private _checkForLabelSlot() {
+        this.hasLabelSlot = hasSlot(this.el)
     }
 
     private _onClick(e: Event): void {
@@ -200,7 +205,9 @@ export class RuxCheckbox implements FormFieldInterface {
                                     hidden: !hasLabel,
                                 }}
                             >
-                                <slot></slot>
+                                <slot
+                                    onSlotchange={this._checkForLabelSlot}
+                                ></slot>
                             </span>
                         </label>
                     </div>

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
@@ -121,8 +121,6 @@ export class RuxCheckbox implements FormFieldInterface {
     }
 
     get hasLabel() {
-        console.log(this.label, 'Label')
-        console.log(this.hasLabelSlot, 'hasLabelSlot')
         return this.label ? true : this.hasLabelSlot
     }
 
@@ -146,7 +144,6 @@ export class RuxCheckbox implements FormFieldInterface {
     }
 
     private _handleSlotChange() {
-        console.log('slot change')
         this.hasLabelSlot = hasSlot(this.el)
     }
 

--- a/packages/web-components/src/components/rux-checkbox/test/__snapshots__/rux-checkbox.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-checkbox/test/__snapshots__/rux-checkbox.spec.tsx.snap
@@ -6,8 +6,8 @@ exports[`rux-checkbox renders 1`] = `
     <div class="rux-form-field" part="form-field">
       <div class="rux-checkbox">
         <input id="rux-checkbox-2" type="checkbox" value="">
-        <label htmlfor="rux-checkbox-2" part="label">
-          <span>
+        <label class="rux-checkbox--no-label" htmlfor="rux-checkbox-2" part="label">
+          <span class="hidden">
             <slot></slot>
           </span>
         </label>

--- a/packages/web-components/src/components/rux-input/rux-input.scss
+++ b/packages/web-components/src/components/rux-input/rux-input.scss
@@ -160,6 +160,7 @@
             }
         }
     }
+
     .rux-input-label {
         font-family: var(--font-body-1-font-family);
         font-size: var(--font-body-1-font-size);

--- a/packages/web-components/src/components/rux-input/rux-input.tsx
+++ b/packages/web-components/src/components/rux-input/rux-input.tsx
@@ -263,32 +263,38 @@ export class RuxInput implements FormFieldInterface {
         return (
             <Host>
                 <div class="rux-form-field" part="form-field">
-                    <label
-                        class={{
-                            'rux-input-label': true,
-                        }}
-                        part="label"
-                        aria-hidden={hasLabel ? 'false' : 'true'}
-                        htmlFor={inputId}
-                    >
-                        <span
+                    {hasLabel ? (
+                        <label
                             class={{
-                                hidden: !hasLabel,
+                                'rux-input-label': true,
                             }}
+                            part="label"
+                            aria-hidden={hasLabel ? 'false' : 'true'}
+                            htmlFor={inputId}
                         >
-                            <slot name="label" onSlotchange={_handleSlotChange}>
-                                {label}
-                                {required && (
-                                    <span
-                                        part="required"
-                                        class="rux-input-label__asterisk"
-                                    >
-                                        &#42;
-                                    </span>
-                                )}
-                            </slot>
-                        </span>
-                    </label>
+                            <span
+                                class={{
+                                    hidden: !hasLabel,
+                                }}
+                            >
+                                <slot
+                                    name="label"
+                                    onSlotchange={_handleSlotChange}
+                                >
+                                    {label}
+                                    {required && (
+                                        <span
+                                            part="required"
+                                            class="rux-input-label__asterisk"
+                                        >
+                                            &#42;
+                                        </span>
+                                    )}
+                                </slot>
+                            </span>
+                        </label>
+                    ) : null}
+
                     <div
                         class={{
                             'rux-input': true,

--- a/packages/web-components/src/components/rux-input/test/__snapshots__/rux-input.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-input/test/__snapshots__/rux-input.spec.tsx.snap
@@ -4,11 +4,6 @@ exports[`rux-input renders 1`] = `
 <rux-input value="">
   <mock:shadow-root>
     <div class="rux-form-field" part="form-field">
-      <label aria-hidden="true" class="rux-input-label" htmlfor="rux-input-1" part="label">
-        <span class="hidden">
-          <slot name="label"></slot>
-        </span>
-      </label>
       <div class="rux-input rux-input--medium">
         <span class="rux-input-prefix" part="prefix">
           <slot name="prefix"></slot>
@@ -81,11 +76,6 @@ exports[`rux-input renders rux-icon if type is password 1`] = `
 <rux-input type="password" value="">
   <mock:shadow-root>
     <div class="rux-form-field" part="form-field">
-      <label aria-hidden="true" class="rux-input-label" htmlfor="rux-input-4" part="label">
-        <span class="hidden">
-          <slot name="label"></slot>
-        </span>
-      </label>
       <div class="rux-input rux-input--medium">
         <span class="rux-input-prefix" part="prefix">
           <slot name="prefix"></slot>

--- a/packages/web-components/src/components/rux-radio/rux-radio.scss
+++ b/packages/web-components/src/components/rux-radio/rux-radio.scss
@@ -75,6 +75,12 @@
                 content: '';
             }
         }
+        //If no label is passed in we don't want the margin
+        + .rux-radio--no-label {
+            &::before {
+                margin: 0;
+            }
+        }
 
         &:checked {
             + label {

--- a/packages/web-components/src/components/rux-radio/rux-radio.tsx
+++ b/packages/web-components/src/components/rux-radio/rux-radio.tsx
@@ -1,4 +1,14 @@
-import { Component, h, Prop, Element, Event, EventEmitter } from '@stencil/core'
+import {
+    Component,
+    h,
+    Prop,
+    Element,
+    Event,
+    EventEmitter,
+    State,
+    Watch,
+} from '@stencil/core'
+import { hasSlot } from '../../utils/utils'
 
 let id = 0
 
@@ -18,6 +28,8 @@ export class RuxRadio {
     private radioGroup: HTMLRuxRadioGroupElement | null = null
 
     @Element() el!: HTMLRuxRadioElement
+
+    @State() hasLabelSlot = false
 
     /**
      * The radio name
@@ -42,7 +54,10 @@ export class RuxRadio {
      * The radio label text. For HTML content, use the default slot instead.
      */
     @Prop() label?: string
-
+    @Watch('label')
+    handleLabelChange() {
+        this._handleSlotChange()
+    }
     /**
      * Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)
      */
@@ -50,12 +65,17 @@ export class RuxRadio {
 
     connectedCallback() {
         this._onChange = this._onChange.bind(this)
+        this._handleSlotChange = this._handleSlotChange.bind(this)
         this.radioGroup = this.el.closest('rux-radio-group')
         this._syncFromGroup = this._syncFromGroup.bind(this)
         if (this.radioGroup) {
             this._syncFromGroup()
             this.radioGroup.addEventListener('ruxchange', this._syncFromGroup)
         }
+    }
+
+    componentWillLoad() {
+        this._handleSlotChange()
     }
 
     disconnectedCallback() {
@@ -65,6 +85,10 @@ export class RuxRadio {
                 this._syncFromGroup
             )
         }
+    }
+
+    private _handleSlotChange() {
+        this.hasLabelSlot = hasSlot(this.el)
     }
 
     /**
@@ -85,6 +109,10 @@ export class RuxRadio {
         this.ruxBlur.emit()
     }
 
+    get hasLabel() {
+        return this.label ? true : this.hasLabelSlot
+    }
+
     render() {
         const {
             label,
@@ -95,6 +123,7 @@ export class RuxRadio {
             value,
             _onChange,
             _onBlur,
+            hasLabel,
         } = this
 
         return (
@@ -110,7 +139,13 @@ export class RuxRadio {
                         onChange={_onChange}
                         onBlur={_onBlur}
                     />
-                    <label htmlFor={radioId} part="label">
+                    <label
+                        htmlFor={radioId}
+                        part="label"
+                        class={{
+                            'rux-radio--no-label': !hasLabel,
+                        }}
+                    >
                         <slot>{label}</slot>
                     </label>
                 </div>

--- a/packages/web-components/src/components/rux-radio/test/__snapshots__/rux-radio.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-radio/test/__snapshots__/rux-radio.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`rux-radio renders 1`] = `
     <div class="rux-form-field" part="form-field">
       <div class="rux-radio">
         <input id="rux-radio-2" type="radio" value="test">
-        <label htmlfor="rux-radio-2" part="label">
+        <label class="rux-radio--no-label" htmlfor="rux-radio-2" part="label">
           <slot></slot>
         </label>
       </div>

--- a/packages/web-components/src/components/rux-slider/rux-slider.tsx
+++ b/packages/web-components/src/components/rux-slider/rux-slider.tsx
@@ -226,6 +226,7 @@ export class RuxSlider implements FormFieldInterface {
             el,
             sliderId,
             label,
+            hasLabel,
             min,
             max,
             value,
@@ -240,17 +241,20 @@ export class RuxSlider implements FormFieldInterface {
         return (
             <Host>
                 <div class="rux-form-field" part="form-field">
-                    <label
-                        class={{
-                            'rux-input-label': true,
-                            hidden: !this.hasLabel,
-                        }}
-                        aria-hidden={this.hasLabel ? 'false' : 'true'}
-                        htmlFor={sliderId}
-                        part="label"
-                    >
-                        <slot name="label">{label}</slot>
-                    </label>
+                    {hasLabel ? (
+                        <label
+                            class={{
+                                'rux-input-label': true,
+                                hidden: !this.hasLabel,
+                            }}
+                            aria-hidden={this.hasLabel ? 'false' : 'true'}
+                            htmlFor={sliderId}
+                            part="label"
+                        >
+                            <slot name="label">{label}</slot>
+                        </label>
+                    ) : null}
+
                     <div
                         class={{
                             'rux-slider': true,
@@ -312,13 +316,3 @@ export class RuxSlider implements FormFieldInterface {
         )
     }
 }
-
-/*
-                                return (
-                                    <div class="tick-label">
-                                        <div class="tick"></div>
-                                        <option>{label}</option>
-                                    </div>
-                                )
-
-*/

--- a/packages/web-components/src/components/rux-slider/test/__snapshots__/rux-slider.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-slider/test/__snapshots__/rux-slider.spec.tsx.snap
@@ -4,9 +4,6 @@ exports[`rux-slider renders 1`] = `
 <rux-slider style="--slider-value-percent: 50%;">
   <mock:shadow-root>
     <div class="rux-form-field" part="form-field">
-      <label aria-hidden="true" class="hidden rux-input-label" htmlfor="rux-slider-1" part="label">
-        <slot name="label"></slot>
-      </label>
       <div class="rux-slider">
         <input aria-disabled="false" aria-label="slider" class="rux-range" id="rux-slider-1" list="steplist" max="100" min="0" part="input" step="1" type="range" value="50">
       </div>

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.tsx
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.tsx
@@ -164,31 +164,34 @@ export class RuxTextarea implements FormFieldInterface {
         return (
             <Host>
                 <div class="rux-textarea-field" part="form-field">
-                    <label
-                        class={{
-                            'rux-textarea-label': true,
-                        }}
-                        aria-hidden={this.hasLabel ? 'false' : 'true'}
-                        htmlFor={this.inputId}
-                        part="label"
-                    >
-                        <span class={{ hidden: !this.hasLabel }}>
-                            <slot
-                                onSlotchange={this._handleSlotChange}
-                                name="label"
-                            >
-                                {this.label}
-                                {this.required && (
-                                    <span
-                                        part="required"
-                                        class="rux-textarea-label__asterisk"
-                                    >
-                                        &#42;
-                                    </span>
-                                )}
-                            </slot>
-                        </span>
-                    </label>
+                    {this.hasLabel ? (
+                        <label
+                            class={{
+                                'rux-textarea-label': true,
+                            }}
+                            aria-hidden={this.hasLabel ? 'false' : 'true'}
+                            htmlFor={this.inputId}
+                            part="label"
+                        >
+                            <span class={{ hidden: !this.hasLabel }}>
+                                <slot
+                                    onSlotchange={this._handleSlotChange}
+                                    name="label"
+                                >
+                                    {this.label}
+                                    {this.required && (
+                                        <span
+                                            part="required"
+                                            class="rux-textarea-label__asterisk"
+                                        >
+                                            &#42;
+                                        </span>
+                                    )}
+                                </slot>
+                            </span>
+                        </label>
+                    ) : null}
+
                     <textarea
                         name={this.name}
                         disabled={this.disabled}

--- a/packages/web-components/src/components/rux-textarea/test/__snapshots__/rux-textarea.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-textarea/test/__snapshots__/rux-textarea.spec.tsx.snap
@@ -3,12 +3,7 @@
 exports[`rux-textarea renders 1`] = `
 <rux-textarea value="">
   <mock:shadow-root>
-    <div class="rux-textarea-field" part="form-field">
-      <label aria-hidden="true" class="rux-textarea-label" htmlfor="rux-textarea-1" part="label">
-        <span class="hidden">
-          <slot name="label"></slot>
-        </span>
-      </label><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-1" part="textarea" value=""></textarea>
+    <div class="rux-textarea-field" part="form-field"><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-1" part="textarea" value=""></textarea>
     </div>
   </mock:shadow-root>
   <input class="aux-input" type="hidden" value="">

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -19,17 +19,5 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body>
-        <div style="width: 400px; padding: 2%">
-            <rux-checkbox name="checkbox" label="Checkbox Label"></rux-checkbox>
-            <br />
-            <rux-checkbox name="checkbox"><span>Slot</span></rux-checkbox>
-            <br />
-            <rux-checkbox name="checkbox"></rux-checkbox>
-            <br />
-            <rux-checkbox name="checkbox" label="Props Label"
-                ><span>Slot Label</span></rux-checkbox
-            >
-        </div>
-    </body>
+    <body></body>
 </html>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -16,23 +16,6 @@
     <link rel="stylesheet" href="/build/astro-web-components.css" />
 </head>
 
-<body>
-    <div style="padding: 2%; width: 300px;">
-        <rux-checkbox></rux-checkbox>
-        <br />
-        <rux-checkbox><span>Slot</span></rux-checkbox>
-        <br />
-        <rux-checkbox label="Label"></rux-checkbox>
-        <br />
-        <br />
-        <rux-radio></rux-radio>
-        <br />
-        <rux-radio label="Label"></rux-radio>
-        <br />
-        <rux-radio>
-            <slot>Slot</slot>
-        </rux-radio>
-    </div>
-</body>
+<body></body>
 
 </html>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -1,21 +1,35 @@
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+        />
+        <title>Stencil Component Starter</title>
 
-<head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
-    <title>Stencil Component Starter</title>
+        <link rel="preconnect" href="https://fonts.gstatic.com" />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@100;300;400&family=Roboto:wght@100;300;400;500;700;900&display=swap"
+            rel="stylesheet"
+        />
+        <script type="module" src="/build/astro-web-components.esm.js"></script>
+        <script nomodule src="/build/astro-web-components.js"></script>
 
-    <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link
-        href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@100;300;400&family=Roboto:wght@100;300;400;500;700;900&display=swap"
-        rel="stylesheet" />
-    <script type="module" src="/build/astro-web-components.esm.js"></script>
-    <script nomodule src="/build/astro-web-components.js"></script>
+        <link rel="stylesheet" href="/build/astro-web-components.css" />
+    </head>
 
-    <link rel="stylesheet" href="/build/astro-web-components.css" />
-</head>
-
-<body></body>
-
+    <body>
+        <div style="width: 400px; padding: 2%">
+            <rux-checkbox name="checkbox" label="Checkbox Label"></rux-checkbox>
+            <br />
+            <rux-checkbox name="checkbox"><span>Slot</span></rux-checkbox>
+            <br />
+            <rux-checkbox name="checkbox"></rux-checkbox>
+            <br />
+            <rux-checkbox name="checkbox" label="Props Label"
+                ><span>Slot Label</span></rux-checkbox
+            >
+        </div>
+    </body>
 </html>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -1,23 +1,29 @@
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
-    <head>
-        <meta charset="utf-8" />
-        <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
-        />
-        <title>Stencil Component Starter</title>
 
-        <link rel="preconnect" href="https://fonts.gstatic.com" />
-        <link
-            href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@100;300;400&family=Roboto:wght@100;300;400;500;700;900&display=swap"
-            rel="stylesheet"
-        />
-        <script type="module" src="/build/astro-web-components.esm.js"></script>
-        <script nomodule src="/build/astro-web-components.js"></script>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Stencil Component Starter</title>
 
-        <link rel="stylesheet" href="/build/astro-web-components.css" />
-    </head>
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+        href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@100;300;400&family=Roboto:wght@100;300;400;500;700;900&display=swap"
+        rel="stylesheet" />
+    <script type="module" src="/build/astro-web-components.esm.js"></script>
+    <script nomodule src="/build/astro-web-components.js"></script>
 
-    <body></body>
+    <link rel="stylesheet" href="/build/astro-web-components.css" />
+</head>
+
+<body>
+    <div style="padding: 2%; width: 300px;">
+        <rux-checkbox></rux-checkbox>
+        <br />
+        <rux-checkbox><span>Slot</span></rux-checkbox>
+        <br />
+        <rux-checkbox label="Label"></rux-checkbox>
+    </div>
+</body>
+
 </html>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -23,6 +23,15 @@
         <rux-checkbox><span>Slot</span></rux-checkbox>
         <br />
         <rux-checkbox label="Label"></rux-checkbox>
+        <br />
+        <br />
+        <rux-radio></rux-radio>
+        <br />
+        <rux-radio label="Label"></rux-radio>
+        <br />
+        <rux-radio>
+            <slot>Slot</slot>
+        </rux-radio>
     </div>
 </body>
 

--- a/packages/web-components/src/stories/radio.stories.mdx
+++ b/packages/web-components/src/stories/radio.stories.mdx
@@ -34,6 +34,7 @@ export const Default = (args) => {
     ?checked=${args.checked}
     ?disabled=${args.disabled}
     .value="${args.value}"
+    label="${args.label}"
     >${args.label}</rux-radio
 >
     `


### PR DESCRIPTION
## Brief Description

Removes extra margin on form elements when a label is not included. Also removes extra dom nodes (label, slot) on slider, input and textarea using conditional rendering. For other form elements, the element either didn't render extra margin already or it has specific styling on label (checkbox, radio) that inhibited the exclusion of the `<label>` element.


## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-3389

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/372
## General Notes

Checkbox and Radio both style the `<label>` in order to display anything, so I couldn't omit those when label or slot isn't being used. Instead, I added a conditional class that will override the margin if a label prop or slot isn't being used. 
In all other components, a ternary is being used to conditionally render the `<label>` or `<slot>` if they exist. 

## Motivation and Context

Removes unneeded margin on elements without labels.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
