### PR TITLE
docs: fixed cherry picking section unpkg url button, select, time-region

### DIFF
--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,15 @@
 {
   "name": "@astrouxds/react",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@astrouxds/react",
-      "version": "6.6.0",
+      "version": "6.7.0",
+      "dependencies": {
+        "@astrouxds/astro-web-components": "^6.7.0"
+      },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.1.0",
@@ -31,9 +34,9 @@
       }
     },
     "node_modules/@astrouxds/astro-web-components": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-6.6.0.tgz",
-      "integrity": "sha512-avtLjmRkInb8LlSo9qFPoWFKCGj1FCTCT/ROecfQYnv1snvlvmWqJQjW2n7r40S+/6aMNJfjFMgBkDXPDjErFQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-6.7.0.tgz",
+      "integrity": "sha512-YCOGw8JWW2+d69pDA1K63pjhYVaKtMIsNxIBkUCKmyR9aPMqd7Q35VTIYdjpq2MuizwW8jnJiwQIuFUYkixYrA==",
       "dependencies": {
         "@stencil/core": "~2.5.2",
         "date-fns": "~2.21.1",
@@ -13470,9 +13473,9 @@
   },
   "dependencies": {
     "@astrouxds/astro-web-components": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-6.6.0.tgz",
-      "integrity": "sha512-avtLjmRkInb8LlSo9qFPoWFKCGj1FCTCT/ROecfQYnv1snvlvmWqJQjW2n7r40S+/6aMNJfjFMgBkDXPDjErFQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-6.7.0.tgz",
+      "integrity": "sha512-YCOGw8JWW2+d69pDA1K63pjhYVaKtMIsNxIBkUCKmyR9aPMqd7Q35VTIYdjpq2MuizwW8jnJiwQIuFUYkixYrA==",
       "requires": {
         "@stencil/core": "~2.5.2",
         "date-fns": "~2.21.1",

--- a/packages/web-components/src/stories/button.stories.mdx
+++ b/packages/web-components/src/stories/button.stories.mdx
@@ -428,7 +428,7 @@ import { RuxButton } from '@astrouxds/astro-web-components/dist/components/rux-b
 customElements.define('rux-button', RuxButton)
 
 // If using an icon
-// import { RuxIcon } from 'astro-web-components/dist/components/rux-icon'
+// import { RuxIcon } from '@astrouxds/astro-web-components/dist/components/rux-icon'
 // Import the specific icon being used
 // customElements.define('rux-icon', RuxIcon)
 // customElements.define('rux-icon-*', RuxIcon*)

--- a/packages/web-components/src/stories/button.stories.mdx
+++ b/packages/web-components/src/stories/button.stories.mdx
@@ -424,7 +424,7 @@ export const AllVariants = () => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import { RuxButton } from 'astro-web-components/dist/components/rux-button'
+import { RuxButton } from '@astrouxds/astro-web-components/dist/components/rux-button'
 customElements.define('rux-button', RuxButton)
 
 // If using an icon

--- a/packages/web-components/src/stories/clock.stories.mdx
+++ b/packages/web-components/src/stories/clock.stories.mdx
@@ -186,7 +186,7 @@ export const OtherVariants = () => {
         .clock-list li {
             padding-bottom: 2rem;
         }
-        span {
+        .clock-list span {
             margin: 0 0 1rem 1rem;
         }
     </style>

--- a/packages/web-components/src/stories/select.stories.mdx
+++ b/packages/web-components/src/stories/select.stories.mdx
@@ -612,8 +612,8 @@ export const MultipleWithOptionGroups = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import { RuxSelect } from 'astro-web-components/dist/components/rux-select'
-import { RuxOption } from 'astro-web-components/dist/components/rux-option'
+import { RuxSelect } from '@astrouxds/astro-web-components/dist/components/rux-select'
+import { RuxOption } from '@astrouxds/astro-web-components/dist/components/rux-option'
 
 customElements.define('rux-select', RuxSelect)
 customElements.define('rux-option', RuxOption)

--- a/packages/web-components/src/stories/select.stories.mdx
+++ b/packages/web-components/src/stories/select.stories.mdx
@@ -619,6 +619,6 @@ customElements.define('rux-select', RuxSelect)
 customElements.define('rux-option', RuxOption)
 
 // Optional
-//import { RuxOptionGroup } from 'astro-web-components/dist/components/rux-option-group'
+//import { RuxOptionGroup } from '@astrouxds/astro-web-components/rux-option-group'
 //customElements.define('rux-option-group', RuxOptionGroup)
 ```

--- a/packages/web-components/src/stories/time-region.stories.mdx
+++ b/packages/web-components/src/stories/time-region.stories.mdx
@@ -246,10 +246,10 @@ export const AllVariants = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import { RuxTimeRegion } from 'astro-web-components/dist/components/rux-time-region'
+import { RuxTimeRegion } from '@astrouxds/astro-web-components/dist/components/rux-time-region'
 customElements.define('rux-time-region', RuxTimeRegion)
 
 // If using the status attribute
-// import { RuxStatus } from 'astro-web-components/dist/components/rux-status'
+// import { RuxStatus } from '@astrouxds/astro-web-components/dist/components/rux-status'
 // customElements.define('rux-status', RuxStatus)
 ```


### PR DESCRIPTION
## Brief Description

Fixes the unpkg url in the cherry picking section of the docs for those who were using the wrong one:
- rux-button
- rux-select
- rux-time-region

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-3446

## Related Issue

## General Notes

Since there were only 3 sections to update, I didn't make a reusable cherry picking component or update the auto-gen to handle this. Let me know if I should - it just felt like a lot of work for a quick fix. 

## Motivation and Context

Correct urls for cherry picking in our docs 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
