### PR TITLE
docs: Add rux-button-group to cherry picking

### DIFF
--- a/packages/web-components/src/stories/modal.stories.mdx
+++ b/packages/web-components/src/stories/modal.stories.mdx
@@ -59,8 +59,10 @@ export const Modal = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxModal from '@astrouxds/astro-web-components/dist/components/rux-modal.js'
-import RuxButton from '@astrouxds/astro-web-components/dist/components/rux-button.js'
+import { RuxModal } from '@astrouxds/astro-web-components/dist/components/rux-modal.js'
+import { RuxButton } from '@astrouxds/astro-web-components/dist/components/rux-button.js'
+import { RuxButtonGroup } from '@astrouxds/astro-web-components/dist/components/rux-button-group.js'
 customElements.define('rux-modal', RuxModal)
 customElements.define('rux-button', RuxButton)
+customElements.define('rux-button-group', RuxButtonGroup)
 ```


### PR DESCRIPTION
This fixes the imports for the components, and also adds `rux-button-group`, which is necessary to display the buttons with appropriate padding between them.