### PR TITLE
fix(modal): removed fixed height on dialog

### DIFF
--- a/.changeset/strange-crabs-taste.md
+++ b/.changeset/strange-crabs-taste.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Removed the fix height on the dialog element in rux-modal that was preventing a long modal message.

--- a/.changeset/strange-crabs-taste.md
+++ b/.changeset/strange-crabs-taste.md
@@ -5,4 +5,4 @@
 "@astrouxds/react": patch
 ---
 
-Removed the fix height on the dialog element in rux-modal that was preventing a long modal message.
+Removed the fix height on the dialog element in rux-modal that was preventing a long modal message. Added a new 'dialog' shadow part attatched to the rux-modal's native dialog element.

--- a/packages/web-components/src/components/rux-modal/rux-modal.scss
+++ b/packages/web-components/src/components/rux-modal/rux-modal.scss
@@ -64,7 +64,6 @@ rux-button-group {
         justify-content: space-between;
         background-color: var(--modal-background-color);
         width: 28rem;
-        height: 13.5rem;
         border: 0;
         margin: auto;
         padding: 0;

--- a/packages/web-components/src/components/rux-modal/rux-modal.tsx
+++ b/packages/web-components/src/components/rux-modal/rux-modal.tsx
@@ -13,6 +13,7 @@ import {
 /**
  * @part wrapper - the modal wrapper overlay ! DEPRECATED IN FAVOR OF CONTAINER !
  * @part container - the modal container
+ * @part dialog - the native dialog element
  * @part header - the header of the modal
  * @part message - the message of the modal
  * @part confirm-button - the modal's confirm button
@@ -148,7 +149,11 @@ export class RuxModal {
             open && (
                 <Host>
                     <div part="wrapper container" class="rux-modal__wrapper">
-                        <dialog class="rux-modal__dialog" role="dialog">
+                        <dialog
+                            class="rux-modal__dialog"
+                            role="dialog"
+                            part="dialog"
+                        >
                             {modalTitle && (
                                 <header
                                     class="rux-modal__titlebar"


### PR DESCRIPTION
## Brief Description

Removes the fixed height form the dialog element in order to allow messages of any length.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-3294

## Related Issue

Was brought up thru email by Outside Analytics 

## General Notes

I also thought about putting a shadow part on the dialog. Thoughts? 

## Motivation and Context

Allows for longer modal message's 

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
