### PR TITLE
fix(pop-up): setMenuPosition now accounts for scrollX

### DIFF
--- a/.changeset/soft-dolls-jump.md
+++ b/.changeset/soft-dolls-jump.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Pop-up-menu will now position correctly if the anchor element is beyond a horizontal scrollbar.

--- a/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
+++ b/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
@@ -87,7 +87,6 @@ export class RuxPopUpMenu {
     connectedCallback() {
         this._handleClick = this._handleClick.bind(this)
         this._handleOutsideClick = this._handleOutsideClick.bind(this)
-
         this._bindElements()
 
         this._toggleOpenClose()
@@ -172,21 +171,27 @@ export class RuxPopUpMenu {
 
     private _setMenuPosition() {
         if (this.anchorEl && this.anchorBounds && this.menuBounds) {
+            console.log('anchorEl, bounds and menuBounds are there')
             let { anchorBounds, menuBounds } = this
             anchorBounds = this.anchorEl.getBoundingClientRect()
             menuBounds = this.el.getBoundingClientRect()
+            console.log(
+                `anchorBounds: ${anchorBounds.right} --- menuBounds: ${menuBounds.right}`
+            )
             const caret = parseInt(getComputedStyle(this.el, ':after').height)
             let top: number
             let left: number
             let caretLeft: number
 
             const padding = 8
+            // Need to compensate for the amount scrolled horizontally, if present.
+            const scrollX = window.scrollX - padding
 
             if (
                 menuBounds.width + anchorBounds.left - padding >
                 window.innerWidth
             ) {
-                left = anchorBounds.right - menuBounds.width
+                left = anchorBounds.right - menuBounds.width + scrollX
                 caretLeft = menuBounds.width - 25
             } else if (anchorBounds.left - padding > 0) {
                 left = anchorBounds.left - padding
@@ -246,6 +251,10 @@ export class RuxPopUpMenu {
 
             const debounce = setTimeout(() => {
                 window.addEventListener('resize', () => this._setMenuPosition())
+                window.addEventListener('scroll', () => {
+                    console.log('scroll, setmenupos')
+                    this._setMenuPosition()
+                })
                 window.addEventListener('mousedown', this._handleOutsideClick)
                 clearTimeout(debounce)
             }, 10)

--- a/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
+++ b/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
@@ -171,13 +171,10 @@ export class RuxPopUpMenu {
 
     private _setMenuPosition() {
         if (this.anchorEl && this.anchorBounds && this.menuBounds) {
-            console.log('anchorEl, bounds and menuBounds are there')
             let { anchorBounds, menuBounds } = this
             anchorBounds = this.anchorEl.getBoundingClientRect()
             menuBounds = this.el.getBoundingClientRect()
-            console.log(
-                `anchorBounds: ${anchorBounds.right} --- menuBounds: ${menuBounds.right}`
-            )
+
             const caret = parseInt(getComputedStyle(this.el, ':after').height)
             let top: number
             let left: number
@@ -252,7 +249,6 @@ export class RuxPopUpMenu {
             const debounce = setTimeout(() => {
                 window.addEventListener('resize', () => this._setMenuPosition())
                 window.addEventListener('scroll', () => {
-                    console.log('scroll, setmenupos')
                     this._setMenuPosition()
                 })
                 window.addEventListener('mousedown', this._handleOutsideClick)

--- a/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
+++ b/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
@@ -248,9 +248,6 @@ export class RuxPopUpMenu {
 
             const debounce = setTimeout(() => {
                 window.addEventListener('resize', () => this._setMenuPosition())
-                window.addEventListener('scroll', () => {
-                    this._setMenuPosition()
-                })
                 window.addEventListener('mousedown', this._handleOutsideClick)
                 clearTimeout(debounce)
             }, 10)

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -19,5 +19,29 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body></body>
+    <body>
+        <rux-global-status-bar
+            app-domain="Test"
+            app-name="Application"
+            style="width: 2000px"
+        >
+            <rux-icon
+                slot="right-side"
+                icon="settings"
+                label="Settings"
+                aria-controls="popup-menu-1"
+            ></rux-icon>
+        </rux-global-status-bar>
+
+        <rux-pop-up-menu id="popup-menu-1">
+            <rux-menu-item> Item 1 </rux-menu-item>
+            <rux-menu-item disabled="">Item 2 is disabled</rux-menu-item>
+            <rux-menu-item value="Item 3"
+                >Item 3 has a string value</rux-menu-item
+            >
+            <rux-menu-item href="https://www.astrouxds.com"
+                >Item 4 is an anchor/action item...</rux-menu-item
+            >
+        </rux-pop-up-menu>
+    </body>
 </html>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -19,29 +19,5 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body>
-        <rux-global-status-bar
-            app-domain="Test"
-            app-name="Application"
-            style="width: 2000px"
-        >
-            <rux-icon
-                slot="right-side"
-                icon="settings"
-                label="Settings"
-                aria-controls="popup-menu-1"
-            ></rux-icon>
-        </rux-global-status-bar>
-
-        <rux-pop-up-menu id="popup-menu-1">
-            <rux-menu-item> Item 1 </rux-menu-item>
-            <rux-menu-item disabled="">Item 2 is disabled</rux-menu-item>
-            <rux-menu-item value="Item 3"
-                >Item 3 has a string value</rux-menu-item
-            >
-            <rux-menu-item href="https://www.astrouxds.com"
-                >Item 4 is an anchor/action item...</rux-menu-item
-            >
-        </rux-pop-up-menu>
-    </body>
+    <body></body>
 </html>


### PR DESCRIPTION
## Brief Description

When there is a horizontal scroll bar present and a pop-up anchor is used beyond the window.innerWidth, the pop-up would render in the wrong spot. This adds support for this case by computing the window.scrollX value in the setMenuPosition function. 


## JIRA Link
https://rocketcom.atlassian.net/browse/ASTRO-3597

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/422
## General Notes

This change gets the `window.scrollX` value, stores it, and adds it to the `left` calculation if the pop-up anchor is placed at a larger `left` value than `window.innerWidth`

## Motivation and Context

Pop up menu rendering incorrectly if anchor was beyond a horizontal scrollbar.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
