### PR TITLE
refactor(web-components): use opacity-disabled token

### DIFF
--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -16,7 +16,7 @@
             },
             "devDependencies": {
                 "@astrouxds/astro-figma-export": "~1.0.1",
-                "@astrouxds/design-tokens": "2.0.0-beta.7",
+                "@astrouxds/design-tokens": "2.0.0-beta.8",
                 "@astrouxds/storybook-addon-docs-stencil": "~1.0.10",
                 "@babel/core": "~7.13.16",
                 "@stencil/angular-output-target": "~0.2.1",
@@ -80,9 +80,9 @@
             }
         },
         "node_modules/@astrouxds/design-tokens": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.6.tgz",
-            "integrity": "sha512-ekaSlqzvDZFCGEqhhp+dSWNRiP9lKU0dzcWb8BpV3Wip0gjFiNOeL4WdvDU0w5RnGpR1KoR3MwJKjY4GPBGgfw==",
+            "version": "2.0.0-beta.8",
+            "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.8.tgz",
+            "integrity": "sha512-qBPVG5xYBwJE+IdUMrsQHE5zBSD22eFpkM+LjGwV8rzJLJ6tkYbMbfFx+nOACIEqHUbzKl5P7/F7llKqE3yTKQ==",
             "dev": true,
             "dependencies": {
                 "@changesets/cli": "^2.22.0",
@@ -50008,9 +50008,9 @@
             }
         },
         "@astrouxds/design-tokens": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.6.tgz",
-            "integrity": "sha512-ekaSlqzvDZFCGEqhhp+dSWNRiP9lKU0dzcWb8BpV3Wip0gjFiNOeL4WdvDU0w5RnGpR1KoR3MwJKjY4GPBGgfw==",
+            "version": "2.0.0-beta.8",
+            "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.8.tgz",
+            "integrity": "sha512-qBPVG5xYBwJE+IdUMrsQHE5zBSD22eFpkM+LjGwV8rzJLJ6tkYbMbfFx+nOACIEqHUbzKl5P7/F7llKqE3yTKQ==",
             "dev": true,
             "requires": {
                 "@changesets/cli": "^2.22.0",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -48,7 +48,7 @@
     "license": "MIT",
     "devDependencies": {
         "@astrouxds/astro-figma-export": "~1.0.1",
-        "@astrouxds/design-tokens": "2.0.0-beta.7",
+        "@astrouxds/design-tokens": "2.0.0-beta.8",
         "@astrouxds/storybook-addon-docs-stencil": "~1.0.10",
         "@babel/core": "~7.13.16",
         "@stencil/angular-output-target": "~0.2.1",

--- a/packages/web-components/src/components/rux-button-group/test/__snapshots__/rux-button-group.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-button-group/test/__snapshots__/rux-button-group.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`rux-button-group renders 1`] = `
   </mock:shadow-root>
   <rux-button icon="" secondary="">
     <mock:shadow-root>
-      <button class="rux-button rux-button--secondary" part="container" type="button">
+      <button class="--medium --secondary rux-button" part="container" type="button">
         <slot></slot>
       </button>
     </mock:shadow-root>
@@ -27,7 +27,7 @@ exports[`rux-button-group renders 1`] = `
   </rux-button>
   <rux-button icon="">
     <mock:shadow-root>
-      <button class="rux-button rux-button--default" part="container" type="button">
+      <button class="--medium --primary rux-button" part="container" type="button">
         <slot></slot>
       </button>
     </mock:shadow-root>

--- a/packages/web-components/src/components/rux-button/rux-button.scss
+++ b/packages/web-components/src/components/rux-button/rux-button.scss
@@ -50,12 +50,13 @@ button {
 
     /* decoration */
     border-radius: var(--radius-base);
-    box-shadow: var(--border-color, transparent) 0 0 0 var(--border-width, 0px) inset;
+    box-shadow: var(--border-color, transparent) 0 0 0 var(--border-width, 0px)
+        inset;
 
     /* state: disabled */
     &:disabled {
         cursor: not-allowed;
-        opacity: var(--disabled-opacity);
+        opacity: var(--opacity-disabled, 40%);
         pointer-events: none;
     }
 

--- a/packages/web-components/src/components/rux-button/test/__snapshots__/rux-button.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-button/test/__snapshots__/rux-button.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`rux-button renders 1`] = `
 <rux-button>
   <mock:shadow-root>
-    <button class="rux-button rux-button--default" part="container" type="button">
+    <button class="--medium --primary rux-button" part="container" type="button">
       <slot></slot>
     </button>
   </mock:shadow-root>
@@ -14,7 +14,7 @@ exports[`rux-button renders 1`] = `
 exports[`rux-button sets attributes 1`] = `
 <rux-button disabled="" secondary="" type="submit">
   <mock:shadow-root>
-    <button aria-disabled="true" class="rux-button rux-button--secondary" disabled="" part="container" type="button">
+    <button aria-disabled="true" class="--medium --secondary rux-button" disabled="" part="container" type="button">
       <slot></slot>
     </button>
   </mock:shadow-root>

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
@@ -105,7 +105,7 @@
         &:disabled {
             + label {
                 cursor: not-allowed;
-                opacity: var(--disabled-opacity);
+                opacity: var(--opacity-disabled, 40%);
             }
         }
     }

--- a/packages/web-components/src/components/rux-input/rux-input.scss
+++ b/packages/web-components/src/components/rux-input/rux-input.scss
@@ -70,7 +70,7 @@
         }
         &--disabled {
             opacity: 0.4;
-            opacity: var(--disabled-opacity);
+            opacity: var(--opacity-disabled, 40%);
             cursor: not-allowed;
         }
         &--small {

--- a/packages/web-components/src/components/rux-push-button/rux-push-button.scss
+++ b/packages/web-components/src/components/rux-push-button/rux-push-button.scss
@@ -8,7 +8,7 @@
     user-select: none;
 
     &[disabled] {
-        opacity: var(--disabled-opacity);
+        opacity: var(--opacity-disabled, 40%);
         cursor: not-allowed;
     }
 
@@ -94,7 +94,7 @@
 
         //disabled, not active
         &__input:disabled + .rux-push-button__button {
-            opacity: var(--disabled-opacity);
+            opacity: var(--opacity-disabled, 40%);
             cursor: not-allowed;
             &:hover {
                 border-color: var(--color-border-interactive-default);

--- a/packages/web-components/src/components/rux-radio/rux-radio.scss
+++ b/packages/web-components/src/components/rux-radio/rux-radio.scss
@@ -96,7 +96,7 @@
         &:disabled {
             + label {
                 cursor: not-allowed;
-                opacity: var(--disabled-opacity);
+                opacity: var(--opacity-disabled, 40%);
             }
         }
 

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
@@ -10,7 +10,7 @@
 }
 
 :host([hidden]) {
-  display: none;
+    display: none;
 }
 
 /* reset unorganized list */
@@ -21,7 +21,7 @@ ul {
 }
 
 li {
-  display: contents;
+    display: contents;
 }
 
 /* remove input display */
@@ -68,7 +68,7 @@ label {
         cursor: not-allowed;
 
         /* appearance */
-        opacity: var(--disabled-opacity);
+        opacity: var(--opacity-disabled, 40%);
     }
 
     /* variant: first-child */

--- a/packages/web-components/src/components/rux-select/rux-select.scss
+++ b/packages/web-components/src/components/rux-select/rux-select.scss
@@ -138,7 +138,7 @@ label {
                 color: var(--color-text-primary);
             }
             &:disabled {
-                opacity: var(--disabled-opacity);
+                opacity: var(--opacity-disabled, 40%);
                 cursor: not-allowed;
                 &:hover {
                     color: var(--color-background-interactive-default);
@@ -195,7 +195,7 @@ label {
             background-color: var(--color-background-surface-selected);
         }
         &:disabled {
-            opacity: var(--disabled-opacity);
+            opacity: var(--opacity-disabled, 40%);
             cursor: not-allowed;
         }
     }

--- a/packages/web-components/src/components/rux-slider/rux-slider.scss
+++ b/packages/web-components/src/components/rux-slider/rux-slider.scss
@@ -38,7 +38,7 @@
         cursor: not-allowed;
     }
     .rux-range:disabled + #steplist {
-        opacity: var(--disabled-opacity);
+        opacity: var(--opacity-disabled, 40%);
         cursor: not-allowed;
         .tick {
             cursor: not-allowed;
@@ -77,7 +77,7 @@
             padding: 0;
         }
         :disabled {
-            opacity: var(--disabled-opacity);
+            opacity: var(--opacity-disabled, 40%);
         }
     }
 }
@@ -124,7 +124,7 @@ input[type='range']:focus {
     background-position: left, right;
 }
 .rux-range:disabled::-webkit-slider-runnable-track {
-    opacity: var(--disabled-opacity, 0.4);
+    opacity: var(--opacity-disabled, 40%);
     cursor: not-allowed;
 }
 
@@ -155,14 +155,14 @@ input[type='range']:focus {
 }
 .rux-range:disabled::-moz-range-track,
 .rux-range:disabled::-moz-range-progress {
-    opacity: var(--disabled-opacity, 0.4);
+    opacity: var(--opacity-disabled, 40%);
     cursor: not-allowed;
 }
 .rux-range::-moz-range-progress {
     background-color: var(--color-background-interactive-default);
 }
 .rux-input:disabled {
-    opacity: var(--disabled-opacity, 0.4);
+    opacity: var(--opacity-disabled, 40%);
     cursor: not-allowed;
 }
 
@@ -262,7 +262,7 @@ input:-moz-focusring {
     outline: none;
 }
 .rux-range:disabled::-moz-range-thumb {
-    opacity: var(--disabled-opacity, 0.4);
+    opacity: var(--opacity-disabled, 40%);
     cursor: not-allowed;
 }
 

--- a/packages/web-components/src/components/rux-switch/rux-switch.scss
+++ b/packages/web-components/src/components/rux-switch/rux-switch.scss
@@ -73,7 +73,7 @@
         &:disabled {
             + .rux-switch__button {
                 cursor: not-allowed;
-                opacity: var(--disabled-opacity);
+                opacity: var(--opacity-disabled, 40%);
             }
         }
     }

--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
@@ -41,7 +41,7 @@
 
 .rux-tab--disabled {
     color: var(--color-background-interactive-default);
-    opacity: var(--disabled-opacity);
+    opacity: var(--opacity-disabled, 40%);
     cursor: not-allowed;
 }
 

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -29,7 +29,7 @@
     }
     &--disabled {
         opacity: 0.4;
-        opacity: var(--disabled-opacity);
+        opacity: var(--opacity-disabled, 40%);
         cursor: not-allowed;
     }
     &--small {

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -5,9 +5,6 @@
     // Sets default theme variables for component library
     @include variables.root-variables;
 
-    /* Opacity applied to disabled elements. */
-    --disabled-opacity: 40%;
-
     /* Relative scale applied to elements. */
     --scale: 0.25rem;
 
@@ -18,6 +15,7 @@
     --button-type-line-spacing: 1.25;
 
     /* Typography size, line height, and family applied to a button. */
+    // prettier-ignore
     --button-type-shorthand: var(--button-type-size)/var(--button-type-line-spacing) var(--type-family);
 
     /* Typography size applied to a button. */


### PR DESCRIPTION
## Brief Description
House keeping

* upgrades to tokens@beta.8
* replaces temp '--disabled-opacitycustom prop with the--opacity-disabled` token.
* updates the useless failing jest snapshots for button

## Issues and Limitations

* Prettier keeps adding spaces to the / in `--button-type-shorthand: var(--button-type-size)/var(--button-type-line-spacing) var(--type-family);` so I threw in a prettier-ignore for now because I couldn't figure out what that rule was.

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
