### PR TITLE
chore(angular): bump deps

### DIFF
--- a/packages/angular/package-lock.json
+++ b/packages/angular/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "@astrouxds/angular",
-  "version": "6.8.0",
+  "name": "@micahjones13/angular",
+  "version": "6.9.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@astrouxds/angular",
-      "version": "6.8.0",
+      "name": "@micahjones13/angular",
+      "version": "6.9.23",
       "license": "MIT",
       "dependencies": {
+        "@astrouxds/astro-web-components": "^6.9.0",
         "tslib": "^1.9.3"
       },
       "devDependencies": {
@@ -38,18 +39,18 @@
         "zone.js": "^0.8.28"
       },
       "peerDependencies": {
-        "@angular-devkit/core": "^7.2.1",
-        "@angular-devkit/schematics": "^7.2.1",
-        "@angular/common": "^7.2.1",
-        "@angular/compiler": "^7.2.1",
-        "@angular/compiler-cli": "^7.2.1",
-        "@angular/core": "^7.2.1",
-        "@angular/forms": "^7.2.1",
-        "@angular/platform-browser": "^7.2.1",
-        "@angular/platform-browser-dynamic": "^7.2.1",
-        "@angular/router": "^7.2.1",
+        "@angular-devkit/core": ">=10.0.0",
+        "@angular-devkit/schematics": ">=10.0.0",
+        "@angular/common": ">=10.0.0",
+        "@angular/compiler": ">=10.0.0",
+        "@angular/compiler-cli": ">=10.0.0",
+        "@angular/core": ">=10.0.0",
+        "@angular/forms": ">=10.0.0",
+        "@angular/platform-browser": ">=10.0.0",
+        "@angular/platform-browser-dynamic": ">=10.0.0",
+        "@angular/router": ">=10.0.0",
         "rxjs": ">=6.2.0",
-        "zone.js": "^0.8.26"
+        "zone.js": ">=0.10.0"
       }
     },
     "../web-components": {
@@ -311,6 +312,16 @@
         "@angular/core": "7.2.15",
         "@angular/platform-browser": "7.2.15",
         "rxjs": "^6.0.0"
+      }
+    },
+    "node_modules/@astrouxds/astro-web-components": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-6.9.0.tgz",
+      "integrity": "sha512-lpNThvFed1OujKr81SPMkibqzERMcVnAgyeR6sXnltnb5nYcdO68GcnV/7lFSmK1cY40F2lpzE6uT8XG6Fpd6w==",
+      "dependencies": {
+        "@stencil/core": "~2.5.2",
+        "date-fns": "~2.21.1",
+        "date-fns-tz": "~1.3.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1947,6 +1958,18 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@stencil/core": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.5.2.tgz",
+      "integrity": "sha512-bgjPXkSzzg1WnTgVUm6m5ZzpKt602WmA/QljODAW1xVN40OHJdbGblzF/F6MFzqv2c5Cy30CB41arc8qADIdcQ==",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=12.10.0",
+        "npm": ">=6.0.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.8",
       "dev": true,
@@ -2908,6 +2931,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
+      "integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.4.tgz",
+      "integrity": "sha512-O47vEyz85F2ax/ZdhMBJo187RivZGjH6V0cPjPzpm/yi6YffJg4upD/8ibezO11ezZwP3QYlBHh/t4JhRNx0Ow==",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/debug": {
@@ -11127,6 +11170,16 @@
         "tslib": "^1.9.0"
       }
     },
+    "@astrouxds/astro-web-components": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-6.9.0.tgz",
+      "integrity": "sha512-lpNThvFed1OujKr81SPMkibqzERMcVnAgyeR6sXnltnb5nYcdO68GcnV/7lFSmK1cY40F2lpzE6uT8XG6Fpd6w==",
+      "requires": {
+        "@stencil/core": "~2.5.2",
+        "date-fns": "~2.21.1",
+        "date-fns-tz": "~1.3.3"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "dev": true,
@@ -12269,6 +12322,11 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@stencil/core": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.5.2.tgz",
+      "integrity": "sha512-bgjPXkSzzg1WnTgVUm6m5ZzpKt602WmA/QljODAW1xVN40OHJdbGblzF/F6MFzqv2c5Cy30CB41arc8qADIdcQ=="
+    },
     "@types/babel__core": {
       "version": "7.1.8",
       "dev": true,
@@ -12954,6 +13012,17 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
+      "integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw=="
+    },
+    "date-fns-tz": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.4.tgz",
+      "integrity": "sha512-O47vEyz85F2ax/ZdhMBJo187RivZGjH6V0cPjPzpm/yi6YffJg4upD/8ibezO11ezZwP3QYlBHh/t4JhRNx0Ow==",
+      "requires": {}
     },
     "debug": {
       "version": "2.6.9",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -33,18 +33,18 @@
     "tslib": "^1.9.3"
   },
   "peerDependencies": {
-    "@angular-devkit/core": "^7.2.1",
-    "@angular-devkit/schematics": "^7.2.1",
-    "@angular/common": "^7.2.1",
-    "@angular/compiler": "^7.2.1",
-    "@angular/compiler-cli": "^7.2.1",
-    "@angular/core": "^7.2.1",
-    "@angular/forms": "^7.2.1",
-    "@angular/platform-browser": "^7.2.1",
-    "@angular/platform-browser-dynamic": "^7.2.1",
-    "@angular/router": "^7.2.1",
+    "@angular-devkit/core": ">=10.0.0",
+    "@angular-devkit/schematics": ">=10.0.0",
+    "@angular/common": ">=10.0.0",
+    "@angular/compiler": ">=10.0.0",
+    "@angular/compiler-cli": ">=10.0.0",
+    "@angular/core": ">=10.0.0",
+    "@angular/forms": ">=10.0.0",
+    "@angular/platform-browser": ">=10.0.0",
+    "@angular/platform-browser-dynamic": ">=10.0.0",
+    "@angular/router": ">=10.0.0",
     "rxjs": ">=6.2.0",
-    "zone.js": "^0.8.26"
+    "zone.js": ">=0.10.0"
   },
   "devDependencies": {
     "@angular-devkit/core": "^7.2.1",


### PR DESCRIPTION
## Brief Description

Bumps the angular wrapper peer deps in order to resolve peer dep issue when using angular 12 or higher. Our wrapper is now compatible with angular 10 and up.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-3591

## Related Issue

## General Notes

## Motivation and Context

Fixes the peer dependency issue when using our wrapper and angular 12 and up

## Issues and Limitations

Does not work with 9 and below. It didn't before this change either. 

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
