### PR TITLE
Update Design Tokens

### DIFF
--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -16,7 +16,7 @@
             },
             "devDependencies": {
                 "@astrouxds/astro-figma-export": "~1.0.1",
-                "@astrouxds/design-tokens": "2.0.0-beta.6",
+                "@astrouxds/design-tokens": "2.0.0-beta.7",
                 "@astrouxds/storybook-addon-docs-stencil": "~1.0.10",
                 "@babel/core": "~7.13.16",
                 "@stencil/angular-output-target": "~0.2.1",
@@ -80,7 +80,7 @@
             }
         },
         "node_modules/@astrouxds/design-tokens": {
-            "version": "2.0.0-beta.6",
+            "version": "2.0.0-beta.7",
             "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.6.tgz",
             "integrity": "sha512-ekaSlqzvDZFCGEqhhp+dSWNRiP9lKU0dzcWb8BpV3Wip0gjFiNOeL4WdvDU0w5RnGpR1KoR3MwJKjY4GPBGgfw==",
             "dev": true,
@@ -49572,7 +49572,7 @@
             }
         },
         "@astrouxds/design-tokens": {
-            "version": "2.0.0-beta.6",
+            "version": "2.0.0-beta.7",
             "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.6.tgz",
             "integrity": "sha512-ekaSlqzvDZFCGEqhhp+dSWNRiP9lKU0dzcWb8BpV3Wip0gjFiNOeL4WdvDU0w5RnGpR1KoR3MwJKjY4GPBGgfw==",
             "dev": true,

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -48,7 +48,7 @@
     "license": "MIT",
     "devDependencies": {
         "@astrouxds/astro-figma-export": "~1.0.1",
-        "@astrouxds/design-tokens": "2.0.0-beta.6",
+        "@astrouxds/design-tokens": "2.0.0-beta.7",
         "@astrouxds/storybook-addon-docs-stencil": "~1.0.10",
         "@babel/core": "~7.13.16",
         "@stencil/angular-output-target": "~0.2.1",


### PR DESCRIPTION
## Brief Description

This change updates the `@astrouxds/design-tokens` library from `2.0.0-beta.6` to `2.0.0-beta.7`. This is necessary to use the `--spacing-*` tokens.

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
