### PR TITLE
Use opacity-disabled token

### DIFF
--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -16,7 +16,7 @@
             },
             "devDependencies": {
                 "@astrouxds/astro-figma-export": "~1.0.1",
-                "@astrouxds/design-tokens": "2.0.0-beta.6",
+                "@astrouxds/design-tokens": "2.0.0-beta.7",
                 "@astrouxds/storybook-addon-docs-stencil": "~1.0.10",
                 "@babel/core": "~7.13.16",
                 "@stencil/angular-output-target": "~0.2.1",
@@ -80,7 +80,7 @@
             }
         },
         "node_modules/@astrouxds/design-tokens": {
-            "version": "2.0.0-beta.6",
+            "version": "2.0.0-beta.7",
             "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.6.tgz",
             "integrity": "sha512-ekaSlqzvDZFCGEqhhp+dSWNRiP9lKU0dzcWb8BpV3Wip0gjFiNOeL4WdvDU0w5RnGpR1KoR3MwJKjY4GPBGgfw==",
             "dev": true,
@@ -49572,7 +49572,7 @@
             }
         },
         "@astrouxds/design-tokens": {
-            "version": "2.0.0-beta.6",
+            "version": "2.0.0-beta.7",
             "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.6.tgz",
             "integrity": "sha512-ekaSlqzvDZFCGEqhhp+dSWNRiP9lKU0dzcWb8BpV3Wip0gjFiNOeL4WdvDU0w5RnGpR1KoR3MwJKjY4GPBGgfw==",
             "dev": true,

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -16,7 +16,7 @@
             },
             "devDependencies": {
                 "@astrouxds/astro-figma-export": "~1.0.1",
-                "@astrouxds/design-tokens": "2.0.0-beta.7",
+                "@astrouxds/design-tokens": "2.0.0-beta.8",
                 "@astrouxds/storybook-addon-docs-stencil": "~1.0.10",
                 "@babel/core": "~7.13.16",
                 "@stencil/angular-output-target": "~0.2.1",
@@ -80,9 +80,9 @@
             }
         },
         "node_modules/@astrouxds/design-tokens": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.6.tgz",
-            "integrity": "sha512-ekaSlqzvDZFCGEqhhp+dSWNRiP9lKU0dzcWb8BpV3Wip0gjFiNOeL4WdvDU0w5RnGpR1KoR3MwJKjY4GPBGgfw==",
+            "version": "2.0.0-beta.8",
+            "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.8.tgz",
+            "integrity": "sha512-qBPVG5xYBwJE+IdUMrsQHE5zBSD22eFpkM+LjGwV8rzJLJ6tkYbMbfFx+nOACIEqHUbzKl5P7/F7llKqE3yTKQ==",
             "dev": true,
             "dependencies": {
                 "@changesets/cli": "^2.22.0",
@@ -49572,9 +49572,9 @@
             }
         },
         "@astrouxds/design-tokens": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.6.tgz",
-            "integrity": "sha512-ekaSlqzvDZFCGEqhhp+dSWNRiP9lKU0dzcWb8BpV3Wip0gjFiNOeL4WdvDU0w5RnGpR1KoR3MwJKjY4GPBGgfw==",
+            "version": "2.0.0-beta.8",
+            "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.8.tgz",
+            "integrity": "sha512-qBPVG5xYBwJE+IdUMrsQHE5zBSD22eFpkM+LjGwV8rzJLJ6tkYbMbfFx+nOACIEqHUbzKl5P7/F7llKqE3yTKQ==",
             "dev": true,
             "requires": {
                 "@changesets/cli": "^2.22.0",
@@ -52086,137 +52086,6 @@
             "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.1.tgz",
             "integrity": "sha512-nOJARIr3pReqK3hfFCSW2Zg/kFcFsSAlIE7z4a0C9D2dPrgD/YSn3ZP2ET/rxKB65SXyG7jJbkynBRm+tGlacw==",
             "dev": true
-        },
-        "@manypkg/find-root": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
-            "integrity": "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==",
-            "dev": true,
-            "requires": {
-                "@babel/runtime": "^7.5.5",
-                "@types/node": "^12.7.1",
-                "find-up": "^4.1.0",
-                "fs-extra": "^8.1.0"
-            },
-            "dependencies": {
-                "@types/node": {
-                    "version": "12.20.51",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.51.tgz",
-                    "integrity": "sha512-anVDMfReTatfH8GVmHmaTZOL0jeTLNZ9wK9SSrQS3tMmn4vUc+9fVWlUzAieuQefWDyWUz4Z3aqXxDgO1VsYjg==",
-                    "dev": true
-                },
-                "find-up": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^5.0.0",
-                        "path-exists": "^4.0.0"
-                    }
-                },
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                },
-                "locate-path": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^4.1.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-                    "dev": true,
-                    "requires": {
-                        "p-try": "^2.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.2.0"
-                    }
-                },
-                "universalify": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-                    "dev": true
-                }
-            }
-        },
-        "@manypkg/get-packages": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
-            "integrity": "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==",
-            "dev": true,
-            "requires": {
-                "@babel/runtime": "^7.5.5",
-                "@changesets/types": "^4.0.1",
-                "@manypkg/find-root": "^1.1.0",
-                "fs-extra": "^8.1.0",
-                "globby": "^11.0.0",
-                "read-yaml-file": "^1.1.0"
-            },
-            "dependencies": {
-                "@changesets/types": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
-                    "integrity": "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==",
-                    "dev": true
-                },
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                },
-                "universalify": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-                    "dev": true
-                }
-            }
         },
         "@manypkg/find-root": {
             "version": "1.1.0",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -48,7 +48,7 @@
     "license": "MIT",
     "devDependencies": {
         "@astrouxds/astro-figma-export": "~1.0.1",
-        "@astrouxds/design-tokens": "2.0.0-beta.7",
+        "@astrouxds/design-tokens": "2.0.0-beta.8",
         "@astrouxds/storybook-addon-docs-stencil": "~1.0.10",
         "@babel/core": "~7.13.16",
         "@stencil/angular-output-target": "~0.2.1",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -48,7 +48,7 @@
     "license": "MIT",
     "devDependencies": {
         "@astrouxds/astro-figma-export": "~1.0.1",
-        "@astrouxds/design-tokens": "2.0.0-beta.6",
+        "@astrouxds/design-tokens": "2.0.0-beta.7",
         "@astrouxds/storybook-addon-docs-stencil": "~1.0.10",
         "@babel/core": "~7.13.16",
         "@stencil/angular-output-target": "~0.2.1",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -33,7 +33,7 @@ export namespace Components {
          */
         "secondary": boolean;
         /**
-          * Changes size of a button from medium to small or large by setting sizing classes rux-button--small rux-button--large
+          * Changes size of a button from medium to small or large by setting sizing classes
          */
         "size"?: 'small' | 'medium' | 'large';
         /**
@@ -20307,7 +20307,7 @@ declare namespace LocalJSX {
          */
         "secondary"?: boolean;
         /**
-          * Changes size of a button from medium to small or large by setting sizing classes rux-button--small rux-button--large
+          * Changes size of a button from medium to small or large by setting sizing classes
          */
         "size"?: 'small' | 'medium' | 'large';
         /**

--- a/packages/web-components/src/components/rux-button-group/test/__snapshots__/rux-button-group.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-button-group/test/__snapshots__/rux-button-group.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`rux-button-group renders 1`] = `
   </mock:shadow-root>
   <rux-button icon="" secondary="">
     <mock:shadow-root>
-      <button class="rux-button rux-button--secondary" part="container" type="button">
+      <button class="--medium --secondary rux-button" part="container" type="button">
         <slot></slot>
       </button>
     </mock:shadow-root>
@@ -27,7 +27,7 @@ exports[`rux-button-group renders 1`] = `
   </rux-button>
   <rux-button icon="">
     <mock:shadow-root>
-      <button class="rux-button rux-button--default" part="container" type="button">
+      <button class="--medium --primary rux-button" part="container" type="button">
         <slot></slot>
       </button>
     </mock:shadow-root>

--- a/packages/web-components/src/components/rux-button/rux-button.scss
+++ b/packages/web-components/src/components/rux-button/rux-button.scss
@@ -50,12 +50,13 @@ button {
 
     /* decoration */
     border-radius: var(--radius-base);
-    box-shadow: var(--border-color, transparent) 0 0 0 var(--border-width, 0px) inset;
+    box-shadow: var(--border-color, transparent) 0 0 0 var(--border-width, 0px)
+        inset;
 
     /* state: disabled */
     &:disabled {
         cursor: not-allowed;
-        opacity: var(--disabled-opacity);
+        opacity: var(--opacity-disabled, 40%);
         pointer-events: none;
     }
 

--- a/packages/web-components/src/components/rux-button/rux-button.scss
+++ b/packages/web-components/src/components/rux-button/rux-button.scss
@@ -1,6 +1,12 @@
 :host {
-    display: inline-block;
-    width: auto;
+    display: inline-flex;
+
+    /* layout */
+    flex-flow: column wrap;
+    vertical-align: middle;
+
+    /* input */
+    cursor: pointer;
 }
 
 :host([hidden]) {
@@ -8,138 +14,139 @@
 }
 
 :host([disabled]) {
-    pointer-events: none;
+    /* input */
+    cursor: not-allowed;
 }
+
+/* reset native button style */
+
+button {
+    appearance: none;
+    background-color: transparent;
+    border-width: 0;
+    color: inherit;
+    font: inherit;
+    line-height: inherit;
+    margin: 0;
+    padding: 0;
+}
+
+/* style rux button */
+
 .rux-button {
     display: flex;
-    position: relative;
-    margin: 0;
-    width: inherit;
-    padding: 0 1rem;
-    height: 2.125rem;
-    min-width: 2.25rem;
-    border-radius: var(--radius-base);
-    color: var(--color-text-inverse);
-    font-family: var(--font-body-1-font-family);
-    font-size: var(--font-body-1-font-size);
-    font-weight: var(--font-body-1-font-weight);
-    letter-spacing: var(--font-body-1-letter-spacing);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    justify-content: center;
+
+    /* layout */
     align-items: center;
+    justify-content: center;
+
+    /* type */
+    font: var(--button-type-shorthand);
+    letter-spacing: var(--font-body-1-letter-spacing);
+
+    /* input */
+    cursor: pointer;
     user-select: none;
 
-    rux-icon,
-    ::slotted(rux-icon) {
-        height: 1rem;
-        width: 1rem;
-        margin-right: 0.625rem;
-        color: var(--color-text-inverse);
-    }
+    /* decoration */
+    border-radius: var(--radius-base);
+    box-shadow: var(--border-color, transparent) 0 0 0 var(--border-width, 0px) inset;
 
+    /* state: disabled */
     &:disabled {
-        opacity: var(--disabled-opacity);
         cursor: not-allowed;
+        opacity: var(--disabled-opacity);
         pointer-events: none;
     }
 
-    &:focus {
-        outline: none;
+    /* variant: icon-only */
+    &.--icon-only {
+        & rux-icon,
+        & ::slotted(rux-icon) {
+            margin-inline: calc(-4 * var(--scale));
+        }
     }
 
-    &:hover:not([disabled]) {
-        cursor: pointer;
+    /* variant: small size */
+    &.--small {
+        padding-block: calc(0.5 * var(--scale));
+        padding-inline: calc(4 * var(--scale));
     }
 
-    &--default {
-        border: 1px solid transparent;
+    /* variant: medium size */
+    &.--medium {
+        padding-block: calc(1.5 * var(--scale));
+        padding-inline: calc(4 * var(--scale));
+    }
+
+    /* variant: large size */
+    &.--large {
+        padding-block: calc(2 * var(--scale));
+        padding-inline: calc(4 * var(--scale));
+    }
+
+    /* variant: primary appearance */
+    &.--primary {
+        color: var(--color-text-inverse);
         background-color: var(--color-background-interactive-default);
-        &:hover:not([disabled]) {
-            border-color: transparent;
+
+        /* state: hovered or keyboard focused */
+        &:hover,
+        &:focus-visible {
             background-color: var(--color-background-interactive-hover);
         }
-        &:active:not([disabled]) {
-            border-color: var(--color-background-interactive-default);
-            background-color: var(--color-background-interactive-default);
+    }
+
+    /* variant: secondary appearance */
+    &.--secondary {
+        /* reference */
+        --border-color: currentColor;
+        --border-width: 1px;
+
+        /* color */
+        background-color: var(--color-background-base-default);
+        color: var(--color-text-interactive-default);
+
+        /* state: hovered or keyboard focused */
+        &:hover,
+        &:focus-visible {
+            color: var(--color-text-interactive-hover);
         }
     }
 
-    &--secondary {
-        color: var(--color-background-interactive-default);
-        background-color: transparent;
-        border: 1px solid var(--color-background-interactive-default);
+    /* variant: borderless appearance */
+    &.--borderless {
+        /* color */
+        background-color: var(--color-background-base-default);
+        color: var(--color-text-interactive-default);
 
-        &:hover:not([disabled]) {
-            color: var(--color-background-interactive-hover);
-            background-color: transparent;
-            border-color: var(--color-background-interactive-hover);
-            rux-icon,
-            ::slotted(rux-icon) {
-                color: var(--color-background-interactive-hover);
-            }
-        }
-
-        &:active:not([disabled]) {
-            border-color: var(--color-background-interactive-default);
-            background-color: transparent;
-            color: var(--color-background-interactive-default);
-            rux-icon,
-            ::slotted(rux-icon) {
-                color: var(--color-background-interactive-default);
-            }
-        }
-        rux-icon,
-        ::slotted(rux-icon) {
-            color: var(--color-background-interactive-default);
-        }
-    }
-    &--borderless {
-        color: var(--color-background-interactive-default);
-        border: none;
-        background: none;
-        &:hover:not([disabled]) {
-            color: var(--color-background-interactive-hover);
-            background: none;
-            rux-icon,
-            ::slotted(rux-icon) {
-                color: var(--color-background-interactive-hover);
-            }
-        }
-        &:active:not([disabled]) {
-            color: var(--color-background-interactive-default);
-            rux-icon,
-            ::slotted(rux-icon) {
-                color: var(--color-background-interactive-default);
-            }
-        }
-        rux-icon,
-        ::slotted(rux-icon) {
-            color: var(--color-background-interactive-default);
+        /* state: hovered or keyboard focused */
+        &:hover,
+        &:focus-visible {
+            color: var(--color-text-interactive-hover);
         }
     }
 
-    &--small {
-        height: 1.625rem;
-        padding: 0 1rem;
-        line-height: 1;
+    /* shadow: embedded icon */
+    & rux-icon,
+    & ::slotted(rux-icon) {
+        display: inline-flex;
+
+        /* layout */
+        align-items: center;
+        block-size: calc(5 * var(--scale));
+        inline-size: calc(5 * var(--scale));
+        justify-content: center;
+        margin-inline: calc(-0.5 * var(--scale)) calc(1.5 * var(--scale));
+        vertical-align: top;
+
+        /* color */
+        color: currentColor;
+        fill: currentColor;
     }
 
-    &--large {
-        height: 2.875rem;
-        min-width: 3rem;
-        padding: 0 1rem;
+    /* shadow: slot */
+    & slot {
+        display: inline-block;
     }
-
-    &--icon-only {
-        font-size: 0;
-        width: 3rem;
-    }
-}
-
-.rux-button--icon-only ::slotted(rux-icon),
-.rux-button--icon-only rux-icon {
-    margin-left: -0.625rem;
-    margin-right: -0.625rem;
 }

--- a/packages/web-components/src/components/rux-button/rux-button.tsx
+++ b/packages/web-components/src/components/rux-button/rux-button.tsx
@@ -43,8 +43,6 @@ export class RuxButton {
 
     /**
      * Changes size of a button from medium to small or large by setting sizing classes
-     * rux-button--small
-     * rux-button--large
      */
     @Prop({ reflect: true }) size?: 'small' | 'medium' | 'large'
 
@@ -78,7 +76,7 @@ export class RuxButton {
     }
 
     render() {
-        const { size, iconOnly, secondary, disabled, icon, borderless } = this
+        const { size = 'medium', iconOnly, secondary, disabled, icon, borderless } = this
         return (
             <Host>
                 <button
@@ -86,12 +84,19 @@ export class RuxButton {
                     onClick={this.handleClick}
                     class={{
                         'rux-button': true,
-                        'rux-button--secondary': secondary,
-                        'rux-button--default': !secondary,
-                        'rux-button--small': size === 'small',
-                        'rux-button--large': size === 'large',
-                        'rux-button--icon-only': iconOnly,
-                        'rux-button--borderless': borderless,
+
+                        // appearance variant
+                        '--primary': !secondary && !borderless,
+                        '--secondary': secondary,
+                        '--borderless': borderless,
+
+                        // size variant
+                        '--small': size === 'small',
+                        '--medium': size === 'medium',
+                        '--large': size === 'large',
+
+                        // icon-only variant
+                        '--icon-only': iconOnly,
                     }}
                     aria-disabled={disabled ? 'true' : null}
                     disabled={disabled}

--- a/packages/web-components/src/components/rux-button/test/__snapshots__/rux-button.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-button/test/__snapshots__/rux-button.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`rux-button renders 1`] = `
 <rux-button>
   <mock:shadow-root>
-    <button class="rux-button rux-button--default" part="container" type="button">
+    <button class="--medium --primary rux-button" part="container" type="button">
       <slot></slot>
     </button>
   </mock:shadow-root>
@@ -14,7 +14,7 @@ exports[`rux-button renders 1`] = `
 exports[`rux-button sets attributes 1`] = `
 <rux-button disabled="" secondary="" type="submit">
   <mock:shadow-root>
-    <button aria-disabled="true" class="rux-button rux-button--secondary" disabled="" part="container" type="button">
+    <button aria-disabled="true" class="--medium --secondary rux-button" disabled="" part="container" type="button">
       <slot></slot>
     </button>
   </mock:shadow-root>

--- a/packages/web-components/src/components/rux-button/test/index.html
+++ b/packages/web-components/src/components/rux-button/test/index.html
@@ -19,8 +19,8 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body class="dark-theme">
-        <div style="padding: 10%; display: flex; justify-content: center">
+    <body class="dark-theme" style="padding: 10% 0">
+        <div style="padding: 0 10%; display: flex; justify-content: center">
             <form id="form">
                 <input type="text" name="myname" value="mark" />
                 <rux-button type="submit">submit</rux-button>
@@ -46,6 +46,143 @@
                     }
                 })
             </script>
+        </div>
+
+        <hr width="100" style="margin-block: 1em 2em" />
+
+        <div style="padding: 0 10%; display: flex; flex-direction: column; align-items: center;">
+          <section>
+            <h3>Primary Button</h3>
+            <p>
+              <rux-button>Button</rux-button>
+              <rux-button disabled>Disabled Button</rux-button>
+            </p>
+            <h5>Large</h5>
+            <p>
+              <rux-button size="large">Button</rux-button>
+              <rux-button size="large" disabled>Disabled Button</rux-button>
+            </p>
+            <h5>Small</h5>
+            <p>
+              <rux-button size="small">Button</rux-button>
+              <rux-button size="small" disabled>Disabled Button</rux-button>
+            </p>
+            <h5>With two lines</h5>
+            <p>
+              <rux-button>Two Lined <br /> Button</rux-button>
+              <rux-button>Two Lined <br /> Disabled Button</rux-button>
+            </p>
+            <h5>With fixed width</h5>
+            <p style="display: flex; flex-flow: column;">
+              <rux-button>Button</rux-button>
+              <br />
+              <rux-button>Two Lined <br /> Button</rux-button>
+            </p>
+            <h5>With an icon</h5>
+            <p>
+              <rux-button icon="apps" icon-only></rux-button>
+              <rux-button icon="apps">
+                Button
+              </rux-button>
+            </p>
+            <p>
+              <rux-button icon-only><rux-icon icon="apps" size="extra-small"></rux-icon></rux-button>
+              <rux-button icon="apps">
+                Button
+              </rux-button>
+            </p>
+          </section>
+
+          <hr width="100" style="margin-block: 1em 2em" />
+
+          <section>
+            <h3>Secondary Button</h3>
+            <p>
+              <rux-button secondary>Button</rux-button>
+              <rux-button secondary disabled>Disabled Button</rux-button>
+            </p>
+            <h5>Large</h5>
+            <p>
+              <rux-button secondary size="large">Button</rux-button>
+              <rux-button secondary size="large" disabled>Disabled Button</rux-button>
+            </p>
+            <h5>Small</h5>
+            <p>
+              <rux-button secondary size="small">Button</rux-button>
+              <rux-button secondary size="small" disabled>Disabled Button</rux-button>
+            </p>
+            <h5>With two lines</h5>
+            <p>
+              <rux-button secondary>Two Lined <br /> Button</rux-button>
+              <rux-button secondary disabled>Two Lined <br /> Disabled Button</rux-button>
+            </p>
+            <p style="display: flex; flex-flow: column;">
+              <rux-button secondary>Two Lined <br /> Button</rux-button>
+              <br />
+              <rux-button secondary disabled>Two Lined <br /> Disabled Button</rux-button>
+            </p>
+            <h5>With an icon</h5>
+            <p>
+              <rux-button secondary icon="apps" icon-only></rux-button>
+              <rux-button secondary icon="apps">
+                Button
+              </rux-button>
+            </p>
+            <p>
+              <rux-button secondary icon-only><rux-icon icon="apps" size="extra-small"></rux-icon></rux-button>
+              <rux-button secondary icon="apps">
+                Button
+              </rux-button>
+            </p>
+          </section>
+
+          <hr width="100" style="margin-block: 1em 2em" />
+
+          <section>
+            <h3>Borderless Button</h3>
+            <p>
+              <rux-button borderless>Button</rux-button>
+              <rux-button borderless disabled>Disabled Button</rux-button>
+            </p>
+            <h5>Large</h5>
+            <p>
+              <rux-button borderless size="large">Button</rux-button>
+              <rux-button borderless size="large" disabled>Disabled Button</rux-button>
+            </p>
+            <h5>Small</h5>
+            <p>
+              <rux-button borderless size="small">Button</rux-button>
+              <rux-button borderless size="small" disabled>Disabled Button</rux-button>
+            </p>
+            <h5>With two lines</h5>
+            <p>
+              <rux-button borderless>Two Lined <br /> Button</rux-button>
+              <rux-button borderless disabled>Two Lined <br /> Disabled Button</rux-button>
+            </p>
+            <p style="display: flex; flex-flow: column;">
+              <rux-button borderless>Button</rux-button>
+              <br />
+              <rux-button borderless disabled>Two Lined <br /> Disabled Button</rux-button>
+            </p>
+            <h5>With an icon</h5>
+            <p>
+              <rux-button borderless icon="apps" icon-only></rux-button>
+              <rux-button borderless icon="apps">
+                Button
+              </rux-button>
+            </p>
+          </section>
+
+          <hr width="100" style="margin-block: 1em 2em" />
+
+          <section>
+            <h5>With a hidden attribute</h5>
+            <p>
+              <rux-button hidden>Hidden Button</rux-button>
+            </p>
+          </section>
+
+          <hr width="100" style="margin-block: 1em 2em" />
         </div>
     </body>
 </html>

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
@@ -105,7 +105,7 @@
         &:disabled {
             + label {
                 cursor: not-allowed;
-                opacity: var(--disabled-opacity);
+                opacity: var(--opacity-disabled, 40%);
             }
         }
     }

--- a/packages/web-components/src/components/rux-input/rux-input.scss
+++ b/packages/web-components/src/components/rux-input/rux-input.scss
@@ -70,7 +70,7 @@
         }
         &--disabled {
             opacity: 0.4;
-            opacity: var(--disabled-opacity);
+            opacity: var(--opacity-disabled, 40%);
             cursor: not-allowed;
         }
         &--small {

--- a/packages/web-components/src/components/rux-push-button/rux-push-button.scss
+++ b/packages/web-components/src/components/rux-push-button/rux-push-button.scss
@@ -8,7 +8,7 @@
     user-select: none;
 
     &[disabled] {
-        opacity: var(--disabled-opacity);
+        opacity: var(--opacity-disabled, 40%);
         cursor: not-allowed;
     }
 
@@ -94,7 +94,7 @@
 
         //disabled, not active
         &__input:disabled + .rux-push-button__button {
-            opacity: var(--disabled-opacity);
+            opacity: var(--opacity-disabled, 40%);
             cursor: not-allowed;
             &:hover {
                 border-color: var(--color-border-interactive-default);

--- a/packages/web-components/src/components/rux-radio/rux-radio.scss
+++ b/packages/web-components/src/components/rux-radio/rux-radio.scss
@@ -96,7 +96,7 @@
         &:disabled {
             + label {
                 cursor: not-allowed;
-                opacity: var(--disabled-opacity);
+                opacity: var(--opacity-disabled, 40%);
             }
         }
 

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
@@ -3,7 +3,7 @@
     box-sizing: border-box;
 }
 :host([disabled]) {
-    opacity: var(--disabled-opacity);
+    opacity: var(--opacity-disabled, 40%);
     cursor: not-allowed;
     pointer-events: none;
 

--- a/packages/web-components/src/components/rux-select/rux-select.scss
+++ b/packages/web-components/src/components/rux-select/rux-select.scss
@@ -138,7 +138,7 @@ label {
                 color: var(--color-text-primary);
             }
             &:disabled {
-                opacity: var(--disabled-opacity);
+                opacity: var(--opacity-disabled, 40%);
                 cursor: not-allowed;
                 &:hover {
                     color: var(--color-background-interactive-default);
@@ -195,7 +195,7 @@ label {
             background-color: var(--color-background-surface-selected);
         }
         &:disabled {
-            opacity: var(--disabled-opacity);
+            opacity: var(--opacity-disabled, 40%);
             cursor: not-allowed;
         }
     }

--- a/packages/web-components/src/components/rux-slider/rux-slider.scss
+++ b/packages/web-components/src/components/rux-slider/rux-slider.scss
@@ -38,7 +38,7 @@
         cursor: not-allowed;
     }
     .rux-range:disabled + #steplist {
-        opacity: var(--disabled-opacity);
+        opacity: var(--opacity-disabled, 40%);
         cursor: not-allowed;
         .tick {
             cursor: not-allowed;
@@ -77,7 +77,7 @@
             padding: 0;
         }
         :disabled {
-            opacity: var(--disabled-opacity);
+            opacity: var(--opacity-disabled, 40%);
         }
     }
 }
@@ -124,7 +124,7 @@ input[type='range']:focus {
     background-position: left, right;
 }
 .rux-range:disabled::-webkit-slider-runnable-track {
-    opacity: var(--disabled-opacity, 0.4);
+    opacity: var(--opacity-disabled, 40%);
     cursor: not-allowed;
 }
 
@@ -155,14 +155,14 @@ input[type='range']:focus {
 }
 .rux-range:disabled::-moz-range-track,
 .rux-range:disabled::-moz-range-progress {
-    opacity: var(--disabled-opacity, 0.4);
+    opacity: var(--opacity-disabled, 40%);
     cursor: not-allowed;
 }
 .rux-range::-moz-range-progress {
     background-color: var(--color-background-interactive-default);
 }
 .rux-input:disabled {
-    opacity: var(--disabled-opacity, 0.4);
+    opacity: var(--opacity-disabled, 40%);
     cursor: not-allowed;
 }
 
@@ -262,7 +262,7 @@ input:-moz-focusring {
     outline: none;
 }
 .rux-range:disabled::-moz-range-thumb {
-    opacity: var(--disabled-opacity, 0.4);
+    opacity: var(--opacity-disabled, 40%);
     cursor: not-allowed;
 }
 

--- a/packages/web-components/src/components/rux-switch/rux-switch.scss
+++ b/packages/web-components/src/components/rux-switch/rux-switch.scss
@@ -73,7 +73,7 @@
         &:disabled {
             + .rux-switch__button {
                 cursor: not-allowed;
-                opacity: var(--disabled-opacity);
+                opacity: var(--opacity-disabled, 40%);
             }
         }
     }

--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
@@ -41,7 +41,7 @@
 
 .rux-tab--disabled {
     color: var(--color-background-interactive-default);
-    opacity: var(--disabled-opacity);
+    opacity: var(--opacity-disabled, 40%);
     cursor: not-allowed;
 }
 

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -29,7 +29,7 @@
     }
     &--disabled {
         opacity: 0.4;
-        opacity: var(--disabled-opacity);
+        opacity: var(--opacity-disabled, 40%);
         cursor: not-allowed;
     }
     &--small {

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -4,7 +4,25 @@
 :root {
     // Sets default theme variables for component library
     @include variables.root-variables;
-    --disabled-opacity: 0.4;
+
+    /* Opacity applied to disabled elements. */
+    --disabled-opacity: 40%;
+
+    /* Relative scale applied to elements. */
+    --scale: 0.25rem;
+
+    /* Typography family applied to elements. */
+    --type-family: 'Roboto', system-ui;
+
+    /* Typography line height applied to a button. */
+    --button-type-line-spacing: 1.25;
+
+    /* Typography size, line height, and family applied to a button. */
+    --button-type-shorthand: var(--button-type-size)/var(--button-type-line-spacing) var(--type-family);
+
+    /* Typography size applied to a button. */
+    --button-type-size: calc(4 * var(--step));
+
     --radius-base: 3px;
 
     --status-symbols: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAAAgCAMAAABzRoe3AAAAgVBMVEUAAAD/tQv/swL/OTn/PDzftl9W8QBW8AAtzP8v0P9Z9gD/tAP/uQb/tAItzf8tzf+eqK2ep60uzP9X8QCfqK4uzf8uzf9X8QAuzP9X8ACeqK4vzP9Y8QAuzv9Y8gCeqq4wz/8xzv9A1f9Y8QD/tAP86DpW8AD/swL/ODgtzP+ep63tgXPUAAAAJXRSTlMAGNfAQAv98/IdG8Io52zz8+DZ2dC9trabm4F+a05OQjAaDG6dAJcYcwAAAfdJREFUWMPtmNlygkAQRScyrBp3QTZFNBj8/w9MCGI3dBOHMg9jyvOmVFnn1HUSULx4LibjN/HMTN7Po2cu+PY/cwUfPYg2XhKsbHsVJJ5gcaf+cjZb+lN3qJjxyWIw/lAwNMALreKKFTIJh215Y3sYFiD5AEn9oWBowM4uEPau65A6JcJJ/2ACg/pDwdCAo1W0sI6ixbTsMH18Akn9oWBgwK7xh4LWBmlJSB+dwCD+pEA5wLMLgo3OwcGpvzhxludZfH1Bz4EZrefzdWSqTSCJPylQDggLhhA+oD6/G7d+5W7qk9yV3C8uPyz2KhMYxJ8UKAd4Fhdg3SZwa3/4wLrA7fhfbuwVJpDEnxQoByQFS9I6wQ7ydR16js0FBCzMuxMY1J8WqAYEfEDQXPcr3RjbxNU7vsBEF0R0dwJJ/LkCxYAVH7Bqri8r3QzbZNU7S4FZ44B1/ymgA4zPfZwUA2w+wG6uzyrdHMvk1TszgZnjgLmgyL4T8Dbq8R+bWgUIgw4ABby/Vl8hIckAUMD7a3WIYQIYgC0Af73+jOIJpKAF1F+vf2QwAQxAC7C/ZrcSeAIpegvAX7ObOZgABiAF2F+322mYAAagBeCv2wMNTEAGIAWVv3aPlDABDMAW1P7aPdQjDBiALaj89ftZBSGl+LXgZIoXL/4VXyptNwzuHR/QAAAAAElFTkSuQmCC');

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -5,9 +5,6 @@
     // Sets default theme variables for component library
     @include variables.root-variables;
 
-    /* Opacity applied to disabled elements. */
-    --disabled-opacity: 40%;
-
     /* Relative scale applied to elements. */
     --scale: 0.25rem;
 
@@ -18,7 +15,8 @@
     --button-type-line-spacing: 1.25;
 
     /* Typography size, line height, and family applied to a button. */
-    --button-type-shorthand: var(--button-type-size)/var(--button-type-line-spacing) var(--type-family);
+    --button-type-shorthand: var(--button-type-size) /
+        var(--button-type-line-spacing) var(--type-family);
 
     /* Typography size applied to a button. */
     --button-type-size: calc(4 * var(--step));


### PR DESCRIPTION
## Brief Description

* upgrades to tokens@beta.8 
* replaces temp '--disabled-opacity` custom prop with the `--opacity-disabled` token.
* updates the useless failing jest snapshots for button

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
