### PR TITLE
refactor(clock): move :host styles inside shadow dom

### DIFF
--- a/.changeset/old-ravens-love.md
+++ b/.changeset/old-ravens-love.md
@@ -1,0 +1,30 @@
+---
+"@astrouxds/angular": major
+"astro-website": major
+"@astrouxds/react": major
+"@astrouxds/astro-web-components": major
+---
+
+Clock - The following styles have been removed from the :host element:
+
+`margin: 0 1rem`
+
+You may need to apply this to your element directly:
+
+```
+rux-clock {
+  margin: 0 1rem;
+}
+```
+
+`user-select: none`
+
+If you wish to override this, use the new `container` CSS Shadow Part.
+
+`height: 3.938rem`
+
+If you wish to override this, use the new `container` CSS Shadow Part.
+
+`display: flex`
+
+The default `display` has been changed to `inline-block`. This can be overwritten by targeting the `rux-clock` host element.

--- a/.changeset/six-frogs-remember.md
+++ b/.changeset/six-frogs-remember.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/angular": minor
+"astro-website": minor
+"@astrouxds/react": minor
+"@astrouxds/astro-web-components": minor
+---
+
+Clock - add container shadow part

--- a/packages/web-components/src/components/rux-clock/rux-clock.scss
+++ b/packages/web-components/src/components/rux-clock/rux-clock.scss
@@ -19,18 +19,18 @@
     */
     --clock-label-color: var(--color-palette-neutral-000);
 
-    display: flex;
-    margin: 0 1rem;
-    color: var(--clock-text-color);
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    height: 3.938rem; //63px
+    display: inline-block;
 }
 
 :host([hidden]) {
     display: none;
+}
+
+.rux-clock {
+    display: flex;
+    user-select: none;
+    color: var(--clock-text-color);
+    height: 3.938rem; //63px
 }
 
 .rux-clock__segment {

--- a/packages/web-components/src/components/rux-clock/rux-clock.tsx
+++ b/packages/web-components/src/components/rux-clock/rux-clock.tsx
@@ -5,9 +5,10 @@ import { militaryTimezones } from './military-timezones'
 import { MilitaryTimezone } from './rux-clock.model'
 
 /**
+ * @part container - the container for the clock
  * @part date - the container for the date section of clock
  * @part date-label - the container for the date label
- * @part time - the conatiner for the time section of clock
+ * @part time - the container for the time section of clock
  * @part time-label - the container for the time label
  * @part aos - the container for the aos section of clock
  * @part aos-label - the container for the aos label
@@ -160,89 +161,91 @@ export class RuxClock {
     render() {
         return (
             <Host>
-                {!this.hideDate && (
+                <div class="rux-clock" part="container">
+                    {!this.hideDate && (
+                        <div class="rux-clock__segment">
+                            <div
+                                class="rux-clock__segment__value"
+                                aria-labelledby="rux-clock__day-of-year-label"
+                                part="date"
+                            >
+                                {this.dayOfYear.toString().padStart(3, '0')}
+                            </div>
+                            {!this.hideLabels && (
+                                <div
+                                    class="rux-clock__segment__label"
+                                    id="rux-clock__day-of-year-label"
+                                    part="date-label"
+                                >
+                                    Date
+                                </div>
+                            )}
+                        </div>
+                    )}
+
                     <div class="rux-clock__segment">
                         <div
                             class="rux-clock__segment__value"
-                            aria-labelledby="rux-clock__day-of-year-label"
-                            part="date"
+                            aria-labelledby="rux-clock__time-label"
+                            part="time"
                         >
-                            {this.dayOfYear.toString().padStart(3, '0')}
+                            {this.time}
                         </div>
                         {!this.hideLabels && (
                             <div
                                 class="rux-clock__segment__label"
-                                id="rux-clock__day-of-year-label"
-                                part="date-label"
+                                id="rux-clock__time-label"
+                                part="time-label"
                             >
-                                Date
+                                Time
                             </div>
                         )}
                     </div>
-                )}
 
-                <div class="rux-clock__segment">
-                    <div
-                        class="rux-clock__segment__value"
-                        aria-labelledby="rux-clock__time-label"
-                        part="time"
-                    >
-                        {this.time}
-                    </div>
-                    {!this.hideLabels && (
-                        <div
-                            class="rux-clock__segment__label"
-                            id="rux-clock__time-label"
-                            part="time-label"
-                        >
-                            Time
+                    {this.aos && (
+                        <div class="rux-clock__segment rux-clock__aos">
+                            <div
+                                class="rux-clock__segment__value"
+                                aria-labelledby="rux-clock__time-label--aos"
+                                id="rux-clock__time--aos"
+                                part="aos"
+                            >
+                                {this.convertedAos}
+                            </div>
+                            {!this.hideLabels && (
+                                <div
+                                    class="rux-clock__segment__label"
+                                    id="rux-clock__time-label--aos"
+                                    part="aos-label"
+                                >
+                                    AOS
+                                </div>
+                            )}
+                        </div>
+                    )}
+
+                    {this.los && (
+                        <div class="rux-clock__segment rux-clock__los">
+                            <div
+                                class="rux-clock__segment__value"
+                                aria-labelledby="rux-clock__time-label--los"
+                                id="rux-clock__time--los"
+                                part="los"
+                            >
+                                {this.convertedLos}
+                            </div>
+                            {!this.hideLabels && (
+                                <div
+                                    class="rux-clock__segment__label"
+                                    id="rux-clock__time-label--los"
+                                    part="los-label"
+                                >
+                                    LOS
+                                </div>
+                            )}
                         </div>
                     )}
                 </div>
-
-                {this.aos && (
-                    <div class="rux-clock__segment rux-clock__aos">
-                        <div
-                            class="rux-clock__segment__value"
-                            aria-labelledby="rux-clock__time-label--aos"
-                            id="rux-clock__time--aos"
-                            part="aos"
-                        >
-                            {this.convertedAos}
-                        </div>
-                        {!this.hideLabels && (
-                            <div
-                                class="rux-clock__segment__label"
-                                id="rux-clock__time-label--aos"
-                                part="aos-label"
-                            >
-                                AOS
-                            </div>
-                        )}
-                    </div>
-                )}
-
-                {this.los && (
-                    <div class="rux-clock__segment rux-clock__los">
-                        <div
-                            class="rux-clock__segment__value"
-                            aria-labelledby="rux-clock__time-label--los"
-                            id="rux-clock__time--los"
-                            part="los"
-                        >
-                            {this.convertedLos}
-                        </div>
-                        {!this.hideLabels && (
-                            <div
-                                class="rux-clock__segment__label"
-                                id="rux-clock__time-label--los"
-                                part="los-label"
-                            >
-                                LOS
-                            </div>
-                        )}
-                    </div>
-                )}
             </Host>
         )
     }

--- a/packages/web-components/src/components/rux-clock/test/__snapshots__/rux-clock.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-clock/test/__snapshots__/rux-clock.spec.tsx.snap
@@ -3,20 +3,22 @@
 exports[`rux-clock converts all military timezones 1`] = `
 <rux-clock timezone="A">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        02:02:03 GMT+1
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          02:02:03 GMT+1
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -26,20 +28,22 @@ exports[`rux-clock converts all military timezones 1`] = `
 exports[`rux-clock converts all military timezones 2`] = `
 <rux-clock timezone="B">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        03:02:03 GMT+2
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          03:02:03 GMT+2
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -49,20 +53,22 @@ exports[`rux-clock converts all military timezones 2`] = `
 exports[`rux-clock converts all military timezones 3`] = `
 <rux-clock timezone="C">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        04:02:03 GMT+3
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          04:02:03 GMT+3
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -72,20 +78,22 @@ exports[`rux-clock converts all military timezones 3`] = `
 exports[`rux-clock converts all military timezones 4`] = `
 <rux-clock timezone="D">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        05:02:03 GMT+4
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          05:02:03 GMT+4
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -95,20 +103,22 @@ exports[`rux-clock converts all military timezones 4`] = `
 exports[`rux-clock converts all military timezones 5`] = `
 <rux-clock timezone="E">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        06:02:03 GMT+5
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          06:02:03 GMT+5
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -118,20 +128,22 @@ exports[`rux-clock converts all military timezones 5`] = `
 exports[`rux-clock converts all military timezones 6`] = `
 <rux-clock timezone="F">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        07:02:03 GMT+6
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          07:02:03 GMT+6
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -141,20 +153,22 @@ exports[`rux-clock converts all military timezones 6`] = `
 exports[`rux-clock converts all military timezones 7`] = `
 <rux-clock timezone="G">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        08:02:03 GMT+7
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          08:02:03 GMT+7
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -164,20 +178,22 @@ exports[`rux-clock converts all military timezones 7`] = `
 exports[`rux-clock converts all military timezones 8`] = `
 <rux-clock timezone="H">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        09:02:03 GMT+8
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          09:02:03 GMT+8
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -187,20 +203,22 @@ exports[`rux-clock converts all military timezones 8`] = `
 exports[`rux-clock converts all military timezones 9`] = `
 <rux-clock timezone="I">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        10:02:03 GMT+9
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          10:02:03 GMT+9
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -210,20 +228,22 @@ exports[`rux-clock converts all military timezones 9`] = `
 exports[`rux-clock converts all military timezones 10`] = `
 <rux-clock timezone="K">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        11:02:03 GMT+10
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          11:02:03 GMT+10
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -233,20 +253,22 @@ exports[`rux-clock converts all military timezones 10`] = `
 exports[`rux-clock converts all military timezones 11`] = `
 <rux-clock timezone="L">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        12:02:03 GMT+11
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          12:02:03 GMT+11
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -256,20 +278,22 @@ exports[`rux-clock converts all military timezones 11`] = `
 exports[`rux-clock converts all military timezones 12`] = `
 <rux-clock timezone="M">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        13:02:03 GMT+12
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          13:02:03 GMT+12
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -279,20 +303,22 @@ exports[`rux-clock converts all military timezones 12`] = `
 exports[`rux-clock converts all military timezones 13`] = `
 <rux-clock timezone="N">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        00:02:03 GMT-1
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          00:02:03 GMT-1
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -302,20 +328,22 @@ exports[`rux-clock converts all military timezones 13`] = `
 exports[`rux-clock converts all military timezones 14`] = `
 <rux-clock timezone="O">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        366
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          366
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        23:02:03 GMT-2
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          23:02:03 GMT-2
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -325,20 +353,22 @@ exports[`rux-clock converts all military timezones 14`] = `
 exports[`rux-clock converts all military timezones 15`] = `
 <rux-clock timezone="P">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        366
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          366
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        22:02:03 GMT-3
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          22:02:03 GMT-3
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -348,20 +378,22 @@ exports[`rux-clock converts all military timezones 15`] = `
 exports[`rux-clock converts all military timezones 16`] = `
 <rux-clock timezone="Q">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        366
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          366
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        21:02:03 GMT-4
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          21:02:03 GMT-4
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -371,20 +403,22 @@ exports[`rux-clock converts all military timezones 16`] = `
 exports[`rux-clock converts all military timezones 17`] = `
 <rux-clock timezone="R">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        366
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          366
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        20:02:03 GMT-5
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          20:02:03 GMT-5
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -394,20 +428,22 @@ exports[`rux-clock converts all military timezones 17`] = `
 exports[`rux-clock converts all military timezones 18`] = `
 <rux-clock timezone="S">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        366
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          366
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        19:02:03 GMT-6
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          19:02:03 GMT-6
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -417,20 +453,22 @@ exports[`rux-clock converts all military timezones 18`] = `
 exports[`rux-clock converts all military timezones 19`] = `
 <rux-clock timezone="T">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        366
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          366
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        18:02:03 GMT-7
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          18:02:03 GMT-7
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -440,20 +478,22 @@ exports[`rux-clock converts all military timezones 19`] = `
 exports[`rux-clock converts all military timezones 20`] = `
 <rux-clock timezone="U">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        366
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          366
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        17:02:03 GMT-8
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          17:02:03 GMT-8
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -463,20 +503,22 @@ exports[`rux-clock converts all military timezones 20`] = `
 exports[`rux-clock converts all military timezones 21`] = `
 <rux-clock timezone="V">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        366
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          366
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        16:02:03 GMT-9
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          16:02:03 GMT-9
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -486,20 +528,22 @@ exports[`rux-clock converts all military timezones 21`] = `
 exports[`rux-clock converts all military timezones 22`] = `
 <rux-clock timezone="W">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        366
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          366
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        15:02:03 GMT-10
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          15:02:03 GMT-10
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -509,20 +553,22 @@ exports[`rux-clock converts all military timezones 22`] = `
 exports[`rux-clock converts all military timezones 23`] = `
 <rux-clock timezone="X">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        366
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          366
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        14:02:03 GMT-11
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          14:02:03 GMT-11
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -532,20 +578,22 @@ exports[`rux-clock converts all military timezones 23`] = `
 exports[`rux-clock converts all military timezones 24`] = `
 <rux-clock timezone="Y">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        366
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          366
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        13:02:03 GMT-12
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          13:02:03 GMT-12
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -555,20 +603,22 @@ exports[`rux-clock converts all military timezones 24`] = `
 exports[`rux-clock converts all military timezones 25`] = `
 <rux-clock timezone="Z">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        01:02:03 Z
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          01:02:03 Z
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -578,36 +628,38 @@ exports[`rux-clock converts all military timezones 25`] = `
 exports[`rux-clock converts aos/los unix timestamps when timezone is changed 1`] = `
 <rux-clock aos="1638373590145" los="1638373590145">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          01:02:03 UTC
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        01:02:03 UTC
+      <div class="rux-clock__aos rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos" part="aos">
+          15:46:30
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label--aos" part="aos-label">
+          AOS
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
-      </div>
-    </div>
-    <div class="rux-clock__aos rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos" part="aos">
-        15:46:30
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos" part="aos-label">
-        AOS
-      </div>
-    </div>
-    <div class="rux-clock__los rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los" part="los">
-        15:46:30
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--los" part="los-label">
-        LOS
+      <div class="rux-clock__los rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los" part="los">
+          15:46:30
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label--los" part="los-label">
+          LOS
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -617,36 +669,38 @@ exports[`rux-clock converts aos/los unix timestamps when timezone is changed 1`]
 exports[`rux-clock converts aos/los unix timestamps when timezone is changed 2`] = `
 <rux-clock aos="1638373590145" los="1638373590145" timezone="America/Los_Angeles">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        366
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          366
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          17:02:03 PST
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        17:02:03 PST
+      <div class="rux-clock__aos rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos" part="aos">
+          07:46:30
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label--aos" part="aos-label">
+          AOS
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
-      </div>
-    </div>
-    <div class="rux-clock__aos rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos" part="aos">
-        07:46:30
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos" part="aos-label">
-        AOS
-      </div>
-    </div>
-    <div class="rux-clock__los rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los" part="los">
-        07:46:30
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--los" part="los-label">
-        LOS
+      <div class="rux-clock__los rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los" part="los">
+          07:46:30
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label--los" part="los-label">
+          LOS
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -656,20 +710,22 @@ exports[`rux-clock converts aos/los unix timestamps when timezone is changed 2`]
 exports[`rux-clock converts time to timezone 1`] = `
 <rux-clock timezone="America/Los_Angeles">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        366
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          366
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        17:02:03 PST
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          17:02:03 PST
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -679,20 +735,22 @@ exports[`rux-clock converts time to timezone 1`] = `
 exports[`rux-clock converts time to timezone on the fly 1`] = `
 <rux-clock>
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        01:02:03 UTC
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          01:02:03 UTC
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -702,20 +760,22 @@ exports[`rux-clock converts time to timezone on the fly 1`] = `
 exports[`rux-clock converts time to timezone on the fly 2`] = `
 <rux-clock timezone="America/Los_Angeles">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        366
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          366
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        17:02:03 PST
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          17:02:03 PST
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -725,12 +785,14 @@ exports[`rux-clock converts time to timezone on the fly 2`] = `
 exports[`rux-clock hides the date 1`] = `
 <rux-clock hide-date="">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        01:02:03 UTC
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          01:02:03 UTC
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -740,14 +802,16 @@ exports[`rux-clock hides the date 1`] = `
 exports[`rux-clock hides the labels 1`] = `
 <rux-clock hide-labels="">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
       </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        01:02:03 UTC
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          01:02:03 UTC
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -757,20 +821,22 @@ exports[`rux-clock hides the labels 1`] = `
 exports[`rux-clock hides the timezone 1`] = `
 <rux-clock hide-timezone="">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        01:02:03
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          01:02:03
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -780,28 +846,30 @@ exports[`rux-clock hides the timezone 1`] = `
 exports[`rux-clock shows and updates aos 1`] = `
 <rux-clock aos="1988-04-22 12:12:12">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          01:02:03 UTC
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        01:02:03 UTC
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
-      </div>
-    </div>
-    <div class="rux-clock__aos rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos" part="aos">
-        12:12:12
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos" part="aos-label">
-        AOS
+      <div class="rux-clock__aos rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos" part="aos">
+          12:12:12
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label--aos" part="aos-label">
+          AOS
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -811,28 +879,30 @@ exports[`rux-clock shows and updates aos 1`] = `
 exports[`rux-clock shows and updates aos 2`] = `
 <rux-clock aos="1988-04-22 09:12:12">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          01:02:03 UTC
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        01:02:03 UTC
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
-      </div>
-    </div>
-    <div class="rux-clock__aos rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos" part="aos">
-        09:12:12
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--aos" part="aos-label">
-        AOS
+      <div class="rux-clock__aos rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label--aos" class="rux-clock__segment__value" id="rux-clock__time--aos" part="aos">
+          09:12:12
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label--aos" part="aos-label">
+          AOS
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -842,28 +912,30 @@ exports[`rux-clock shows and updates aos 2`] = `
 exports[`rux-clock shows and updates los 1`] = `
 <rux-clock los="1988-04-22 12:12:12">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          01:02:03 UTC
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        01:02:03 UTC
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
-      </div>
-    </div>
-    <div class="rux-clock__los rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los" part="los">
-        12:12:12
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--los" part="los-label">
-        LOS
+      <div class="rux-clock__los rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los" part="los">
+          12:12:12
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label--los" part="los-label">
+          LOS
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -873,28 +945,30 @@ exports[`rux-clock shows and updates los 1`] = `
 exports[`rux-clock shows and updates los 2`] = `
 <rux-clock los="1988-04-22 09:12:12">
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          01:02:03 UTC
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        01:02:03 UTC
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
-      </div>
-    </div>
-    <div class="rux-clock__los rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los" part="los">
-        09:12:12
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label--los" part="los-label">
-        LOS
+      <div class="rux-clock__los rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label--los" class="rux-clock__segment__value" id="rux-clock__time--los" part="los">
+          09:12:12
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label--los" part="los-label">
+          LOS
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -904,20 +978,22 @@ exports[`rux-clock shows and updates los 2`] = `
 exports[`rux-clock shows the current time 1`] = `
 <rux-clock>
   <mock:shadow-root>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
-        001
+    <div class="rux-clock" part="container">
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__day-of-year-label" class="rux-clock__segment__value" part="date">
+          001
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
+          Date
+        </div>
       </div>
-      <div class="rux-clock__segment__label" id="rux-clock__day-of-year-label" part="date-label">
-        Date
-      </div>
-    </div>
-    <div class="rux-clock__segment">
-      <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
-        01:02:03 UTC
-      </div>
-      <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
-        Time
+      <div class="rux-clock__segment">
+        <div aria-labelledby="rux-clock__time-label" class="rux-clock__segment__value" part="time">
+          01:02:03 UTC
+        </div>
+        <div class="rux-clock__segment__label" id="rux-clock__time-label" part="time-label">
+          Time
+        </div>
       </div>
     </div>
   </mock:shadow-root>


### PR DESCRIPTION
## Brief Description

Removes margin on :host. This is a breaking change
Moves :host styles into shadow dom

## JIRA Link

ASTRO-3602

## Related Issue

## General Notes

## Motivation and Context

Clock had some styles on :host, moved them into shadow dom so that we can have more control over them and keep our styling API consistent. 

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
