### PR TITLE
docs(input): added margin-bottom 0 to horizontal label story

### DIFF
--- a/packages/web-components/src/stories/input.stories.mdx
+++ b/packages/web-components/src/stories/input.stories.mdx
@@ -603,6 +603,7 @@ export const HorizontalLabel = (args) => {
             }
             #left-example::part(label) {
                 margin-right: var(--spacing-input-label-left);
+                margin-bottom: 0;
             }
         </style>
         <rux-input


### PR DESCRIPTION
## Brief Description

The issue with this label not center aligned by default is the margin bottom that is being placed on <label>. It's easy enough to throw a margin-bottom: 0 in the part that's making it horizontal in the first place, so I think that's the answer here. Any strong feelings otherwise?

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-3333

## Related Issue

## General Notes

## Motivation and Context

Horizontal label on input SB was not actually centered. 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
