### PR TITLE
fix(modal): default buttons emit true or false in event detail

### DIFF
--- a/.changeset/blue-taxis-wash.md
+++ b/.changeset/blue-taxis-wash.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Fixed modal not emitting a detail value when using default confirm/deny buttons.

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,15 @@
 {
   "name": "@astrouxds/react",
-  "version": "6.7.0",
+  "version": "6.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@astrouxds/react",
-      "version": "6.7.0",
+      "version": "6.8.0",
+      "dependencies": {
+        "@astrouxds/astro-web-components": "^6.8.0"
+      },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.1.0",
@@ -85,6 +88,36 @@
         "stylelint-config-standard": "~22.0.0",
         "svgo": "~2.3.0",
         "wait-on": "~6.0.0"
+      }
+    },
+    "node_modules/@astrouxds/astro-web-components": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-6.8.0.tgz",
+      "integrity": "sha512-ED2/SPAVRzrkEs+V1MAXdJYFyj8K22+B1RHjgpjjDgt5KQGwfdtUDivA5GeGg/35Ll205x1i8nevVxHrw1XQlQ==",
+      "dependencies": {
+        "@stencil/core": "~2.5.2",
+        "date-fns": "~2.21.1",
+        "date-fns-tz": "~1.3.3"
+      }
+    },
+    "node_modules/@astrouxds/astro-web-components/node_modules/date-fns": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
+      "integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/@astrouxds/astro-web-components/node_modules/date-fns-tz": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.4.tgz",
+      "integrity": "sha512-O47vEyz85F2ax/ZdhMBJo187RivZGjH6V0cPjPzpm/yi6YffJg4upD/8ibezO11ezZwP3QYlBHh/t4JhRNx0Ow==",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2370,6 +2403,18 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@stencil/core": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.5.2.tgz",
+      "integrity": "sha512-bgjPXkSzzg1WnTgVUm6m5ZzpKt602WmA/QljODAW1xVN40OHJdbGblzF/F6MFzqv2c5Cy30CB41arc8qADIdcQ==",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=12.10.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -12343,6 +12388,29 @@
     }
   },
   "dependencies": {
+    "@astrouxds/astro-web-components": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-6.8.0.tgz",
+      "integrity": "sha512-ED2/SPAVRzrkEs+V1MAXdJYFyj8K22+B1RHjgpjjDgt5KQGwfdtUDivA5GeGg/35Ll205x1i8nevVxHrw1XQlQ==",
+      "requires": {
+        "@stencil/core": "~2.5.2",
+        "date-fns": "~2.21.1",
+        "date-fns-tz": "~1.3.3"
+      },
+      "dependencies": {
+        "date-fns": {
+          "version": "2.21.3",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
+          "integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw=="
+        },
+        "date-fns-tz": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.4.tgz",
+          "integrity": "sha512-O47vEyz85F2ax/ZdhMBJo187RivZGjH6V0cPjPzpm/yi6YffJg4upD/8ibezO11ezZwP3QYlBHh/t4JhRNx0Ow==",
+          "requires": {}
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.14.5",
       "dev": true,
@@ -13884,6 +13952,11 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "@stencil/core": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.5.2.tgz",
+      "integrity": "sha512-bgjPXkSzzg1WnTgVUm6m5ZzpKt602WmA/QljODAW1xVN40OHJdbGblzF/F6MFzqv2c5Cy30CB41arc8qADIdcQ=="
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -34,7 +34,8 @@
         "test.e2e": "npm run test.e2e.run",
         "test.unit.watch": "TZ=UTC stencil test --spec --watchAll",
         "test.unit": "TZ=UTC stencil test --spec --coverage",
-        "test.all": "concurrently npm:test.unit npm:test.e2e",
+        "test.unit.silent": "TZ=UTC stencil test --spec --coverage, --silent",
+        "test.all": "concurrently npm:test.unit.silent npm:test.e2e",
         "deploy.beta": "netlify deploy --site '27100b54-2df5-4ab2-a331-4ef2b81f8054'",
         "deploy.storybook": "netlify deploy --site 'bfaf1790-0a59-47fb-ab34-4a3530a715f1'"
     },

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -32304,7 +32304,7 @@ declare namespace LocalJSX {
         /**
           * Event that is fired when modal closes
          */
-        "onRuxmodalclosed"?: (event: CustomEvent<boolean>) => void;
+        "onRuxmodalclosed"?: (event: CustomEvent<boolean | null>) => void;
         /**
           * Event that is fired when modal opens
          */

--- a/packages/web-components/src/components/rux-modal/rux-modal.tsx
+++ b/packages/web-components/src/components/rux-modal/rux-modal.tsx
@@ -70,13 +70,14 @@ export class RuxModal {
         composed: true,
         bubbles: true,
     })
-    ruxModalClosed!: EventEmitter<boolean>
+    ruxModalClosed!: EventEmitter<boolean | null>
 
     @Element() element!: HTMLRuxModalElement
 
     @State() hasFooter = hasSlot(this.element, 'footer')
     @State() hasHeader = hasSlot(this.element, 'header')
     @State() hasMessage = hasSlot(this.element)
+    private _userInput: boolean | null = null
 
     // confirm dialog if Enter key is pressed
     @Listen('keydown', { target: 'window' })
@@ -95,6 +96,7 @@ export class RuxModal {
         const wrapper = this._getWrapper()
         if (ev.composedPath()[0] === wrapper) {
             this.open = false
+            this.ruxModalClosed.emit()
         }
     }
 
@@ -108,10 +110,16 @@ export class RuxModal {
                 }
             }, 0)
         }
-        this.open ? this.ruxModalOpened.emit() : this.ruxModalClosed.emit()
+        this.open
+            ? this.ruxModalOpened.emit()
+            : this.ruxModalClosed.emit(this._userInput)
     }
 
-    private _handleModalChoice() {
+    private _handleModalChoice(e: MouseEvent) {
+        // convert string value to boolean
+        const target = e.currentTarget as HTMLElement
+        const choice = target.dataset.value === 'true'
+        this._userInput = choice
         this.open = false
     }
 
@@ -227,6 +235,7 @@ export class RuxModal {
                                                     confirmText.length > 0
                                                 }
                                                 onClick={_handleModalChoice}
+                                                data-value="false"
                                                 hidden={!denyText}
                                                 tabindex="-1"
                                                 exportparts="container:deny-button"
@@ -236,6 +245,7 @@ export class RuxModal {
                                             <rux-button
                                                 onClick={_handleModalChoice}
                                                 hidden={!confirmText}
+                                                data-value="true"
                                                 tabindex="0"
                                                 exportparts="container:confirm-button"
                                             >

--- a/packages/web-components/src/components/rux-modal/test/rux-modal.e2e.js
+++ b/packages/web-components/src/components/rux-modal/test/rux-modal.e2e.js
@@ -119,4 +119,44 @@ describe('Modal', () => {
             .children()
             .should('have.length', '1')
     })
+    it('should emit ruxmodalclosed with a detail of false when default deny button is clicked', () => {
+        cy.get('rux-modal').then(($modal) => {
+            $modal[0].setAttribute('open', true)
+        })
+        cy.document().invoke(
+            'addEventListener',
+            'ruxmodalclosed',
+            cy.stub().as('ruxmodalclosed')
+        )
+        cy.get('rux-modal')
+            .shadow()
+            .find('rux-button-group')
+            .find('rux-button')
+            .first()
+            .click()
+        cy.get('@ruxmodalclosed')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', false)
+    })
+    it('should emit ruxmodalclosed with a detail of true when default confirm button is clicked', () => {
+        cy.get('rux-modal').then(($modal) => {
+            $modal[0].setAttribute('open', true)
+        })
+        cy.document().invoke(
+            'addEventListener',
+            'ruxmodalclosed',
+            cy.stub().as('ruxmodalclosed')
+        )
+        cy.get('rux-modal')
+            .shadow()
+            .find('rux-button-group')
+            .find('rux-button')
+            .next()
+            .click()
+        cy.get('@ruxmodalclosed')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', true)
+    })
 })


### PR DESCRIPTION
## Brief Description

Fixes a bug introduced in the modal backport that removed the true/false in the ruxmodalclosed detail when using the default comfirm/deny buttons.
Adds tests to prevent this from happening again.

I've also added a `test.unit.silent` command to the web-components package that github actions will use when testing in order to avoid all of the console noise - if react tests fail we'll actually see the failures now. 

## JIRA Link
https://rocketcom.atlassian.net/browse/ASTRO-3596

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/421

## General Notes

## Motivation and Context

Allows for users to determine if the confirm or deny button was pressed when using the default modal footer.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
