### PR TITLE
fix(tab): prevent light dom styles

### DIFF
--- a/.changeset/brown-panthers-study.md
+++ b/.changeset/brown-panthers-study.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Tabs - fixed issue where styles were not properly shadow dom encapsulated

--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
@@ -23,8 +23,9 @@
     *   @prop --tab-selected-border-color: Tab selected border color
     */
     --tab-selected-border-color: var(--color-background-interactive-default);
-
-    box-sizing: border-box;
+    display: contents;
+}
+.rux-tab {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -34,6 +35,9 @@
     text-decoration: none;
     color: var(--tab-text-color);
     border-bottom: 5px solid var(--tab-border-color);
+    &:hover {
+        color: var(--color-background-interactive-hover);
+    }
 }
 
 :host([hidden]) {
@@ -45,26 +49,26 @@
     white-space: nowrap;
     text-overflow: ellipsis;
 }
-:host([small]) {
+.rux-tab--small {
     min-width: 2rem;
     padding: 1.25rem 1rem; //20 16
     border-bottom: 3px solid var(--tab-border-color);
 }
-:host([small][selected]) {
-    border-bottom: solid 3px var(--tab-selected-border-color);
-}
-:host([selected]) {
+
+.rux-tab--selected {
     color: var(--tab-selected-text-color);
     border-bottom: 5px solid var(--tab-selected-border-color);
+    &:hover {
+        color: var(--tab-selected-text-color);
+    }
 }
-:host([selected]:hover) {
-    color: var(--tab-selected-text-color);
-}
-:host(:hover) {
-    color: var(--color-background-interactive-hover);
-}
-:host([disabled]) {
+
+.rux-tab--disabled {
     color: var(--tab-text-color);
     opacity: var(--disabled-opacity);
     cursor: not-allowed;
+}
+
+.rux-tab--small.rux-tab--selected {
+    border-bottom: solid 3px var(--tab-selected-border-color);
 }

--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Element } from '@stencil/core'
+import { Component, Host, h, Prop, State, Element } from '@stencil/core'
 
 @Component({
     tag: 'rux-tab',
@@ -14,6 +14,7 @@ export class RuxTab {
      * If present, sets a disabled state on this tab item, indicating it cannot be selected by user action.
      */
     @Prop({ reflect: true }) disabled: boolean = false
+    @State() small = false
 
     @Element() el!: HTMLRuxTabElement
 
@@ -22,6 +23,7 @@ export class RuxTab {
         this.el.addEventListener('click', this._clickHandler)
 
         if (this.el?.parentElement?.getAttributeNode('small')) {
+            this.small = true
             this.el.setAttribute('small', '')
         }
     }
@@ -35,7 +37,16 @@ export class RuxTab {
     render() {
         return (
             <Host onClick={this._clickHandler}>
-                <slot></slot>
+                <div
+                    class={{
+                        'rux-tab': true,
+                        'rux-tab--selected': this.selected,
+                        'rux-tab--disabled': this.disabled,
+                        'rux-tab--small': this.small,
+                    }}
+                >
+                    <slot></slot>
+                </div>
             </Host>
         )
     }

--- a/packages/web-components/src/components/rux-tabs/test/rux-tabs.e2e.js
+++ b/packages/web-components/src/components/rux-tabs/test/rux-tabs.e2e.js
@@ -7,22 +7,27 @@ describe('Tab', () => {
         cy.get('rux-tab').should('have.class', 'hydrated')
     })
 
-    it('first tab is selected by default', async () => {
+    it('first tab is selected by default', () => {
         cy.get('#tab-id-1').should('have.attr', 'selected')
         cy.get('#tab-id-2').should('not.have.attr', 'selected')
     })
 
     it('selects tab when user clicks', () => {
-        cy.get('#tab-id-2').click().should('have.attr', 'selected')
+        cy.get('#tab-id-2').shadow().find('.rux-tab').click({ force: true })
+        cy.get('#tab-id-2').should('have.attr', 'selected')
+        cy.get('#tab-id-1').shadow().find('.rux-tab')
         cy.get('#tab-id-1').should('not.have.attr', 'selected')
-        cy.get('#tab-id-1').click().should('have.attr', 'selected')
+        cy.get('#tab-id-1').shadow().find('.rux-tab')
+        cy.get('#tab-id-1')
+            .click({ force: true })
+            .should('have.attr', 'selected')
     })
 
     it('shows correct panel when its tab is clicked', () => {
         cy.get('rux-tab-panel').eq(0).should('not.have.class', 'hidden')
         cy.get('rux-tab-panel').eq(1).should('have.class', 'hidden')
         cy.get('rux-tab-panel').eq(2).should('have.class', 'hidden')
-        cy.get('#tab-id-2').click()
+        cy.get('#tab-id-2').click({ force: true })
         cy.get('rux-tab-panel').eq(0).should('have.class', 'hidden')
         cy.get('rux-tab-panel').eq(1).should('not.have.class', 'hidden')
         cy.get('rux-tab-panel').eq(2).should('have.class', 'hidden')


### PR DESCRIPTION
## Brief Description

Tab were being styled entirely on the host + attributes and basically weren't shadow domed at all. Which caused issues when you pull in something like Tailwind


## JIRA Link

ASTRO-3494

## Motivation and Context

https://github.com/RocketCommunicationsInc/astro/issues/391

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
