### PR TITLE
Astro 3912 modal extra event

### DIFF
--- a/.changeset/slow-apples-build.md
+++ b/.changeset/slow-apples-build.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+Fixed an issue with modal emitting an extra 'ruxmodalclosed' event when closed by an off click.

--- a/packages/web-components/src/components/rux-modal/rux-modal.tsx
+++ b/packages/web-components/src/components/rux-modal/rux-modal.tsx
@@ -96,7 +96,6 @@ export class RuxModal {
         const wrapper = this._getWrapper()
         if (ev.composedPath()[0] === wrapper) {
             this.open = false
-            this.ruxModalClosed.emit()
         }
     }
 


### PR DESCRIPTION
## Brief Description

Modal was emitting 2 `ruxmodalclosed` events when the modal was closed by an off click.

## JIRA Link

https://rocketcom.atlassian.net/jira/software/c/projects/ASTRO/boards/32?modal=detail&selectedIssue=ASTRO-3912&assignee=6098f2aa8cbda70068049d4c

## Related Issue

## General Notes

## Motivation and Context

Don't want double events being emitted 

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
