### PR TITLE
feat(dialog): create dialog component

### DIFF
--- a/.changeset/polite-spoons-attack.md
+++ b/.changeset/polite-spoons-attack.md
@@ -1,0 +1,12 @@
+---
+"@astrouxds/angular": minor
+"@astrouxds/react": minor
+"@astrouxds/astro-web-components": minor
+"astro-website": minor
+---
+
+Modal is now deprecated and will be removed in 7.0. It is being renamed to Dialog to align with our Design System naming and which shares the exact same API as Modal. It is recommended that you migrate to Dialog before 7.0. You can do a global find/replace on your project for:
+
+`rux-modal` -> `rux-dialog`
+`ruxmodalclosed` -> `ruxdialogclosed`
+`ruxmodalopened` -> `ruxmodalopened`

--- a/.changeset/polite-spoons-attack.md
+++ b/.changeset/polite-spoons-attack.md
@@ -9,4 +9,4 @@ Modal is now deprecated and will be removed in 7.0. It is being renamed to Dialo
 
 `rux-modal` -> `rux-dialog`
 `ruxmodalclosed` -> `ruxdialogclosed`
-`ruxmodalopened` -> `ruxmodalopened`
+`ruxmodalopened` -> `ruxdialogopened`

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Install Modules
         run: npm run web-comps.install && npm run react.install
 
+      - name: Symlink
+        run: lerna link
+
       - name: Build
         run: npm run build.tests
 

--- a/packages/angular/src/directives/angular-component-lib/utils.ts
+++ b/packages/angular/src/directives/angular-component-lib/utils.ts
@@ -32,13 +32,34 @@ export const proxyOutputs = (instance: any, el: any, events: string[]) => {
   events.forEach((eventName) => (instance[eventName] = new EventEmitter()));
 };
 
-export function ProxyCmp(opts: { inputs?: any; methods?: any }) {
+export const defineCustomElement = (tagName: string, customElement: any) => {
+  if (
+    customElement !== undefined &&
+    typeof customElements !== "undefined" &&
+    !customElements.get(tagName)
+  ) {
+    customElements.define(tagName, customElement);
+  }
+};
+
+// tslint:disable-next-line: only-arrow-functions
+export function ProxyCmp(opts: {
+  defineCustomElementFn?: () => void;
+  inputs?: any;
+  methods?: any;
+}) {
   const decorator = function (cls: any) {
-    if (opts.inputs) {
-      proxyInputs(cls, opts.inputs);
+    const { defineCustomElementFn, inputs, methods } = opts;
+
+    if (defineCustomElementFn !== undefined) {
+      defineCustomElementFn();
     }
-    if (opts.methods) {
-      proxyMethods(cls, opts.methods);
+
+    if (inputs) {
+      proxyInputs(cls, inputs);
+    }
+    if (methods) {
+      proxyMethods(cls, methods);
     }
     return cls;
   };

--- a/packages/angular/src/directives/proxies-list.ts
+++ b/packages/angular/src/directives/proxies-list.ts
@@ -8,6 +8,7 @@ export const DIRECTIVES = [
   d.RuxClassificationMarking,
   d.RuxClock,
   d.RuxDatetime,
+  d.RuxDialog,
   d.RuxGlobalStatusBar,
   d.RuxIcon,
   d.RuxIcon360,

--- a/packages/angular/src/directives/proxies.ts
+++ b/packages/angular/src/directives/proxies.ts
@@ -6,9 +6,12 @@ import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
 import { Components } from '@astrouxds/astro-web-components';
 
 
+
+
 export declare interface RuxButton extends Components.RuxButton {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['borderless', 'disabled', 'icon', 'iconOnly', 'secondary', 'size', 'type']
 })
 @Component({
@@ -29,6 +32,7 @@ export class RuxButton {
 export declare interface RuxButtonGroup extends Components.RuxButtonGroup {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['hAlign']
 })
 @Component({
@@ -63,6 +67,7 @@ export declare interface RuxCheckbox extends Components.RuxCheckbox {
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['checked', 'disabled', 'helpText', 'indeterminate', 'label', 'name', 'required', 'value']
 })
 @Component({
@@ -84,6 +89,7 @@ export class RuxCheckbox {
 export declare interface RuxCheckboxGroup extends Components.RuxCheckboxGroup {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['errorText', 'helpText', 'invalid', 'label', 'required']
 })
 @Component({
@@ -104,6 +110,7 @@ export class RuxCheckboxGroup {
 export declare interface RuxClassificationMarking extends Components.RuxClassificationMarking {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['classification', 'label', 'tag']
 })
 @Component({
@@ -124,6 +131,7 @@ export class RuxClassificationMarking {
 export declare interface RuxClock extends Components.RuxClock {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['aos', 'dateIn', 'hideDate', 'hideLabels', 'hideTimezone', 'los', 'small', 'timezone']
 })
 @Component({
@@ -144,6 +152,7 @@ export class RuxClock {
 export declare interface RuxDatetime extends Components.RuxDatetime {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['date', 'day', 'era', 'hour', 'hour12', 'locale', 'minute', 'month', 'second', 'timeZone', 'timeZoneName', 'weekday', 'year']
 })
 @Component({
@@ -161,9 +170,42 @@ export class RuxDatetime {
 }
 
 
+export declare interface RuxDialog extends Components.RuxDialog {
+  /**
+   * Event that is fired when dialog opens 
+   */
+  ruxdialogopened: EventEmitter<CustomEvent<void>>;
+  /**
+   * Event that is fired when dialog closes 
+   */
+  ruxdialogclosed: EventEmitter<CustomEvent<boolean | null>>;
+
+}
+
+@ProxyCmp({
+  defineCustomElementFn: undefined,
+  inputs: ['confirmText', 'denyText', 'modalMessage', 'modalTitle', 'open']
+})
+@Component({
+  selector: 'rux-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  inputs: ['confirmText', 'denyText', 'modalMessage', 'modalTitle', 'open']
+})
+export class RuxDialog {
+  protected el: HTMLElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+    c.detach();
+    this.el = r.nativeElement;
+    proxyOutputs(this, this.el, ['ruxdialogopened', 'ruxdialogclosed']);
+  }
+}
+
+
 export declare interface RuxGlobalStatusBar extends Components.RuxGlobalStatusBar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['appDomain', 'appName', 'appState', 'appStateColor', 'appVersion', 'includeIcon', 'menuIcon', 'username']
 })
 @Component({
@@ -184,6 +226,7 @@ export class RuxGlobalStatusBar {
 export declare interface RuxIcon extends Components.RuxIcon {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['icon', 'label', 'size']
 })
 @Component({
@@ -204,6 +247,7 @@ export class RuxIcon {
 export declare interface RuxIcon360 extends Components.RuxIcon360 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -224,6 +268,7 @@ export class RuxIcon360 {
 export declare interface RuxIcon3dRotation extends Components.RuxIcon3dRotation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -244,6 +289,7 @@ export class RuxIcon3dRotation {
 export declare interface RuxIcon4k extends Components.RuxIcon4k {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -264,6 +310,7 @@ export class RuxIcon4k {
 export declare interface RuxIconAcUnit extends Components.RuxIconAcUnit {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -284,6 +331,7 @@ export class RuxIconAcUnit {
 export declare interface RuxIconAccessAlarms extends Components.RuxIconAccessAlarms {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -304,6 +352,7 @@ export class RuxIconAccessAlarms {
 export declare interface RuxIconAccessTime extends Components.RuxIconAccessTime {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -324,6 +373,7 @@ export class RuxIconAccessTime {
 export declare interface RuxIconAccessibility extends Components.RuxIconAccessibility {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -344,6 +394,7 @@ export class RuxIconAccessibility {
 export declare interface RuxIconAccessibilityNew extends Components.RuxIconAccessibilityNew {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -364,6 +415,7 @@ export class RuxIconAccessibilityNew {
 export declare interface RuxIconAccessible extends Components.RuxIconAccessible {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -384,6 +436,7 @@ export class RuxIconAccessible {
 export declare interface RuxIconAccessibleForward extends Components.RuxIconAccessibleForward {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -404,6 +457,7 @@ export class RuxIconAccessibleForward {
 export declare interface RuxIconAccountBalance extends Components.RuxIconAccountBalance {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -424,6 +478,7 @@ export class RuxIconAccountBalance {
 export declare interface RuxIconAccountBalanceWallet extends Components.RuxIconAccountBalanceWallet {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -444,6 +499,7 @@ export class RuxIconAccountBalanceWallet {
 export declare interface RuxIconAccountBox extends Components.RuxIconAccountBox {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -464,6 +520,7 @@ export class RuxIconAccountBox {
 export declare interface RuxIconAccountCircle extends Components.RuxIconAccountCircle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -484,6 +541,7 @@ export class RuxIconAccountCircle {
 export declare interface RuxIconAdb extends Components.RuxIconAdb {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -504,6 +562,7 @@ export class RuxIconAdb {
 export declare interface RuxIconAdd extends Components.RuxIconAdd {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -524,6 +583,7 @@ export class RuxIconAdd {
 export declare interface RuxIconAddAPhoto extends Components.RuxIconAddAPhoto {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -544,6 +604,7 @@ export class RuxIconAddAPhoto {
 export declare interface RuxIconAddAlarm extends Components.RuxIconAddAlarm {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -564,6 +625,7 @@ export class RuxIconAddAlarm {
 export declare interface RuxIconAddAlert extends Components.RuxIconAddAlert {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -584,6 +646,7 @@ export class RuxIconAddAlert {
 export declare interface RuxIconAddBox extends Components.RuxIconAddBox {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -604,6 +667,7 @@ export class RuxIconAddBox {
 export declare interface RuxIconAddCircle extends Components.RuxIconAddCircle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -624,6 +688,7 @@ export class RuxIconAddCircle {
 export declare interface RuxIconAddCircleOutline extends Components.RuxIconAddCircleOutline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -644,6 +709,7 @@ export class RuxIconAddCircleOutline {
 export declare interface RuxIconAddComment extends Components.RuxIconAddComment {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -664,6 +730,7 @@ export class RuxIconAddComment {
 export declare interface RuxIconAddLocation extends Components.RuxIconAddLocation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -684,6 +751,7 @@ export class RuxIconAddLocation {
 export declare interface RuxIconAddPhotoAlternate extends Components.RuxIconAddPhotoAlternate {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -704,6 +772,7 @@ export class RuxIconAddPhotoAlternate {
 export declare interface RuxIconAddShoppingCart extends Components.RuxIconAddShoppingCart {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -724,6 +793,7 @@ export class RuxIconAddShoppingCart {
 export declare interface RuxIconAddToHomeScreen extends Components.RuxIconAddToHomeScreen {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -744,6 +814,7 @@ export class RuxIconAddToHomeScreen {
 export declare interface RuxIconAddToPhotos extends Components.RuxIconAddToPhotos {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -764,6 +835,7 @@ export class RuxIconAddToPhotos {
 export declare interface RuxIconAddToQueue extends Components.RuxIconAddToQueue {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -784,6 +856,7 @@ export class RuxIconAddToQueue {
 export declare interface RuxIconAdjust extends Components.RuxIconAdjust {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -804,6 +877,7 @@ export class RuxIconAdjust {
 export declare interface RuxIconAirlineSeatFlat extends Components.RuxIconAirlineSeatFlat {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -824,6 +898,7 @@ export class RuxIconAirlineSeatFlat {
 export declare interface RuxIconAirlineSeatFlatAngled extends Components.RuxIconAirlineSeatFlatAngled {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -844,6 +919,7 @@ export class RuxIconAirlineSeatFlatAngled {
 export declare interface RuxIconAirlineSeatIndividualSuite extends Components.RuxIconAirlineSeatIndividualSuite {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -864,6 +940,7 @@ export class RuxIconAirlineSeatIndividualSuite {
 export declare interface RuxIconAirlineSeatLegroomExtra extends Components.RuxIconAirlineSeatLegroomExtra {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -884,6 +961,7 @@ export class RuxIconAirlineSeatLegroomExtra {
 export declare interface RuxIconAirlineSeatLegroomNormal extends Components.RuxIconAirlineSeatLegroomNormal {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -904,6 +982,7 @@ export class RuxIconAirlineSeatLegroomNormal {
 export declare interface RuxIconAirlineSeatLegroomReduced extends Components.RuxIconAirlineSeatLegroomReduced {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -924,6 +1003,7 @@ export class RuxIconAirlineSeatLegroomReduced {
 export declare interface RuxIconAirlineSeatReclineExtra extends Components.RuxIconAirlineSeatReclineExtra {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -944,6 +1024,7 @@ export class RuxIconAirlineSeatReclineExtra {
 export declare interface RuxIconAirlineSeatReclineNormal extends Components.RuxIconAirlineSeatReclineNormal {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -964,6 +1045,7 @@ export class RuxIconAirlineSeatReclineNormal {
 export declare interface RuxIconAirplanemodeActive extends Components.RuxIconAirplanemodeActive {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -984,6 +1066,7 @@ export class RuxIconAirplanemodeActive {
 export declare interface RuxIconAirplanemodeInactive extends Components.RuxIconAirplanemodeInactive {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1004,6 +1087,7 @@ export class RuxIconAirplanemodeInactive {
 export declare interface RuxIconAirplay extends Components.RuxIconAirplay {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1024,6 +1108,7 @@ export class RuxIconAirplay {
 export declare interface RuxIconAirportShuttle extends Components.RuxIconAirportShuttle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1044,6 +1129,7 @@ export class RuxIconAirportShuttle {
 export declare interface RuxIconAlarm extends Components.RuxIconAlarm {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1064,6 +1150,7 @@ export class RuxIconAlarm {
 export declare interface RuxIconAlarmAdd extends Components.RuxIconAlarmAdd {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1084,6 +1171,7 @@ export class RuxIconAlarmAdd {
 export declare interface RuxIconAlarmOff extends Components.RuxIconAlarmOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1104,6 +1192,7 @@ export class RuxIconAlarmOff {
 export declare interface RuxIconAlarmOn extends Components.RuxIconAlarmOn {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1124,6 +1213,7 @@ export class RuxIconAlarmOn {
 export declare interface RuxIconAlbum extends Components.RuxIconAlbum {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1144,6 +1234,7 @@ export class RuxIconAlbum {
 export declare interface RuxIconAllInbox extends Components.RuxIconAllInbox {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1164,6 +1255,7 @@ export class RuxIconAllInbox {
 export declare interface RuxIconAllInclusive extends Components.RuxIconAllInclusive {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1184,6 +1276,7 @@ export class RuxIconAllInclusive {
 export declare interface RuxIconAllOut extends Components.RuxIconAllOut {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1204,6 +1297,7 @@ export class RuxIconAllOut {
 export declare interface RuxIconAlternateEmail extends Components.RuxIconAlternateEmail {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1224,6 +1318,7 @@ export class RuxIconAlternateEmail {
 export declare interface RuxIconAltitude extends Components.RuxIconAltitude {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1244,6 +1339,7 @@ export class RuxIconAltitude {
 export declare interface RuxIconAndroid extends Components.RuxIconAndroid {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1264,6 +1360,7 @@ export class RuxIconAndroid {
 export declare interface RuxIconAnnouncement extends Components.RuxIconAnnouncement {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1284,6 +1381,7 @@ export class RuxIconAnnouncement {
 export declare interface RuxIconAntenna extends Components.RuxIconAntenna {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1304,6 +1402,7 @@ export class RuxIconAntenna {
 export declare interface RuxIconAntennaOff extends Components.RuxIconAntennaOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1324,6 +1423,7 @@ export class RuxIconAntennaOff {
 export declare interface RuxIconAntennaReceive extends Components.RuxIconAntennaReceive {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1344,6 +1444,7 @@ export class RuxIconAntennaReceive {
 export declare interface RuxIconAntennaTransmit extends Components.RuxIconAntennaTransmit {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1364,6 +1465,7 @@ export class RuxIconAntennaTransmit {
 export declare interface RuxIconApps extends Components.RuxIconApps {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1384,6 +1486,7 @@ export class RuxIconApps {
 export declare interface RuxIconArchive extends Components.RuxIconArchive {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1404,6 +1507,7 @@ export class RuxIconArchive {
 export declare interface RuxIconArrowBack extends Components.RuxIconArrowBack {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1424,6 +1528,7 @@ export class RuxIconArrowBack {
 export declare interface RuxIconArrowBackIos extends Components.RuxIconArrowBackIos {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1444,6 +1549,7 @@ export class RuxIconArrowBackIos {
 export declare interface RuxIconArrowDownward extends Components.RuxIconArrowDownward {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1464,6 +1570,7 @@ export class RuxIconArrowDownward {
 export declare interface RuxIconArrowDropDown extends Components.RuxIconArrowDropDown {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1484,6 +1591,7 @@ export class RuxIconArrowDropDown {
 export declare interface RuxIconArrowDropDownCircle extends Components.RuxIconArrowDropDownCircle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1504,6 +1612,7 @@ export class RuxIconArrowDropDownCircle {
 export declare interface RuxIconArrowDropUp extends Components.RuxIconArrowDropUp {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1524,6 +1633,7 @@ export class RuxIconArrowDropUp {
 export declare interface RuxIconArrowForward extends Components.RuxIconArrowForward {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1544,6 +1654,7 @@ export class RuxIconArrowForward {
 export declare interface RuxIconArrowForwardIos extends Components.RuxIconArrowForwardIos {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1564,6 +1675,7 @@ export class RuxIconArrowForwardIos {
 export declare interface RuxIconArrowLeft extends Components.RuxIconArrowLeft {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1584,6 +1696,7 @@ export class RuxIconArrowLeft {
 export declare interface RuxIconArrowRight extends Components.RuxIconArrowRight {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1604,6 +1717,7 @@ export class RuxIconArrowRight {
 export declare interface RuxIconArrowRightAlt extends Components.RuxIconArrowRightAlt {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1624,6 +1738,7 @@ export class RuxIconArrowRightAlt {
 export declare interface RuxIconArrowUpward extends Components.RuxIconArrowUpward {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1644,6 +1759,7 @@ export class RuxIconArrowUpward {
 export declare interface RuxIconArtTrack extends Components.RuxIconArtTrack {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1664,6 +1780,7 @@ export class RuxIconArtTrack {
 export declare interface RuxIconAspectRatio extends Components.RuxIconAspectRatio {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1684,6 +1801,7 @@ export class RuxIconAspectRatio {
 export declare interface RuxIconAssessment extends Components.RuxIconAssessment {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1704,6 +1822,7 @@ export class RuxIconAssessment {
 export declare interface RuxIconAssignment extends Components.RuxIconAssignment {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1724,6 +1843,7 @@ export class RuxIconAssignment {
 export declare interface RuxIconAssignmentFind extends Components.RuxIconAssignmentFind {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1744,6 +1864,7 @@ export class RuxIconAssignmentFind {
 export declare interface RuxIconAssignmentLate extends Components.RuxIconAssignmentLate {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1764,6 +1885,7 @@ export class RuxIconAssignmentLate {
 export declare interface RuxIconAssignmentReturn extends Components.RuxIconAssignmentReturn {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1784,6 +1906,7 @@ export class RuxIconAssignmentReturn {
 export declare interface RuxIconAssignmentReturned extends Components.RuxIconAssignmentReturned {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1804,6 +1927,7 @@ export class RuxIconAssignmentReturned {
 export declare interface RuxIconAssignmentTurnedIn extends Components.RuxIconAssignmentTurnedIn {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1824,6 +1948,7 @@ export class RuxIconAssignmentTurnedIn {
 export declare interface RuxIconAssistant extends Components.RuxIconAssistant {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1844,6 +1969,7 @@ export class RuxIconAssistant {
 export declare interface RuxIconAssistantPhoto extends Components.RuxIconAssistantPhoto {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1864,6 +1990,7 @@ export class RuxIconAssistantPhoto {
 export declare interface RuxIconAttachFile extends Components.RuxIconAttachFile {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1884,6 +2011,7 @@ export class RuxIconAttachFile {
 export declare interface RuxIconAttachMoney extends Components.RuxIconAttachMoney {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1904,6 +2032,7 @@ export class RuxIconAttachMoney {
 export declare interface RuxIconAttachment extends Components.RuxIconAttachment {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1924,6 +2053,7 @@ export class RuxIconAttachment {
 export declare interface RuxIconAudiotrack extends Components.RuxIconAudiotrack {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1944,6 +2074,7 @@ export class RuxIconAudiotrack {
 export declare interface RuxIconAutorenew extends Components.RuxIconAutorenew {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1964,6 +2095,7 @@ export class RuxIconAutorenew {
 export declare interface RuxIconAvTimer extends Components.RuxIconAvTimer {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -1984,6 +2116,7 @@ export class RuxIconAvTimer {
 export declare interface RuxIconBackspace extends Components.RuxIconBackspace {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2004,6 +2137,7 @@ export class RuxIconBackspace {
 export declare interface RuxIconBackup extends Components.RuxIconBackup {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2024,6 +2158,7 @@ export class RuxIconBackup {
 export declare interface RuxIconBallot extends Components.RuxIconBallot {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2044,6 +2179,7 @@ export class RuxIconBallot {
 export declare interface RuxIconBarChart extends Components.RuxIconBarChart {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2064,6 +2200,7 @@ export class RuxIconBarChart {
 export declare interface RuxIconBattery20 extends Components.RuxIconBattery20 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2084,6 +2221,7 @@ export class RuxIconBattery20 {
 export declare interface RuxIconBattery30 extends Components.RuxIconBattery30 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2104,6 +2242,7 @@ export class RuxIconBattery30 {
 export declare interface RuxIconBattery50 extends Components.RuxIconBattery50 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2124,6 +2263,7 @@ export class RuxIconBattery50 {
 export declare interface RuxIconBattery60 extends Components.RuxIconBattery60 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2144,6 +2284,7 @@ export class RuxIconBattery60 {
 export declare interface RuxIconBattery80 extends Components.RuxIconBattery80 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2164,6 +2305,7 @@ export class RuxIconBattery80 {
 export declare interface RuxIconBattery90 extends Components.RuxIconBattery90 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2184,6 +2326,7 @@ export class RuxIconBattery90 {
 export declare interface RuxIconBatteryAlert extends Components.RuxIconBatteryAlert {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2204,6 +2347,7 @@ export class RuxIconBatteryAlert {
 export declare interface RuxIconBatteryCharging20 extends Components.RuxIconBatteryCharging20 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2224,6 +2368,7 @@ export class RuxIconBatteryCharging20 {
 export declare interface RuxIconBatteryCharging30 extends Components.RuxIconBatteryCharging30 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2244,6 +2389,7 @@ export class RuxIconBatteryCharging30 {
 export declare interface RuxIconBatteryCharging50 extends Components.RuxIconBatteryCharging50 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2264,6 +2410,7 @@ export class RuxIconBatteryCharging50 {
 export declare interface RuxIconBatteryCharging60 extends Components.RuxIconBatteryCharging60 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2284,6 +2431,7 @@ export class RuxIconBatteryCharging60 {
 export declare interface RuxIconBatteryCharging80 extends Components.RuxIconBatteryCharging80 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2304,6 +2452,7 @@ export class RuxIconBatteryCharging80 {
 export declare interface RuxIconBatteryCharging90 extends Components.RuxIconBatteryCharging90 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2324,6 +2473,7 @@ export class RuxIconBatteryCharging90 {
 export declare interface RuxIconBatteryChargingFull extends Components.RuxIconBatteryChargingFull {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2344,6 +2494,7 @@ export class RuxIconBatteryChargingFull {
 export declare interface RuxIconBatteryFull extends Components.RuxIconBatteryFull {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2364,6 +2515,7 @@ export class RuxIconBatteryFull {
 export declare interface RuxIconBatteryStd extends Components.RuxIconBatteryStd {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2384,6 +2536,7 @@ export class RuxIconBatteryStd {
 export declare interface RuxIconBatteryUnknown extends Components.RuxIconBatteryUnknown {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2404,6 +2557,7 @@ export class RuxIconBatteryUnknown {
 export declare interface RuxIconBeachAccess extends Components.RuxIconBeachAccess {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2424,6 +2578,7 @@ export class RuxIconBeachAccess {
 export declare interface RuxIconBeenhere extends Components.RuxIconBeenhere {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2444,6 +2599,7 @@ export class RuxIconBeenhere {
 export declare interface RuxIconBlock extends Components.RuxIconBlock {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2464,6 +2620,7 @@ export class RuxIconBlock {
 export declare interface RuxIconBluetooth extends Components.RuxIconBluetooth {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2484,6 +2641,7 @@ export class RuxIconBluetooth {
 export declare interface RuxIconBluetoothAudio extends Components.RuxIconBluetoothAudio {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2504,6 +2662,7 @@ export class RuxIconBluetoothAudio {
 export declare interface RuxIconBluetoothConnected extends Components.RuxIconBluetoothConnected {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2524,6 +2683,7 @@ export class RuxIconBluetoothConnected {
 export declare interface RuxIconBluetoothDisabled extends Components.RuxIconBluetoothDisabled {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2544,6 +2704,7 @@ export class RuxIconBluetoothDisabled {
 export declare interface RuxIconBluetoothSearching extends Components.RuxIconBluetoothSearching {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2564,6 +2725,7 @@ export class RuxIconBluetoothSearching {
 export declare interface RuxIconBlurCircular extends Components.RuxIconBlurCircular {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2584,6 +2746,7 @@ export class RuxIconBlurCircular {
 export declare interface RuxIconBlurLinear extends Components.RuxIconBlurLinear {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2604,6 +2767,7 @@ export class RuxIconBlurLinear {
 export declare interface RuxIconBlurOff extends Components.RuxIconBlurOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2624,6 +2788,7 @@ export class RuxIconBlurOff {
 export declare interface RuxIconBlurOn extends Components.RuxIconBlurOn {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2644,6 +2809,7 @@ export class RuxIconBlurOn {
 export declare interface RuxIconBook extends Components.RuxIconBook {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2664,6 +2830,7 @@ export class RuxIconBook {
 export declare interface RuxIconBookmark extends Components.RuxIconBookmark {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2684,6 +2851,7 @@ export class RuxIconBookmark {
 export declare interface RuxIconBookmarkBorder extends Components.RuxIconBookmarkBorder {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2704,6 +2872,7 @@ export class RuxIconBookmarkBorder {
 export declare interface RuxIconBookmarks extends Components.RuxIconBookmarks {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2724,6 +2893,7 @@ export class RuxIconBookmarks {
 export declare interface RuxIconBorderAll extends Components.RuxIconBorderAll {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2744,6 +2914,7 @@ export class RuxIconBorderAll {
 export declare interface RuxIconBorderBottom extends Components.RuxIconBorderBottom {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2764,6 +2935,7 @@ export class RuxIconBorderBottom {
 export declare interface RuxIconBorderClear extends Components.RuxIconBorderClear {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2784,6 +2956,7 @@ export class RuxIconBorderClear {
 export declare interface RuxIconBorderColor extends Components.RuxIconBorderColor {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2804,6 +2977,7 @@ export class RuxIconBorderColor {
 export declare interface RuxIconBorderHorizontal extends Components.RuxIconBorderHorizontal {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2824,6 +2998,7 @@ export class RuxIconBorderHorizontal {
 export declare interface RuxIconBorderInner extends Components.RuxIconBorderInner {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2844,6 +3019,7 @@ export class RuxIconBorderInner {
 export declare interface RuxIconBorderLeft extends Components.RuxIconBorderLeft {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2864,6 +3040,7 @@ export class RuxIconBorderLeft {
 export declare interface RuxIconBorderOuter extends Components.RuxIconBorderOuter {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2884,6 +3061,7 @@ export class RuxIconBorderOuter {
 export declare interface RuxIconBorderRight extends Components.RuxIconBorderRight {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2904,6 +3082,7 @@ export class RuxIconBorderRight {
 export declare interface RuxIconBorderStyle extends Components.RuxIconBorderStyle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2924,6 +3103,7 @@ export class RuxIconBorderStyle {
 export declare interface RuxIconBorderTop extends Components.RuxIconBorderTop {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2944,6 +3124,7 @@ export class RuxIconBorderTop {
 export declare interface RuxIconBorderVertical extends Components.RuxIconBorderVertical {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2964,6 +3145,7 @@ export class RuxIconBorderVertical {
 export declare interface RuxIconBrandingWatermark extends Components.RuxIconBrandingWatermark {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -2984,6 +3166,7 @@ export class RuxIconBrandingWatermark {
 export declare interface RuxIconBrightness1 extends Components.RuxIconBrightness1 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3004,6 +3187,7 @@ export class RuxIconBrightness1 {
 export declare interface RuxIconBrightness2 extends Components.RuxIconBrightness2 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3024,6 +3208,7 @@ export class RuxIconBrightness2 {
 export declare interface RuxIconBrightness3 extends Components.RuxIconBrightness3 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3044,6 +3229,7 @@ export class RuxIconBrightness3 {
 export declare interface RuxIconBrightness4 extends Components.RuxIconBrightness4 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3064,6 +3250,7 @@ export class RuxIconBrightness4 {
 export declare interface RuxIconBrightness5 extends Components.RuxIconBrightness5 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3084,6 +3271,7 @@ export class RuxIconBrightness5 {
 export declare interface RuxIconBrightness6 extends Components.RuxIconBrightness6 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3104,6 +3292,7 @@ export class RuxIconBrightness6 {
 export declare interface RuxIconBrightness7 extends Components.RuxIconBrightness7 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3124,6 +3313,7 @@ export class RuxIconBrightness7 {
 export declare interface RuxIconBrightnessAuto extends Components.RuxIconBrightnessAuto {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3144,6 +3334,7 @@ export class RuxIconBrightnessAuto {
 export declare interface RuxIconBrightnessHigh extends Components.RuxIconBrightnessHigh {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3164,6 +3355,7 @@ export class RuxIconBrightnessHigh {
 export declare interface RuxIconBrightnessLow extends Components.RuxIconBrightnessLow {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3184,6 +3376,7 @@ export class RuxIconBrightnessLow {
 export declare interface RuxIconBrightnessMedium extends Components.RuxIconBrightnessMedium {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3204,6 +3397,7 @@ export class RuxIconBrightnessMedium {
 export declare interface RuxIconBrokenImage extends Components.RuxIconBrokenImage {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3224,6 +3418,7 @@ export class RuxIconBrokenImage {
 export declare interface RuxIconBrush extends Components.RuxIconBrush {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3244,6 +3439,7 @@ export class RuxIconBrush {
 export declare interface RuxIconBubbleChart extends Components.RuxIconBubbleChart {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3264,6 +3460,7 @@ export class RuxIconBubbleChart {
 export declare interface RuxIconBugReport extends Components.RuxIconBugReport {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3284,6 +3481,7 @@ export class RuxIconBugReport {
 export declare interface RuxIconBuild extends Components.RuxIconBuild {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3304,6 +3502,7 @@ export class RuxIconBuild {
 export declare interface RuxIconBurstMode extends Components.RuxIconBurstMode {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3324,6 +3523,7 @@ export class RuxIconBurstMode {
 export declare interface RuxIconBusiness extends Components.RuxIconBusiness {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3344,6 +3544,7 @@ export class RuxIconBusiness {
 export declare interface RuxIconBusinessCenter extends Components.RuxIconBusinessCenter {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3364,6 +3565,7 @@ export class RuxIconBusinessCenter {
 export declare interface RuxIconCached extends Components.RuxIconCached {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3384,6 +3586,7 @@ export class RuxIconCached {
 export declare interface RuxIconCake extends Components.RuxIconCake {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3404,6 +3607,7 @@ export class RuxIconCake {
 export declare interface RuxIconCalendarToday extends Components.RuxIconCalendarToday {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3424,6 +3628,7 @@ export class RuxIconCalendarToday {
 export declare interface RuxIconCalendarViewDay extends Components.RuxIconCalendarViewDay {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3444,6 +3649,7 @@ export class RuxIconCalendarViewDay {
 export declare interface RuxIconCall extends Components.RuxIconCall {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3464,6 +3670,7 @@ export class RuxIconCall {
 export declare interface RuxIconCallEnd extends Components.RuxIconCallEnd {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3484,6 +3691,7 @@ export class RuxIconCallEnd {
 export declare interface RuxIconCallMade extends Components.RuxIconCallMade {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3504,6 +3712,7 @@ export class RuxIconCallMade {
 export declare interface RuxIconCallMerge extends Components.RuxIconCallMerge {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3524,6 +3733,7 @@ export class RuxIconCallMerge {
 export declare interface RuxIconCallMissed extends Components.RuxIconCallMissed {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3544,6 +3754,7 @@ export class RuxIconCallMissed {
 export declare interface RuxIconCallMissedOutgoing extends Components.RuxIconCallMissedOutgoing {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3564,6 +3775,7 @@ export class RuxIconCallMissedOutgoing {
 export declare interface RuxIconCallReceived extends Components.RuxIconCallReceived {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3584,6 +3796,7 @@ export class RuxIconCallReceived {
 export declare interface RuxIconCallSplit extends Components.RuxIconCallSplit {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3604,6 +3817,7 @@ export class RuxIconCallSplit {
 export declare interface RuxIconCallToAction extends Components.RuxIconCallToAction {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3624,6 +3838,7 @@ export class RuxIconCallToAction {
 export declare interface RuxIconCamera extends Components.RuxIconCamera {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3644,6 +3859,7 @@ export class RuxIconCamera {
 export declare interface RuxIconCameraAlt extends Components.RuxIconCameraAlt {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3664,6 +3880,7 @@ export class RuxIconCameraAlt {
 export declare interface RuxIconCameraEnhance extends Components.RuxIconCameraEnhance {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3684,6 +3901,7 @@ export class RuxIconCameraEnhance {
 export declare interface RuxIconCameraFront extends Components.RuxIconCameraFront {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3704,6 +3922,7 @@ export class RuxIconCameraFront {
 export declare interface RuxIconCameraRear extends Components.RuxIconCameraRear {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3724,6 +3943,7 @@ export class RuxIconCameraRear {
 export declare interface RuxIconCameraRoll extends Components.RuxIconCameraRoll {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3744,6 +3964,7 @@ export class RuxIconCameraRoll {
 export declare interface RuxIconCancel extends Components.RuxIconCancel {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3764,6 +3985,7 @@ export class RuxIconCancel {
 export declare interface RuxIconCancelPresentation extends Components.RuxIconCancelPresentation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3784,6 +4006,7 @@ export class RuxIconCancelPresentation {
 export declare interface RuxIconCardGiftcard extends Components.RuxIconCardGiftcard {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3804,6 +4027,7 @@ export class RuxIconCardGiftcard {
 export declare interface RuxIconCardMembership extends Components.RuxIconCardMembership {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3824,6 +4048,7 @@ export class RuxIconCardMembership {
 export declare interface RuxIconCardTravel extends Components.RuxIconCardTravel {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3844,6 +4069,7 @@ export class RuxIconCardTravel {
 export declare interface RuxIconCasino extends Components.RuxIconCasino {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3864,6 +4090,7 @@ export class RuxIconCasino {
 export declare interface RuxIconCast extends Components.RuxIconCast {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3884,6 +4111,7 @@ export class RuxIconCast {
 export declare interface RuxIconCastConnected extends Components.RuxIconCastConnected {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3904,6 +4132,7 @@ export class RuxIconCastConnected {
 export declare interface RuxIconCastForEducation extends Components.RuxIconCastForEducation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3924,6 +4153,7 @@ export class RuxIconCastForEducation {
 export declare interface RuxIconCategory extends Components.RuxIconCategory {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3944,6 +4174,7 @@ export class RuxIconCategory {
 export declare interface RuxIconCellWifi extends Components.RuxIconCellWifi {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3964,6 +4195,7 @@ export class RuxIconCellWifi {
 export declare interface RuxIconCenterFocusStrong extends Components.RuxIconCenterFocusStrong {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -3984,6 +4216,7 @@ export class RuxIconCenterFocusStrong {
 export declare interface RuxIconCenterFocusWeak extends Components.RuxIconCenterFocusWeak {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4004,6 +4237,7 @@ export class RuxIconCenterFocusWeak {
 export declare interface RuxIconChangeHistory extends Components.RuxIconChangeHistory {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4024,6 +4258,7 @@ export class RuxIconChangeHistory {
 export declare interface RuxIconChat extends Components.RuxIconChat {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4044,6 +4279,7 @@ export class RuxIconChat {
 export declare interface RuxIconChatBubble extends Components.RuxIconChatBubble {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4064,6 +4300,7 @@ export class RuxIconChatBubble {
 export declare interface RuxIconChatBubbleOutline extends Components.RuxIconChatBubbleOutline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4084,6 +4321,7 @@ export class RuxIconChatBubbleOutline {
 export declare interface RuxIconCheck extends Components.RuxIconCheck {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4104,6 +4342,7 @@ export class RuxIconCheck {
 export declare interface RuxIconCheckBox extends Components.RuxIconCheckBox {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4124,6 +4363,7 @@ export class RuxIconCheckBox {
 export declare interface RuxIconCheckBoxOutlineBlank extends Components.RuxIconCheckBoxOutlineBlank {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4144,6 +4384,7 @@ export class RuxIconCheckBoxOutlineBlank {
 export declare interface RuxIconCheckCircle extends Components.RuxIconCheckCircle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4164,6 +4405,7 @@ export class RuxIconCheckCircle {
 export declare interface RuxIconCheckCircleOutline extends Components.RuxIconCheckCircleOutline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4184,6 +4426,7 @@ export class RuxIconCheckCircleOutline {
 export declare interface RuxIconChevronLeft extends Components.RuxIconChevronLeft {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4204,6 +4447,7 @@ export class RuxIconChevronLeft {
 export declare interface RuxIconChevronRight extends Components.RuxIconChevronRight {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4224,6 +4468,7 @@ export class RuxIconChevronRight {
 export declare interface RuxIconChildCare extends Components.RuxIconChildCare {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4244,6 +4489,7 @@ export class RuxIconChildCare {
 export declare interface RuxIconChildFriendly extends Components.RuxIconChildFriendly {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4264,6 +4510,7 @@ export class RuxIconChildFriendly {
 export declare interface RuxIconChromeReaderMode extends Components.RuxIconChromeReaderMode {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4284,6 +4531,7 @@ export class RuxIconChromeReaderMode {
 export declare interface RuxIconClass extends Components.RuxIconClass {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4304,6 +4552,7 @@ export class RuxIconClass {
 export declare interface RuxIconClear extends Components.RuxIconClear {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4324,6 +4573,7 @@ export class RuxIconClear {
 export declare interface RuxIconClearAll extends Components.RuxIconClearAll {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4344,6 +4594,7 @@ export class RuxIconClearAll {
 export declare interface RuxIconClose extends Components.RuxIconClose {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4364,6 +4615,7 @@ export class RuxIconClose {
 export declare interface RuxIconClosedCaption extends Components.RuxIconClosedCaption {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4384,6 +4636,7 @@ export class RuxIconClosedCaption {
 export declare interface RuxIconCloud extends Components.RuxIconCloud {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4404,6 +4657,7 @@ export class RuxIconCloud {
 export declare interface RuxIconCloudCircle extends Components.RuxIconCloudCircle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4424,6 +4678,7 @@ export class RuxIconCloudCircle {
 export declare interface RuxIconCloudDone extends Components.RuxIconCloudDone {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4444,6 +4699,7 @@ export class RuxIconCloudDone {
 export declare interface RuxIconCloudDownload extends Components.RuxIconCloudDownload {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4464,6 +4720,7 @@ export class RuxIconCloudDownload {
 export declare interface RuxIconCloudOff extends Components.RuxIconCloudOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4484,6 +4741,7 @@ export class RuxIconCloudOff {
 export declare interface RuxIconCloudQueue extends Components.RuxIconCloudQueue {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4504,6 +4762,7 @@ export class RuxIconCloudQueue {
 export declare interface RuxIconCloudUpload extends Components.RuxIconCloudUpload {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4524,6 +4783,7 @@ export class RuxIconCloudUpload {
 export declare interface RuxIconCode extends Components.RuxIconCode {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4544,6 +4804,7 @@ export class RuxIconCode {
 export declare interface RuxIconCollections extends Components.RuxIconCollections {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4564,6 +4825,7 @@ export class RuxIconCollections {
 export declare interface RuxIconCollectionsBookmark extends Components.RuxIconCollectionsBookmark {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4584,6 +4846,7 @@ export class RuxIconCollectionsBookmark {
 export declare interface RuxIconColorLens extends Components.RuxIconColorLens {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4604,6 +4867,7 @@ export class RuxIconColorLens {
 export declare interface RuxIconColorize extends Components.RuxIconColorize {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4624,6 +4888,7 @@ export class RuxIconColorize {
 export declare interface RuxIconComment extends Components.RuxIconComment {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4644,6 +4909,7 @@ export class RuxIconComment {
 export declare interface RuxIconCommute extends Components.RuxIconCommute {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4664,6 +4930,7 @@ export class RuxIconCommute {
 export declare interface RuxIconCompare extends Components.RuxIconCompare {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4684,6 +4951,7 @@ export class RuxIconCompare {
 export declare interface RuxIconCompareArrows extends Components.RuxIconCompareArrows {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4704,6 +4972,7 @@ export class RuxIconCompareArrows {
 export declare interface RuxIconCompassCalibration extends Components.RuxIconCompassCalibration {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4724,6 +4993,7 @@ export class RuxIconCompassCalibration {
 export declare interface RuxIconComputer extends Components.RuxIconComputer {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4744,6 +5014,7 @@ export class RuxIconComputer {
 export declare interface RuxIconConfirmationNumber extends Components.RuxIconConfirmationNumber {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4764,6 +5035,7 @@ export class RuxIconConfirmationNumber {
 export declare interface RuxIconContactMail extends Components.RuxIconContactMail {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4784,6 +5056,7 @@ export class RuxIconContactMail {
 export declare interface RuxIconContactPhone extends Components.RuxIconContactPhone {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4804,6 +5077,7 @@ export class RuxIconContactPhone {
 export declare interface RuxIconContactSupport extends Components.RuxIconContactSupport {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4824,6 +5098,7 @@ export class RuxIconContactSupport {
 export declare interface RuxIconContacts extends Components.RuxIconContacts {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4844,6 +5119,7 @@ export class RuxIconContacts {
 export declare interface RuxIconControlCamera extends Components.RuxIconControlCamera {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4864,6 +5140,7 @@ export class RuxIconControlCamera {
 export declare interface RuxIconControlPoint extends Components.RuxIconControlPoint {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4884,6 +5161,7 @@ export class RuxIconControlPoint {
 export declare interface RuxIconControlPointDuplicate extends Components.RuxIconControlPointDuplicate {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4904,6 +5182,7 @@ export class RuxIconControlPointDuplicate {
 export declare interface RuxIconCopyright extends Components.RuxIconCopyright {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4924,6 +5203,7 @@ export class RuxIconCopyright {
 export declare interface RuxIconCreate extends Components.RuxIconCreate {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4944,6 +5224,7 @@ export class RuxIconCreate {
 export declare interface RuxIconCreateNewFolder extends Components.RuxIconCreateNewFolder {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4964,6 +5245,7 @@ export class RuxIconCreateNewFolder {
 export declare interface RuxIconCreditCard extends Components.RuxIconCreditCard {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -4984,6 +5266,7 @@ export class RuxIconCreditCard {
 export declare interface RuxIconCrop extends Components.RuxIconCrop {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5004,6 +5287,7 @@ export class RuxIconCrop {
 export declare interface RuxIconCrop169 extends Components.RuxIconCrop169 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5024,6 +5308,7 @@ export class RuxIconCrop169 {
 export declare interface RuxIconCrop32 extends Components.RuxIconCrop32 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5044,6 +5329,7 @@ export class RuxIconCrop32 {
 export declare interface RuxIconCrop54 extends Components.RuxIconCrop54 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5064,6 +5350,7 @@ export class RuxIconCrop54 {
 export declare interface RuxIconCrop75 extends Components.RuxIconCrop75 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5084,6 +5371,7 @@ export class RuxIconCrop75 {
 export declare interface RuxIconCropDin extends Components.RuxIconCropDin {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5104,6 +5392,7 @@ export class RuxIconCropDin {
 export declare interface RuxIconCropFree extends Components.RuxIconCropFree {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5124,6 +5413,7 @@ export class RuxIconCropFree {
 export declare interface RuxIconCropLandscape extends Components.RuxIconCropLandscape {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5144,6 +5434,7 @@ export class RuxIconCropLandscape {
 export declare interface RuxIconCropOriginal extends Components.RuxIconCropOriginal {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5164,6 +5455,7 @@ export class RuxIconCropOriginal {
 export declare interface RuxIconCropPortrait extends Components.RuxIconCropPortrait {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5184,6 +5476,7 @@ export class RuxIconCropPortrait {
 export declare interface RuxIconCropRotate extends Components.RuxIconCropRotate {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5204,6 +5497,7 @@ export class RuxIconCropRotate {
 export declare interface RuxIconCropSquare extends Components.RuxIconCropSquare {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5224,6 +5518,7 @@ export class RuxIconCropSquare {
 export declare interface RuxIconDashboard extends Components.RuxIconDashboard {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5244,6 +5539,7 @@ export class RuxIconDashboard {
 export declare interface RuxIconDataUsage extends Components.RuxIconDataUsage {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5264,6 +5560,7 @@ export class RuxIconDataUsage {
 export declare interface RuxIconDateRange extends Components.RuxIconDateRange {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5284,6 +5581,7 @@ export class RuxIconDateRange {
 export declare interface RuxIconDehaze extends Components.RuxIconDehaze {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5304,6 +5602,7 @@ export class RuxIconDehaze {
 export declare interface RuxIconDelete extends Components.RuxIconDelete {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5324,6 +5623,7 @@ export class RuxIconDelete {
 export declare interface RuxIconDeleteForever extends Components.RuxIconDeleteForever {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5344,6 +5644,7 @@ export class RuxIconDeleteForever {
 export declare interface RuxIconDeleteOutline extends Components.RuxIconDeleteOutline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5364,6 +5665,7 @@ export class RuxIconDeleteOutline {
 export declare interface RuxIconDeleteSweep extends Components.RuxIconDeleteSweep {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5384,6 +5686,7 @@ export class RuxIconDeleteSweep {
 export declare interface RuxIconDepartureBoard extends Components.RuxIconDepartureBoard {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5404,6 +5707,7 @@ export class RuxIconDepartureBoard {
 export declare interface RuxIconDescription extends Components.RuxIconDescription {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5424,6 +5728,7 @@ export class RuxIconDescription {
 export declare interface RuxIconDesktopAccessDisabled extends Components.RuxIconDesktopAccessDisabled {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5444,6 +5749,7 @@ export class RuxIconDesktopAccessDisabled {
 export declare interface RuxIconDesktopMac extends Components.RuxIconDesktopMac {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5464,6 +5770,7 @@ export class RuxIconDesktopMac {
 export declare interface RuxIconDesktopWindows extends Components.RuxIconDesktopWindows {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5484,6 +5791,7 @@ export class RuxIconDesktopWindows {
 export declare interface RuxIconDetails extends Components.RuxIconDetails {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5504,6 +5812,7 @@ export class RuxIconDetails {
 export declare interface RuxIconDeveloperBoard extends Components.RuxIconDeveloperBoard {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5524,6 +5833,7 @@ export class RuxIconDeveloperBoard {
 export declare interface RuxIconDeveloperMode extends Components.RuxIconDeveloperMode {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5544,6 +5854,7 @@ export class RuxIconDeveloperMode {
 export declare interface RuxIconDeviceHub extends Components.RuxIconDeviceHub {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5564,6 +5875,7 @@ export class RuxIconDeviceHub {
 export declare interface RuxIconDeviceUnknown extends Components.RuxIconDeviceUnknown {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5584,6 +5896,7 @@ export class RuxIconDeviceUnknown {
 export declare interface RuxIconDevices extends Components.RuxIconDevices {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5604,6 +5917,7 @@ export class RuxIconDevices {
 export declare interface RuxIconDevicesOther extends Components.RuxIconDevicesOther {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5624,6 +5938,7 @@ export class RuxIconDevicesOther {
 export declare interface RuxIconDialerSip extends Components.RuxIconDialerSip {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5644,6 +5959,7 @@ export class RuxIconDialerSip {
 export declare interface RuxIconDialpad extends Components.RuxIconDialpad {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5664,6 +5980,7 @@ export class RuxIconDialpad {
 export declare interface RuxIconDirections extends Components.RuxIconDirections {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5684,6 +6001,7 @@ export class RuxIconDirections {
 export declare interface RuxIconDirectionsBike extends Components.RuxIconDirectionsBike {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5704,6 +6022,7 @@ export class RuxIconDirectionsBike {
 export declare interface RuxIconDirectionsBoat extends Components.RuxIconDirectionsBoat {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5724,6 +6043,7 @@ export class RuxIconDirectionsBoat {
 export declare interface RuxIconDirectionsBus extends Components.RuxIconDirectionsBus {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5744,6 +6064,7 @@ export class RuxIconDirectionsBus {
 export declare interface RuxIconDirectionsCar extends Components.RuxIconDirectionsCar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5764,6 +6085,7 @@ export class RuxIconDirectionsCar {
 export declare interface RuxIconDirectionsRailway extends Components.RuxIconDirectionsRailway {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5784,6 +6106,7 @@ export class RuxIconDirectionsRailway {
 export declare interface RuxIconDirectionsRun extends Components.RuxIconDirectionsRun {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5804,6 +6127,7 @@ export class RuxIconDirectionsRun {
 export declare interface RuxIconDirectionsSubway extends Components.RuxIconDirectionsSubway {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5824,6 +6148,7 @@ export class RuxIconDirectionsSubway {
 export declare interface RuxIconDirectionsTransit extends Components.RuxIconDirectionsTransit {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5844,6 +6169,7 @@ export class RuxIconDirectionsTransit {
 export declare interface RuxIconDirectionsWalk extends Components.RuxIconDirectionsWalk {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5864,6 +6190,7 @@ export class RuxIconDirectionsWalk {
 export declare interface RuxIconDiscFull extends Components.RuxIconDiscFull {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5884,6 +6211,7 @@ export class RuxIconDiscFull {
 export declare interface RuxIconDns extends Components.RuxIconDns {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5904,6 +6232,7 @@ export class RuxIconDns {
 export declare interface RuxIconDock extends Components.RuxIconDock {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5924,6 +6253,7 @@ export class RuxIconDock {
 export declare interface RuxIconDomain extends Components.RuxIconDomain {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5944,6 +6274,7 @@ export class RuxIconDomain {
 export declare interface RuxIconDomainDisabled extends Components.RuxIconDomainDisabled {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5964,6 +6295,7 @@ export class RuxIconDomainDisabled {
 export declare interface RuxIconDone extends Components.RuxIconDone {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -5984,6 +6316,7 @@ export class RuxIconDone {
 export declare interface RuxIconDoneAll extends Components.RuxIconDoneAll {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6004,6 +6337,7 @@ export class RuxIconDoneAll {
 export declare interface RuxIconDoneOutline extends Components.RuxIconDoneOutline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6024,6 +6358,7 @@ export class RuxIconDoneOutline {
 export declare interface RuxIconDonutLarge extends Components.RuxIconDonutLarge {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6044,6 +6379,7 @@ export class RuxIconDonutLarge {
 export declare interface RuxIconDonutSmall extends Components.RuxIconDonutSmall {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6064,6 +6400,7 @@ export class RuxIconDonutSmall {
 export declare interface RuxIconDrafts extends Components.RuxIconDrafts {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6084,6 +6421,7 @@ export class RuxIconDrafts {
 export declare interface RuxIconDragHandle extends Components.RuxIconDragHandle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6104,6 +6442,7 @@ export class RuxIconDragHandle {
 export declare interface RuxIconDragIndicator extends Components.RuxIconDragIndicator {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6124,6 +6463,7 @@ export class RuxIconDragIndicator {
 export declare interface RuxIconDriveEta extends Components.RuxIconDriveEta {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6144,6 +6484,7 @@ export class RuxIconDriveEta {
 export declare interface RuxIconDuo extends Components.RuxIconDuo {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6164,6 +6505,7 @@ export class RuxIconDuo {
 export declare interface RuxIconDvr extends Components.RuxIconDvr {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6184,6 +6526,7 @@ export class RuxIconDvr {
 export declare interface RuxIconEdit extends Components.RuxIconEdit {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6204,6 +6547,7 @@ export class RuxIconEdit {
 export declare interface RuxIconEditAttributes extends Components.RuxIconEditAttributes {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6224,6 +6568,7 @@ export class RuxIconEditAttributes {
 export declare interface RuxIconEditLocation extends Components.RuxIconEditLocation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6244,6 +6589,7 @@ export class RuxIconEditLocation {
 export declare interface RuxIconEject extends Components.RuxIconEject {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6264,6 +6610,7 @@ export class RuxIconEject {
 export declare interface RuxIconEmail extends Components.RuxIconEmail {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6284,6 +6631,7 @@ export class RuxIconEmail {
 export declare interface RuxIconEnhancedEncryption extends Components.RuxIconEnhancedEncryption {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6304,6 +6652,7 @@ export class RuxIconEnhancedEncryption {
 export declare interface RuxIconEqualizer extends Components.RuxIconEqualizer {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6324,6 +6673,7 @@ export class RuxIconEqualizer {
 export declare interface RuxIconEquipment extends Components.RuxIconEquipment {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6344,6 +6694,7 @@ export class RuxIconEquipment {
 export declare interface RuxIconError extends Components.RuxIconError {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6364,6 +6715,7 @@ export class RuxIconError {
 export declare interface RuxIconErrorOutline extends Components.RuxIconErrorOutline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6384,6 +6736,7 @@ export class RuxIconErrorOutline {
 export declare interface RuxIconEuroSymbol extends Components.RuxIconEuroSymbol {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6404,6 +6757,7 @@ export class RuxIconEuroSymbol {
 export declare interface RuxIconEvStation extends Components.RuxIconEvStation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6424,6 +6778,7 @@ export class RuxIconEvStation {
 export declare interface RuxIconEvent extends Components.RuxIconEvent {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6444,6 +6799,7 @@ export class RuxIconEvent {
 export declare interface RuxIconEventAvailable extends Components.RuxIconEventAvailable {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6464,6 +6820,7 @@ export class RuxIconEventAvailable {
 export declare interface RuxIconEventBusy extends Components.RuxIconEventBusy {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6484,6 +6841,7 @@ export class RuxIconEventBusy {
 export declare interface RuxIconEventNote extends Components.RuxIconEventNote {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6504,6 +6862,7 @@ export class RuxIconEventNote {
 export declare interface RuxIconExitToApp extends Components.RuxIconExitToApp {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6524,6 +6883,7 @@ export class RuxIconExitToApp {
 export declare interface RuxIconExpandLess extends Components.RuxIconExpandLess {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6544,6 +6904,7 @@ export class RuxIconExpandLess {
 export declare interface RuxIconExpandMore extends Components.RuxIconExpandMore {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6564,6 +6925,7 @@ export class RuxIconExpandMore {
 export declare interface RuxIconExplicit extends Components.RuxIconExplicit {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6584,6 +6946,7 @@ export class RuxIconExplicit {
 export declare interface RuxIconExplore extends Components.RuxIconExplore {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6604,6 +6967,7 @@ export class RuxIconExplore {
 export declare interface RuxIconExploreOff extends Components.RuxIconExploreOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6624,6 +6988,7 @@ export class RuxIconExploreOff {
 export declare interface RuxIconExposure extends Components.RuxIconExposure {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6644,6 +7009,7 @@ export class RuxIconExposure {
 export declare interface RuxIconExposureNeg1 extends Components.RuxIconExposureNeg1 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6664,6 +7030,7 @@ export class RuxIconExposureNeg1 {
 export declare interface RuxIconExposureNeg2 extends Components.RuxIconExposureNeg2 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6684,6 +7051,7 @@ export class RuxIconExposureNeg2 {
 export declare interface RuxIconExposurePlus1 extends Components.RuxIconExposurePlus1 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6704,6 +7072,7 @@ export class RuxIconExposurePlus1 {
 export declare interface RuxIconExposurePlus2 extends Components.RuxIconExposurePlus2 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6724,6 +7093,7 @@ export class RuxIconExposurePlus2 {
 export declare interface RuxIconExposureZero extends Components.RuxIconExposureZero {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6744,6 +7114,7 @@ export class RuxIconExposureZero {
 export declare interface RuxIconExtension extends Components.RuxIconExtension {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6764,6 +7135,7 @@ export class RuxIconExtension {
 export declare interface RuxIconFace extends Components.RuxIconFace {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6784,6 +7156,7 @@ export class RuxIconFace {
 export declare interface RuxIconFastForward extends Components.RuxIconFastForward {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6804,6 +7177,7 @@ export class RuxIconFastForward {
 export declare interface RuxIconFastRewind extends Components.RuxIconFastRewind {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6824,6 +7198,7 @@ export class RuxIconFastRewind {
 export declare interface RuxIconFastfood extends Components.RuxIconFastfood {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6844,6 +7219,7 @@ export class RuxIconFastfood {
 export declare interface RuxIconFavorite extends Components.RuxIconFavorite {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6864,6 +7240,7 @@ export class RuxIconFavorite {
 export declare interface RuxIconFavoriteBorder extends Components.RuxIconFavoriteBorder {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6884,6 +7261,7 @@ export class RuxIconFavoriteBorder {
 export declare interface RuxIconFeaturedPlayList extends Components.RuxIconFeaturedPlayList {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6904,6 +7282,7 @@ export class RuxIconFeaturedPlayList {
 export declare interface RuxIconFeaturedVideo extends Components.RuxIconFeaturedVideo {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6924,6 +7303,7 @@ export class RuxIconFeaturedVideo {
 export declare interface RuxIconFeedback extends Components.RuxIconFeedback {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6944,6 +7324,7 @@ export class RuxIconFeedback {
 export declare interface RuxIconFiberDvr extends Components.RuxIconFiberDvr {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6964,6 +7345,7 @@ export class RuxIconFiberDvr {
 export declare interface RuxIconFiberManualRecord extends Components.RuxIconFiberManualRecord {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -6984,6 +7366,7 @@ export class RuxIconFiberManualRecord {
 export declare interface RuxIconFiberNew extends Components.RuxIconFiberNew {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7004,6 +7387,7 @@ export class RuxIconFiberNew {
 export declare interface RuxIconFiberPin extends Components.RuxIconFiberPin {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7024,6 +7408,7 @@ export class RuxIconFiberPin {
 export declare interface RuxIconFiberSmartRecord extends Components.RuxIconFiberSmartRecord {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7044,6 +7429,7 @@ export class RuxIconFiberSmartRecord {
 export declare interface RuxIconFileCopy extends Components.RuxIconFileCopy {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7064,6 +7450,7 @@ export class RuxIconFileCopy {
 export declare interface RuxIconFilter extends Components.RuxIconFilter {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7084,6 +7471,7 @@ export class RuxIconFilter {
 export declare interface RuxIconFilter1 extends Components.RuxIconFilter1 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7104,6 +7492,7 @@ export class RuxIconFilter1 {
 export declare interface RuxIconFilter2 extends Components.RuxIconFilter2 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7124,6 +7513,7 @@ export class RuxIconFilter2 {
 export declare interface RuxIconFilter3 extends Components.RuxIconFilter3 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7144,6 +7534,7 @@ export class RuxIconFilter3 {
 export declare interface RuxIconFilter4 extends Components.RuxIconFilter4 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7164,6 +7555,7 @@ export class RuxIconFilter4 {
 export declare interface RuxIconFilter5 extends Components.RuxIconFilter5 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7184,6 +7576,7 @@ export class RuxIconFilter5 {
 export declare interface RuxIconFilter6 extends Components.RuxIconFilter6 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7204,6 +7597,7 @@ export class RuxIconFilter6 {
 export declare interface RuxIconFilter7 extends Components.RuxIconFilter7 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7224,6 +7618,7 @@ export class RuxIconFilter7 {
 export declare interface RuxIconFilter8 extends Components.RuxIconFilter8 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7244,6 +7639,7 @@ export class RuxIconFilter8 {
 export declare interface RuxIconFilter9 extends Components.RuxIconFilter9 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7264,6 +7660,7 @@ export class RuxIconFilter9 {
 export declare interface RuxIconFilter9Plus extends Components.RuxIconFilter9Plus {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7284,6 +7681,7 @@ export class RuxIconFilter9Plus {
 export declare interface RuxIconFilterBAndW extends Components.RuxIconFilterBAndW {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7304,6 +7702,7 @@ export class RuxIconFilterBAndW {
 export declare interface RuxIconFilterCenterFocus extends Components.RuxIconFilterCenterFocus {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7324,6 +7723,7 @@ export class RuxIconFilterCenterFocus {
 export declare interface RuxIconFilterDrama extends Components.RuxIconFilterDrama {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7344,6 +7744,7 @@ export class RuxIconFilterDrama {
 export declare interface RuxIconFilterFrames extends Components.RuxIconFilterFrames {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7364,6 +7765,7 @@ export class RuxIconFilterFrames {
 export declare interface RuxIconFilterHdr extends Components.RuxIconFilterHdr {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7384,6 +7786,7 @@ export class RuxIconFilterHdr {
 export declare interface RuxIconFilterList extends Components.RuxIconFilterList {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7404,6 +7807,7 @@ export class RuxIconFilterList {
 export declare interface RuxIconFilterNone extends Components.RuxIconFilterNone {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7424,6 +7828,7 @@ export class RuxIconFilterNone {
 export declare interface RuxIconFilterTiltShift extends Components.RuxIconFilterTiltShift {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7444,6 +7849,7 @@ export class RuxIconFilterTiltShift {
 export declare interface RuxIconFilterVintage extends Components.RuxIconFilterVintage {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7464,6 +7870,7 @@ export class RuxIconFilterVintage {
 export declare interface RuxIconFindInPage extends Components.RuxIconFindInPage {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7484,6 +7891,7 @@ export class RuxIconFindInPage {
 export declare interface RuxIconFindReplace extends Components.RuxIconFindReplace {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7504,6 +7912,7 @@ export class RuxIconFindReplace {
 export declare interface RuxIconFingerprint extends Components.RuxIconFingerprint {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7524,6 +7933,7 @@ export class RuxIconFingerprint {
 export declare interface RuxIconFirstPage extends Components.RuxIconFirstPage {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7544,6 +7954,7 @@ export class RuxIconFirstPage {
 export declare interface RuxIconFitnessCenter extends Components.RuxIconFitnessCenter {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7564,6 +7975,7 @@ export class RuxIconFitnessCenter {
 export declare interface RuxIconFlag extends Components.RuxIconFlag {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7584,6 +7996,7 @@ export class RuxIconFlag {
 export declare interface RuxIconFlare extends Components.RuxIconFlare {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7604,6 +8017,7 @@ export class RuxIconFlare {
 export declare interface RuxIconFlashAuto extends Components.RuxIconFlashAuto {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7624,6 +8038,7 @@ export class RuxIconFlashAuto {
 export declare interface RuxIconFlashOff extends Components.RuxIconFlashOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7644,6 +8059,7 @@ export class RuxIconFlashOff {
 export declare interface RuxIconFlashOn extends Components.RuxIconFlashOn {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7664,6 +8080,7 @@ export class RuxIconFlashOn {
 export declare interface RuxIconFlight extends Components.RuxIconFlight {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7684,6 +8101,7 @@ export class RuxIconFlight {
 export declare interface RuxIconFlightLand extends Components.RuxIconFlightLand {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7704,6 +8122,7 @@ export class RuxIconFlightLand {
 export declare interface RuxIconFlightTakeoff extends Components.RuxIconFlightTakeoff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7724,6 +8143,7 @@ export class RuxIconFlightTakeoff {
 export declare interface RuxIconFlip extends Components.RuxIconFlip {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7744,6 +8164,7 @@ export class RuxIconFlip {
 export declare interface RuxIconFlipToBack extends Components.RuxIconFlipToBack {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7764,6 +8185,7 @@ export class RuxIconFlipToBack {
 export declare interface RuxIconFlipToFront extends Components.RuxIconFlipToFront {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7784,6 +8206,7 @@ export class RuxIconFlipToFront {
 export declare interface RuxIconFolder extends Components.RuxIconFolder {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7804,6 +8227,7 @@ export class RuxIconFolder {
 export declare interface RuxIconFolderOpen extends Components.RuxIconFolderOpen {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7824,6 +8248,7 @@ export class RuxIconFolderOpen {
 export declare interface RuxIconFolderShared extends Components.RuxIconFolderShared {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7844,6 +8269,7 @@ export class RuxIconFolderShared {
 export declare interface RuxIconFolderSpecial extends Components.RuxIconFolderSpecial {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7864,6 +8290,7 @@ export class RuxIconFolderSpecial {
 export declare interface RuxIconFontDownload extends Components.RuxIconFontDownload {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7884,6 +8311,7 @@ export class RuxIconFontDownload {
 export declare interface RuxIconFormatAlignCenter extends Components.RuxIconFormatAlignCenter {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7904,6 +8332,7 @@ export class RuxIconFormatAlignCenter {
 export declare interface RuxIconFormatAlignJustify extends Components.RuxIconFormatAlignJustify {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7924,6 +8353,7 @@ export class RuxIconFormatAlignJustify {
 export declare interface RuxIconFormatAlignLeft extends Components.RuxIconFormatAlignLeft {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7944,6 +8374,7 @@ export class RuxIconFormatAlignLeft {
 export declare interface RuxIconFormatAlignRight extends Components.RuxIconFormatAlignRight {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7964,6 +8395,7 @@ export class RuxIconFormatAlignRight {
 export declare interface RuxIconFormatBold extends Components.RuxIconFormatBold {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -7984,6 +8416,7 @@ export class RuxIconFormatBold {
 export declare interface RuxIconFormatClear extends Components.RuxIconFormatClear {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8004,6 +8437,7 @@ export class RuxIconFormatClear {
 export declare interface RuxIconFormatColorFill extends Components.RuxIconFormatColorFill {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8024,6 +8458,7 @@ export class RuxIconFormatColorFill {
 export declare interface RuxIconFormatColorReset extends Components.RuxIconFormatColorReset {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8044,6 +8479,7 @@ export class RuxIconFormatColorReset {
 export declare interface RuxIconFormatColorText extends Components.RuxIconFormatColorText {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8064,6 +8500,7 @@ export class RuxIconFormatColorText {
 export declare interface RuxIconFormatIndentDecrease extends Components.RuxIconFormatIndentDecrease {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8084,6 +8521,7 @@ export class RuxIconFormatIndentDecrease {
 export declare interface RuxIconFormatIndentIncrease extends Components.RuxIconFormatIndentIncrease {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8104,6 +8542,7 @@ export class RuxIconFormatIndentIncrease {
 export declare interface RuxIconFormatItalic extends Components.RuxIconFormatItalic {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8124,6 +8563,7 @@ export class RuxIconFormatItalic {
 export declare interface RuxIconFormatLineSpacing extends Components.RuxIconFormatLineSpacing {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8144,6 +8584,7 @@ export class RuxIconFormatLineSpacing {
 export declare interface RuxIconFormatListBulleted extends Components.RuxIconFormatListBulleted {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8164,6 +8605,7 @@ export class RuxIconFormatListBulleted {
 export declare interface RuxIconFormatListNumbered extends Components.RuxIconFormatListNumbered {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8184,6 +8626,7 @@ export class RuxIconFormatListNumbered {
 export declare interface RuxIconFormatListNumberedRtl extends Components.RuxIconFormatListNumberedRtl {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8204,6 +8647,7 @@ export class RuxIconFormatListNumberedRtl {
 export declare interface RuxIconFormatPaint extends Components.RuxIconFormatPaint {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8224,6 +8668,7 @@ export class RuxIconFormatPaint {
 export declare interface RuxIconFormatQuote extends Components.RuxIconFormatQuote {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8244,6 +8689,7 @@ export class RuxIconFormatQuote {
 export declare interface RuxIconFormatShapes extends Components.RuxIconFormatShapes {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8264,6 +8710,7 @@ export class RuxIconFormatShapes {
 export declare interface RuxIconFormatSize extends Components.RuxIconFormatSize {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8284,6 +8731,7 @@ export class RuxIconFormatSize {
 export declare interface RuxIconFormatStrikethrough extends Components.RuxIconFormatStrikethrough {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8304,6 +8752,7 @@ export class RuxIconFormatStrikethrough {
 export declare interface RuxIconFormatTextdirectionLToR extends Components.RuxIconFormatTextdirectionLToR {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8324,6 +8773,7 @@ export class RuxIconFormatTextdirectionLToR {
 export declare interface RuxIconFormatTextdirectionRToL extends Components.RuxIconFormatTextdirectionRToL {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8344,6 +8794,7 @@ export class RuxIconFormatTextdirectionRToL {
 export declare interface RuxIconFormatUnderlined extends Components.RuxIconFormatUnderlined {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8364,6 +8815,7 @@ export class RuxIconFormatUnderlined {
 export declare interface RuxIconForum extends Components.RuxIconForum {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8384,6 +8836,7 @@ export class RuxIconForum {
 export declare interface RuxIconForward extends Components.RuxIconForward {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8404,6 +8857,7 @@ export class RuxIconForward {
 export declare interface RuxIconForward10 extends Components.RuxIconForward10 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8424,6 +8878,7 @@ export class RuxIconForward10 {
 export declare interface RuxIconForward30 extends Components.RuxIconForward30 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8444,6 +8899,7 @@ export class RuxIconForward30 {
 export declare interface RuxIconForward5 extends Components.RuxIconForward5 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8464,6 +8920,7 @@ export class RuxIconForward5 {
 export declare interface RuxIconFreeBreakfast extends Components.RuxIconFreeBreakfast {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8484,6 +8941,7 @@ export class RuxIconFreeBreakfast {
 export declare interface RuxIconFullscreen extends Components.RuxIconFullscreen {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8504,6 +8962,7 @@ export class RuxIconFullscreen {
 export declare interface RuxIconFullscreenExit extends Components.RuxIconFullscreenExit {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8524,6 +8983,7 @@ export class RuxIconFullscreenExit {
 export declare interface RuxIconFunctions extends Components.RuxIconFunctions {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8544,6 +9004,7 @@ export class RuxIconFunctions {
 export declare interface RuxIconGTranslate extends Components.RuxIconGTranslate {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8564,6 +9025,7 @@ export class RuxIconGTranslate {
 export declare interface RuxIconGamepad extends Components.RuxIconGamepad {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8584,6 +9046,7 @@ export class RuxIconGamepad {
 export declare interface RuxIconGames extends Components.RuxIconGames {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8604,6 +9067,7 @@ export class RuxIconGames {
 export declare interface RuxIconGavel extends Components.RuxIconGavel {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8624,6 +9088,7 @@ export class RuxIconGavel {
 export declare interface RuxIconGesture extends Components.RuxIconGesture {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8644,6 +9109,7 @@ export class RuxIconGesture {
 export declare interface RuxIconGetApp extends Components.RuxIconGetApp {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8664,6 +9130,7 @@ export class RuxIconGetApp {
 export declare interface RuxIconGif extends Components.RuxIconGif {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8684,6 +9151,7 @@ export class RuxIconGif {
 export declare interface RuxIconGolfCourse extends Components.RuxIconGolfCourse {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8704,6 +9172,7 @@ export class RuxIconGolfCourse {
 export declare interface RuxIconGpsFixed extends Components.RuxIconGpsFixed {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8724,6 +9193,7 @@ export class RuxIconGpsFixed {
 export declare interface RuxIconGpsNotFixed extends Components.RuxIconGpsNotFixed {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8744,6 +9214,7 @@ export class RuxIconGpsNotFixed {
 export declare interface RuxIconGpsOff extends Components.RuxIconGpsOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8764,6 +9235,7 @@ export class RuxIconGpsOff {
 export declare interface RuxIconGrade extends Components.RuxIconGrade {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8784,6 +9256,7 @@ export class RuxIconGrade {
 export declare interface RuxIconGradient extends Components.RuxIconGradient {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8804,6 +9277,7 @@ export class RuxIconGradient {
 export declare interface RuxIconGrain extends Components.RuxIconGrain {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8824,6 +9298,7 @@ export class RuxIconGrain {
 export declare interface RuxIconGraphicEq extends Components.RuxIconGraphicEq {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8844,6 +9319,7 @@ export class RuxIconGraphicEq {
 export declare interface RuxIconGridOff extends Components.RuxIconGridOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8864,6 +9340,7 @@ export class RuxIconGridOff {
 export declare interface RuxIconGridOn extends Components.RuxIconGridOn {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8884,6 +9361,7 @@ export class RuxIconGridOn {
 export declare interface RuxIconGroup extends Components.RuxIconGroup {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8904,6 +9382,7 @@ export class RuxIconGroup {
 export declare interface RuxIconGroupAdd extends Components.RuxIconGroupAdd {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8924,6 +9403,7 @@ export class RuxIconGroupAdd {
 export declare interface RuxIconGroupWork extends Components.RuxIconGroupWork {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8944,6 +9424,7 @@ export class RuxIconGroupWork {
 export declare interface RuxIconHd extends Components.RuxIconHd {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8964,6 +9445,7 @@ export class RuxIconHd {
 export declare interface RuxIconHdrOff extends Components.RuxIconHdrOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -8984,6 +9466,7 @@ export class RuxIconHdrOff {
 export declare interface RuxIconHdrOn extends Components.RuxIconHdrOn {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9004,6 +9487,7 @@ export class RuxIconHdrOn {
 export declare interface RuxIconHdrStrong extends Components.RuxIconHdrStrong {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9024,6 +9508,7 @@ export class RuxIconHdrStrong {
 export declare interface RuxIconHdrWeak extends Components.RuxIconHdrWeak {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9044,6 +9529,7 @@ export class RuxIconHdrWeak {
 export declare interface RuxIconHeadset extends Components.RuxIconHeadset {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9064,6 +9550,7 @@ export class RuxIconHeadset {
 export declare interface RuxIconHeadsetMic extends Components.RuxIconHeadsetMic {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9084,6 +9571,7 @@ export class RuxIconHeadsetMic {
 export declare interface RuxIconHealing extends Components.RuxIconHealing {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9104,6 +9592,7 @@ export class RuxIconHealing {
 export declare interface RuxIconHearing extends Components.RuxIconHearing {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9124,6 +9613,7 @@ export class RuxIconHearing {
 export declare interface RuxIconHelp extends Components.RuxIconHelp {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9144,6 +9634,7 @@ export class RuxIconHelp {
 export declare interface RuxIconHelpOutline extends Components.RuxIconHelpOutline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9164,6 +9655,7 @@ export class RuxIconHelpOutline {
 export declare interface RuxIconHighQuality extends Components.RuxIconHighQuality {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9184,6 +9676,7 @@ export class RuxIconHighQuality {
 export declare interface RuxIconHighlight extends Components.RuxIconHighlight {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9204,6 +9697,7 @@ export class RuxIconHighlight {
 export declare interface RuxIconHighlightOff extends Components.RuxIconHighlightOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9224,6 +9718,7 @@ export class RuxIconHighlightOff {
 export declare interface RuxIconHistory extends Components.RuxIconHistory {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9244,6 +9739,7 @@ export class RuxIconHistory {
 export declare interface RuxIconHome extends Components.RuxIconHome {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9264,6 +9760,7 @@ export class RuxIconHome {
 export declare interface RuxIconHorizontalSplit extends Components.RuxIconHorizontalSplit {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9284,6 +9781,7 @@ export class RuxIconHorizontalSplit {
 export declare interface RuxIconHotTub extends Components.RuxIconHotTub {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9304,6 +9802,7 @@ export class RuxIconHotTub {
 export declare interface RuxIconHotel extends Components.RuxIconHotel {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9324,6 +9823,7 @@ export class RuxIconHotel {
 export declare interface RuxIconHourglassEmpty extends Components.RuxIconHourglassEmpty {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9344,6 +9844,7 @@ export class RuxIconHourglassEmpty {
 export declare interface RuxIconHourglassFull extends Components.RuxIconHourglassFull {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9364,6 +9865,7 @@ export class RuxIconHourglassFull {
 export declare interface RuxIconHowToReg extends Components.RuxIconHowToReg {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9384,6 +9886,7 @@ export class RuxIconHowToReg {
 export declare interface RuxIconHowToVote extends Components.RuxIconHowToVote {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9404,6 +9907,7 @@ export class RuxIconHowToVote {
 export declare interface RuxIconHttp extends Components.RuxIconHttp {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9424,6 +9928,7 @@ export class RuxIconHttp {
 export declare interface RuxIconHttps extends Components.RuxIconHttps {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9444,6 +9949,7 @@ export class RuxIconHttps {
 export declare interface RuxIconImage extends Components.RuxIconImage {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9464,6 +9970,7 @@ export class RuxIconImage {
 export declare interface RuxIconImageAspectRatio extends Components.RuxIconImageAspectRatio {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9484,6 +9991,7 @@ export class RuxIconImageAspectRatio {
 export declare interface RuxIconImageSearch extends Components.RuxIconImageSearch {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9504,6 +10012,7 @@ export class RuxIconImageSearch {
 export declare interface RuxIconImportContacts extends Components.RuxIconImportContacts {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9524,6 +10033,7 @@ export class RuxIconImportContacts {
 export declare interface RuxIconImportExport extends Components.RuxIconImportExport {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9544,6 +10054,7 @@ export class RuxIconImportExport {
 export declare interface RuxIconImportantDevices extends Components.RuxIconImportantDevices {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9564,6 +10075,7 @@ export class RuxIconImportantDevices {
 export declare interface RuxIconInbox extends Components.RuxIconInbox {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9584,6 +10096,7 @@ export class RuxIconInbox {
 export declare interface RuxIconIndeterminateCheckBox extends Components.RuxIconIndeterminateCheckBox {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9604,6 +10117,7 @@ export class RuxIconIndeterminateCheckBox {
 export declare interface RuxIconInfo extends Components.RuxIconInfo {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9624,6 +10138,7 @@ export class RuxIconInfo {
 export declare interface RuxIconInput extends Components.RuxIconInput {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9644,6 +10159,7 @@ export class RuxIconInput {
 export declare interface RuxIconInsertChart extends Components.RuxIconInsertChart {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9664,6 +10180,7 @@ export class RuxIconInsertChart {
 export declare interface RuxIconInsertChartOutlined extends Components.RuxIconInsertChartOutlined {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9684,6 +10201,7 @@ export class RuxIconInsertChartOutlined {
 export declare interface RuxIconInsertComment extends Components.RuxIconInsertComment {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9704,6 +10222,7 @@ export class RuxIconInsertComment {
 export declare interface RuxIconInsertDriveFile extends Components.RuxIconInsertDriveFile {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9724,6 +10243,7 @@ export class RuxIconInsertDriveFile {
 export declare interface RuxIconInsertEmoticon extends Components.RuxIconInsertEmoticon {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9744,6 +10264,7 @@ export class RuxIconInsertEmoticon {
 export declare interface RuxIconInsertInvitation extends Components.RuxIconInsertInvitation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9764,6 +10285,7 @@ export class RuxIconInsertInvitation {
 export declare interface RuxIconInsertLink extends Components.RuxIconInsertLink {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9784,6 +10306,7 @@ export class RuxIconInsertLink {
 export declare interface RuxIconInsertPhoto extends Components.RuxIconInsertPhoto {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9804,6 +10327,7 @@ export class RuxIconInsertPhoto {
 export declare interface RuxIconInvertColors extends Components.RuxIconInvertColors {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9824,6 +10348,7 @@ export class RuxIconInvertColors {
 export declare interface RuxIconInvertColorsOff extends Components.RuxIconInvertColorsOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9844,6 +10369,7 @@ export class RuxIconInvertColorsOff {
 export declare interface RuxIconIso extends Components.RuxIconIso {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9864,6 +10390,7 @@ export class RuxIconIso {
 export declare interface RuxIconKeyboard extends Components.RuxIconKeyboard {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9884,6 +10411,7 @@ export class RuxIconKeyboard {
 export declare interface RuxIconKeyboardArrowDown extends Components.RuxIconKeyboardArrowDown {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9904,6 +10432,7 @@ export class RuxIconKeyboardArrowDown {
 export declare interface RuxIconKeyboardArrowLeft extends Components.RuxIconKeyboardArrowLeft {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9924,6 +10453,7 @@ export class RuxIconKeyboardArrowLeft {
 export declare interface RuxIconKeyboardArrowRight extends Components.RuxIconKeyboardArrowRight {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9944,6 +10474,7 @@ export class RuxIconKeyboardArrowRight {
 export declare interface RuxIconKeyboardArrowUp extends Components.RuxIconKeyboardArrowUp {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9964,6 +10495,7 @@ export class RuxIconKeyboardArrowUp {
 export declare interface RuxIconKeyboardBackspace extends Components.RuxIconKeyboardBackspace {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -9984,6 +10516,7 @@ export class RuxIconKeyboardBackspace {
 export declare interface RuxIconKeyboardCapslock extends Components.RuxIconKeyboardCapslock {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10004,6 +10537,7 @@ export class RuxIconKeyboardCapslock {
 export declare interface RuxIconKeyboardHide extends Components.RuxIconKeyboardHide {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10024,6 +10558,7 @@ export class RuxIconKeyboardHide {
 export declare interface RuxIconKeyboardReturn extends Components.RuxIconKeyboardReturn {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10044,6 +10579,7 @@ export class RuxIconKeyboardReturn {
 export declare interface RuxIconKeyboardTab extends Components.RuxIconKeyboardTab {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10064,6 +10600,7 @@ export class RuxIconKeyboardTab {
 export declare interface RuxIconKeyboardVoice extends Components.RuxIconKeyboardVoice {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10084,6 +10621,7 @@ export class RuxIconKeyboardVoice {
 export declare interface RuxIconKitchen extends Components.RuxIconKitchen {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10104,6 +10642,7 @@ export class RuxIconKitchen {
 export declare interface RuxIconLabel extends Components.RuxIconLabel {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10124,6 +10663,7 @@ export class RuxIconLabel {
 export declare interface RuxIconLabelImportant extends Components.RuxIconLabelImportant {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10144,6 +10684,7 @@ export class RuxIconLabelImportant {
 export declare interface RuxIconLabelOff extends Components.RuxIconLabelOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10164,6 +10705,7 @@ export class RuxIconLabelOff {
 export declare interface RuxIconLandscape extends Components.RuxIconLandscape {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10184,6 +10726,7 @@ export class RuxIconLandscape {
 export declare interface RuxIconLanguage extends Components.RuxIconLanguage {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10204,6 +10747,7 @@ export class RuxIconLanguage {
 export declare interface RuxIconLaptop extends Components.RuxIconLaptop {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10224,6 +10768,7 @@ export class RuxIconLaptop {
 export declare interface RuxIconLaptopChromebook extends Components.RuxIconLaptopChromebook {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10244,6 +10789,7 @@ export class RuxIconLaptopChromebook {
 export declare interface RuxIconLaptopMac extends Components.RuxIconLaptopMac {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10264,6 +10810,7 @@ export class RuxIconLaptopMac {
 export declare interface RuxIconLaptopWindows extends Components.RuxIconLaptopWindows {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10284,6 +10831,7 @@ export class RuxIconLaptopWindows {
 export declare interface RuxIconLastPage extends Components.RuxIconLastPage {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10304,6 +10852,7 @@ export class RuxIconLastPage {
 export declare interface RuxIconLaunch extends Components.RuxIconLaunch {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10324,6 +10873,7 @@ export class RuxIconLaunch {
 export declare interface RuxIconLayers extends Components.RuxIconLayers {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10344,6 +10894,7 @@ export class RuxIconLayers {
 export declare interface RuxIconLayersClear extends Components.RuxIconLayersClear {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10364,6 +10915,7 @@ export class RuxIconLayersClear {
 export declare interface RuxIconLeakAdd extends Components.RuxIconLeakAdd {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10384,6 +10936,7 @@ export class RuxIconLeakAdd {
 export declare interface RuxIconLeakRemove extends Components.RuxIconLeakRemove {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10404,6 +10957,7 @@ export class RuxIconLeakRemove {
 export declare interface RuxIconLens extends Components.RuxIconLens {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10424,6 +10978,7 @@ export class RuxIconLens {
 export declare interface RuxIconLibraryAdd extends Components.RuxIconLibraryAdd {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10444,6 +10999,7 @@ export class RuxIconLibraryAdd {
 export declare interface RuxIconLibraryBooks extends Components.RuxIconLibraryBooks {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10464,6 +11020,7 @@ export class RuxIconLibraryBooks {
 export declare interface RuxIconLibraryMusic extends Components.RuxIconLibraryMusic {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10484,6 +11041,7 @@ export class RuxIconLibraryMusic {
 export declare interface RuxIconLineStyle extends Components.RuxIconLineStyle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10504,6 +11062,7 @@ export class RuxIconLineStyle {
 export declare interface RuxIconLineWeight extends Components.RuxIconLineWeight {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10524,6 +11083,7 @@ export class RuxIconLineWeight {
 export declare interface RuxIconLinearScale extends Components.RuxIconLinearScale {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10544,6 +11104,7 @@ export class RuxIconLinearScale {
 export declare interface RuxIconLink extends Components.RuxIconLink {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10564,6 +11125,7 @@ export class RuxIconLink {
 export declare interface RuxIconLinkOff extends Components.RuxIconLinkOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10584,6 +11146,7 @@ export class RuxIconLinkOff {
 export declare interface RuxIconLinkedCamera extends Components.RuxIconLinkedCamera {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10604,6 +11167,7 @@ export class RuxIconLinkedCamera {
 export declare interface RuxIconList extends Components.RuxIconList {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10624,6 +11188,7 @@ export class RuxIconList {
 export declare interface RuxIconListAlt extends Components.RuxIconListAlt {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10644,6 +11209,7 @@ export class RuxIconListAlt {
 export declare interface RuxIconLiveHelp extends Components.RuxIconLiveHelp {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10664,6 +11230,7 @@ export class RuxIconLiveHelp {
 export declare interface RuxIconLiveTv extends Components.RuxIconLiveTv {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10684,6 +11251,7 @@ export class RuxIconLiveTv {
 export declare interface RuxIconLocalActivity extends Components.RuxIconLocalActivity {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10704,6 +11272,7 @@ export class RuxIconLocalActivity {
 export declare interface RuxIconLocalAirport extends Components.RuxIconLocalAirport {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10724,6 +11293,7 @@ export class RuxIconLocalAirport {
 export declare interface RuxIconLocalAtm extends Components.RuxIconLocalAtm {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10744,6 +11314,7 @@ export class RuxIconLocalAtm {
 export declare interface RuxIconLocalBar extends Components.RuxIconLocalBar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10764,6 +11335,7 @@ export class RuxIconLocalBar {
 export declare interface RuxIconLocalCafe extends Components.RuxIconLocalCafe {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10784,6 +11356,7 @@ export class RuxIconLocalCafe {
 export declare interface RuxIconLocalCarWash extends Components.RuxIconLocalCarWash {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10804,6 +11377,7 @@ export class RuxIconLocalCarWash {
 export declare interface RuxIconLocalConvenienceStore extends Components.RuxIconLocalConvenienceStore {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10824,6 +11398,7 @@ export class RuxIconLocalConvenienceStore {
 export declare interface RuxIconLocalDining extends Components.RuxIconLocalDining {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10844,6 +11419,7 @@ export class RuxIconLocalDining {
 export declare interface RuxIconLocalDrink extends Components.RuxIconLocalDrink {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10864,6 +11440,7 @@ export class RuxIconLocalDrink {
 export declare interface RuxIconLocalGasStation extends Components.RuxIconLocalGasStation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10884,6 +11461,7 @@ export class RuxIconLocalGasStation {
 export declare interface RuxIconLocalGroceryStore extends Components.RuxIconLocalGroceryStore {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10904,6 +11482,7 @@ export class RuxIconLocalGroceryStore {
 export declare interface RuxIconLocalHospital extends Components.RuxIconLocalHospital {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10924,6 +11503,7 @@ export class RuxIconLocalHospital {
 export declare interface RuxIconLocalHotel extends Components.RuxIconLocalHotel {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10944,6 +11524,7 @@ export class RuxIconLocalHotel {
 export declare interface RuxIconLocalLaundryService extends Components.RuxIconLocalLaundryService {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10964,6 +11545,7 @@ export class RuxIconLocalLaundryService {
 export declare interface RuxIconLocalLibrary extends Components.RuxIconLocalLibrary {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -10984,6 +11566,7 @@ export class RuxIconLocalLibrary {
 export declare interface RuxIconLocalMall extends Components.RuxIconLocalMall {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11004,6 +11587,7 @@ export class RuxIconLocalMall {
 export declare interface RuxIconLocalMovies extends Components.RuxIconLocalMovies {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11024,6 +11608,7 @@ export class RuxIconLocalMovies {
 export declare interface RuxIconLocalOffer extends Components.RuxIconLocalOffer {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11044,6 +11629,7 @@ export class RuxIconLocalOffer {
 export declare interface RuxIconLocalParking extends Components.RuxIconLocalParking {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11064,6 +11650,7 @@ export class RuxIconLocalParking {
 export declare interface RuxIconLocalPharmacy extends Components.RuxIconLocalPharmacy {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11084,6 +11671,7 @@ export class RuxIconLocalPharmacy {
 export declare interface RuxIconLocalPhone extends Components.RuxIconLocalPhone {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11104,6 +11692,7 @@ export class RuxIconLocalPhone {
 export declare interface RuxIconLocalPlay extends Components.RuxIconLocalPlay {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11124,6 +11713,7 @@ export class RuxIconLocalPlay {
 export declare interface RuxIconLocalPostOffice extends Components.RuxIconLocalPostOffice {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11144,6 +11734,7 @@ export class RuxIconLocalPostOffice {
 export declare interface RuxIconLocalPrintshop extends Components.RuxIconLocalPrintshop {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11164,6 +11755,7 @@ export class RuxIconLocalPrintshop {
 export declare interface RuxIconLocalSee extends Components.RuxIconLocalSee {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11184,6 +11776,7 @@ export class RuxIconLocalSee {
 export declare interface RuxIconLocalShipping extends Components.RuxIconLocalShipping {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11204,6 +11797,7 @@ export class RuxIconLocalShipping {
 export declare interface RuxIconLocalTaxi extends Components.RuxIconLocalTaxi {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11224,6 +11818,7 @@ export class RuxIconLocalTaxi {
 export declare interface RuxIconLocationCity extends Components.RuxIconLocationCity {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11244,6 +11839,7 @@ export class RuxIconLocationCity {
 export declare interface RuxIconLocationDisabled extends Components.RuxIconLocationDisabled {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11264,6 +11860,7 @@ export class RuxIconLocationDisabled {
 export declare interface RuxIconLocationOff extends Components.RuxIconLocationOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11284,6 +11881,7 @@ export class RuxIconLocationOff {
 export declare interface RuxIconLocationOn extends Components.RuxIconLocationOn {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11304,6 +11902,7 @@ export class RuxIconLocationOn {
 export declare interface RuxIconLocationSearching extends Components.RuxIconLocationSearching {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11324,6 +11923,7 @@ export class RuxIconLocationSearching {
 export declare interface RuxIconLock extends Components.RuxIconLock {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11344,6 +11944,7 @@ export class RuxIconLock {
 export declare interface RuxIconLockOpen extends Components.RuxIconLockOpen {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11364,6 +11965,7 @@ export class RuxIconLockOpen {
 export declare interface RuxIconLooks extends Components.RuxIconLooks {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11384,6 +11986,7 @@ export class RuxIconLooks {
 export declare interface RuxIconLooks1 extends Components.RuxIconLooks1 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11404,6 +12007,7 @@ export class RuxIconLooks1 {
 export declare interface RuxIconLooks2 extends Components.RuxIconLooks2 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11424,6 +12028,7 @@ export class RuxIconLooks2 {
 export declare interface RuxIconLooks3 extends Components.RuxIconLooks3 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11444,6 +12049,7 @@ export class RuxIconLooks3 {
 export declare interface RuxIconLooks4 extends Components.RuxIconLooks4 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11464,6 +12070,7 @@ export class RuxIconLooks4 {
 export declare interface RuxIconLooks5 extends Components.RuxIconLooks5 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11484,6 +12091,7 @@ export class RuxIconLooks5 {
 export declare interface RuxIconLooks6 extends Components.RuxIconLooks6 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11504,6 +12112,7 @@ export class RuxIconLooks6 {
 export declare interface RuxIconLoop extends Components.RuxIconLoop {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11524,6 +12133,7 @@ export class RuxIconLoop {
 export declare interface RuxIconLoupe extends Components.RuxIconLoupe {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11544,6 +12154,7 @@ export class RuxIconLoupe {
 export declare interface RuxIconLowPriority extends Components.RuxIconLowPriority {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11564,6 +12175,7 @@ export class RuxIconLowPriority {
 export declare interface RuxIconLoyalty extends Components.RuxIconLoyalty {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11584,6 +12196,7 @@ export class RuxIconLoyalty {
 export declare interface RuxIconMail extends Components.RuxIconMail {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11604,6 +12217,7 @@ export class RuxIconMail {
 export declare interface RuxIconMailOutline extends Components.RuxIconMailOutline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11624,6 +12238,7 @@ export class RuxIconMailOutline {
 export declare interface RuxIconMap extends Components.RuxIconMap {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11644,6 +12259,7 @@ export class RuxIconMap {
 export declare interface RuxIconMarkunread extends Components.RuxIconMarkunread {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11664,6 +12280,7 @@ export class RuxIconMarkunread {
 export declare interface RuxIconMarkunreadMailbox extends Components.RuxIconMarkunreadMailbox {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11684,6 +12301,7 @@ export class RuxIconMarkunreadMailbox {
 export declare interface RuxIconMaximize extends Components.RuxIconMaximize {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11704,6 +12322,7 @@ export class RuxIconMaximize {
 export declare interface RuxIconMeetingRoom extends Components.RuxIconMeetingRoom {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11724,6 +12343,7 @@ export class RuxIconMeetingRoom {
 export declare interface RuxIconMemory extends Components.RuxIconMemory {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11744,6 +12364,7 @@ export class RuxIconMemory {
 export declare interface RuxIconMenu extends Components.RuxIconMenu {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11764,6 +12385,7 @@ export class RuxIconMenu {
 export declare interface RuxIconMergeType extends Components.RuxIconMergeType {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11784,6 +12406,7 @@ export class RuxIconMergeType {
 export declare interface RuxIconMessage extends Components.RuxIconMessage {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11804,6 +12427,7 @@ export class RuxIconMessage {
 export declare interface RuxIconMic extends Components.RuxIconMic {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11824,6 +12448,7 @@ export class RuxIconMic {
 export declare interface RuxIconMicNone extends Components.RuxIconMicNone {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11844,6 +12469,7 @@ export class RuxIconMicNone {
 export declare interface RuxIconMicOff extends Components.RuxIconMicOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11864,6 +12490,7 @@ export class RuxIconMicOff {
 export declare interface RuxIconMinimize extends Components.RuxIconMinimize {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11884,6 +12511,7 @@ export class RuxIconMinimize {
 export declare interface RuxIconMissedVideoCall extends Components.RuxIconMissedVideoCall {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11904,6 +12532,7 @@ export class RuxIconMissedVideoCall {
 export declare interface RuxIconMission extends Components.RuxIconMission {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11924,6 +12553,7 @@ export class RuxIconMission {
 export declare interface RuxIconMms extends Components.RuxIconMms {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11944,6 +12574,7 @@ export class RuxIconMms {
 export declare interface RuxIconMobileFriendly extends Components.RuxIconMobileFriendly {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11964,6 +12595,7 @@ export class RuxIconMobileFriendly {
 export declare interface RuxIconMobileOff extends Components.RuxIconMobileOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -11984,6 +12616,7 @@ export class RuxIconMobileOff {
 export declare interface RuxIconMobileScreenShare extends Components.RuxIconMobileScreenShare {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12004,6 +12637,7 @@ export class RuxIconMobileScreenShare {
 export declare interface RuxIconModeComment extends Components.RuxIconModeComment {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12024,6 +12658,7 @@ export class RuxIconModeComment {
 export declare interface RuxIconMonetizationOn extends Components.RuxIconMonetizationOn {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12044,6 +12679,7 @@ export class RuxIconMonetizationOn {
 export declare interface RuxIconMoney extends Components.RuxIconMoney {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12064,6 +12700,7 @@ export class RuxIconMoney {
 export declare interface RuxIconMoneyOff extends Components.RuxIconMoneyOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12084,6 +12721,7 @@ export class RuxIconMoneyOff {
 export declare interface RuxIconMonochromePhotos extends Components.RuxIconMonochromePhotos {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12104,6 +12742,7 @@ export class RuxIconMonochromePhotos {
 export declare interface RuxIconMood extends Components.RuxIconMood {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12124,6 +12763,7 @@ export class RuxIconMood {
 export declare interface RuxIconMoodBad extends Components.RuxIconMoodBad {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12144,6 +12784,7 @@ export class RuxIconMoodBad {
 export declare interface RuxIconMore extends Components.RuxIconMore {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12164,6 +12805,7 @@ export class RuxIconMore {
 export declare interface RuxIconMoreHoriz extends Components.RuxIconMoreHoriz {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12184,6 +12826,7 @@ export class RuxIconMoreHoriz {
 export declare interface RuxIconMoreVert extends Components.RuxIconMoreVert {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12204,6 +12847,7 @@ export class RuxIconMoreVert {
 export declare interface RuxIconMotorcycle extends Components.RuxIconMotorcycle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12224,6 +12868,7 @@ export class RuxIconMotorcycle {
 export declare interface RuxIconMouse extends Components.RuxIconMouse {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12244,6 +12889,7 @@ export class RuxIconMouse {
 export declare interface RuxIconMoveToInbox extends Components.RuxIconMoveToInbox {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12264,6 +12910,7 @@ export class RuxIconMoveToInbox {
 export declare interface RuxIconMovie extends Components.RuxIconMovie {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12284,6 +12931,7 @@ export class RuxIconMovie {
 export declare interface RuxIconMovieCreation extends Components.RuxIconMovieCreation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12304,6 +12952,7 @@ export class RuxIconMovieCreation {
 export declare interface RuxIconMovieFilter extends Components.RuxIconMovieFilter {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12324,6 +12973,7 @@ export class RuxIconMovieFilter {
 export declare interface RuxIconMultilineChart extends Components.RuxIconMultilineChart {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12344,6 +12994,7 @@ export class RuxIconMultilineChart {
 export declare interface RuxIconMusicNote extends Components.RuxIconMusicNote {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12364,6 +13015,7 @@ export class RuxIconMusicNote {
 export declare interface RuxIconMusicOff extends Components.RuxIconMusicOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12384,6 +13036,7 @@ export class RuxIconMusicOff {
 export declare interface RuxIconMusicVideo extends Components.RuxIconMusicVideo {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12404,6 +13057,7 @@ export class RuxIconMusicVideo {
 export declare interface RuxIconMyLocation extends Components.RuxIconMyLocation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12424,6 +13078,7 @@ export class RuxIconMyLocation {
 export declare interface RuxIconNature extends Components.RuxIconNature {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12444,6 +13099,7 @@ export class RuxIconNature {
 export declare interface RuxIconNaturePeople extends Components.RuxIconNaturePeople {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12464,6 +13120,7 @@ export class RuxIconNaturePeople {
 export declare interface RuxIconNavigateBefore extends Components.RuxIconNavigateBefore {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12484,6 +13141,7 @@ export class RuxIconNavigateBefore {
 export declare interface RuxIconNavigateNext extends Components.RuxIconNavigateNext {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12504,6 +13162,7 @@ export class RuxIconNavigateNext {
 export declare interface RuxIconNavigation extends Components.RuxIconNavigation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12524,6 +13183,7 @@ export class RuxIconNavigation {
 export declare interface RuxIconNearMe extends Components.RuxIconNearMe {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12544,6 +13204,7 @@ export class RuxIconNearMe {
 export declare interface RuxIconNetcom extends Components.RuxIconNetcom {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12564,6 +13225,7 @@ export class RuxIconNetcom {
 export declare interface RuxIconNetworkCell extends Components.RuxIconNetworkCell {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12584,6 +13246,7 @@ export class RuxIconNetworkCell {
 export declare interface RuxIconNetworkCheck extends Components.RuxIconNetworkCheck {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12604,6 +13267,7 @@ export class RuxIconNetworkCheck {
 export declare interface RuxIconNetworkLocked extends Components.RuxIconNetworkLocked {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12624,6 +13288,7 @@ export class RuxIconNetworkLocked {
 export declare interface RuxIconNetworkWifi extends Components.RuxIconNetworkWifi {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12644,6 +13309,7 @@ export class RuxIconNetworkWifi {
 export declare interface RuxIconNewReleases extends Components.RuxIconNewReleases {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12664,6 +13330,7 @@ export class RuxIconNewReleases {
 export declare interface RuxIconNextWeek extends Components.RuxIconNextWeek {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12684,6 +13351,7 @@ export class RuxIconNextWeek {
 export declare interface RuxIconNfc extends Components.RuxIconNfc {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12704,6 +13372,7 @@ export class RuxIconNfc {
 export declare interface RuxIconNoEncryption extends Components.RuxIconNoEncryption {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12724,6 +13393,7 @@ export class RuxIconNoEncryption {
 export declare interface RuxIconNoMeetingRoom extends Components.RuxIconNoMeetingRoom {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12744,6 +13414,7 @@ export class RuxIconNoMeetingRoom {
 export declare interface RuxIconNoSim extends Components.RuxIconNoSim {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12764,6 +13435,7 @@ export class RuxIconNoSim {
 export declare interface RuxIconNotInterested extends Components.RuxIconNotInterested {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12784,6 +13456,7 @@ export class RuxIconNotInterested {
 export declare interface RuxIconNotListedLocation extends Components.RuxIconNotListedLocation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12804,6 +13477,7 @@ export class RuxIconNotListedLocation {
 export declare interface RuxIconNote extends Components.RuxIconNote {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12824,6 +13498,7 @@ export class RuxIconNote {
 export declare interface RuxIconNoteAdd extends Components.RuxIconNoteAdd {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12844,6 +13519,7 @@ export class RuxIconNoteAdd {
 export declare interface RuxIconNotes extends Components.RuxIconNotes {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12864,6 +13540,7 @@ export class RuxIconNotes {
 export declare interface RuxIconNotificationImportant extends Components.RuxIconNotificationImportant {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12884,6 +13561,7 @@ export class RuxIconNotificationImportant {
 export declare interface RuxIconNotifications extends Components.RuxIconNotifications {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12904,6 +13582,7 @@ export class RuxIconNotifications {
 export declare interface RuxIconNotificationsActive extends Components.RuxIconNotificationsActive {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12924,6 +13603,7 @@ export class RuxIconNotificationsActive {
 export declare interface RuxIconNotificationsNone extends Components.RuxIconNotificationsNone {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12944,6 +13624,7 @@ export class RuxIconNotificationsNone {
 export declare interface RuxIconNotificationsOff extends Components.RuxIconNotificationsOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12964,6 +13645,7 @@ export class RuxIconNotificationsOff {
 export declare interface RuxIconNotificationsPaused extends Components.RuxIconNotificationsPaused {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -12984,6 +13666,7 @@ export class RuxIconNotificationsPaused {
 export declare interface RuxIconOfflineBolt extends Components.RuxIconOfflineBolt {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13004,6 +13687,7 @@ export class RuxIconOfflineBolt {
 export declare interface RuxIconOfflinePin extends Components.RuxIconOfflinePin {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13024,6 +13708,7 @@ export class RuxIconOfflinePin {
 export declare interface RuxIconOndemandVideo extends Components.RuxIconOndemandVideo {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13044,6 +13729,7 @@ export class RuxIconOndemandVideo {
 export declare interface RuxIconOpacity extends Components.RuxIconOpacity {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13064,6 +13750,7 @@ export class RuxIconOpacity {
 export declare interface RuxIconOpenInBrowser extends Components.RuxIconOpenInBrowser {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13084,6 +13771,7 @@ export class RuxIconOpenInBrowser {
 export declare interface RuxIconOpenInNew extends Components.RuxIconOpenInNew {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13104,6 +13792,7 @@ export class RuxIconOpenInNew {
 export declare interface RuxIconOpenWith extends Components.RuxIconOpenWith {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13124,6 +13813,7 @@ export class RuxIconOpenWith {
 export declare interface RuxIconOutlinedFlag extends Components.RuxIconOutlinedFlag {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13144,6 +13834,7 @@ export class RuxIconOutlinedFlag {
 export declare interface RuxIconPages extends Components.RuxIconPages {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13164,6 +13855,7 @@ export class RuxIconPages {
 export declare interface RuxIconPageview extends Components.RuxIconPageview {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13184,6 +13876,7 @@ export class RuxIconPageview {
 export declare interface RuxIconPalette extends Components.RuxIconPalette {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13204,6 +13897,7 @@ export class RuxIconPalette {
 export declare interface RuxIconPanTool extends Components.RuxIconPanTool {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13224,6 +13918,7 @@ export class RuxIconPanTool {
 export declare interface RuxIconPanorama extends Components.RuxIconPanorama {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13244,6 +13939,7 @@ export class RuxIconPanorama {
 export declare interface RuxIconPanoramaFishEye extends Components.RuxIconPanoramaFishEye {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13264,6 +13960,7 @@ export class RuxIconPanoramaFishEye {
 export declare interface RuxIconPanoramaHorizontal extends Components.RuxIconPanoramaHorizontal {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13284,6 +13981,7 @@ export class RuxIconPanoramaHorizontal {
 export declare interface RuxIconPanoramaVertical extends Components.RuxIconPanoramaVertical {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13304,6 +14002,7 @@ export class RuxIconPanoramaVertical {
 export declare interface RuxIconPanoramaWideAngle extends Components.RuxIconPanoramaWideAngle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13324,6 +14023,7 @@ export class RuxIconPanoramaWideAngle {
 export declare interface RuxIconPartyMode extends Components.RuxIconPartyMode {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13344,6 +14044,7 @@ export class RuxIconPartyMode {
 export declare interface RuxIconPause extends Components.RuxIconPause {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13364,6 +14065,7 @@ export class RuxIconPause {
 export declare interface RuxIconPauseCircleFilled extends Components.RuxIconPauseCircleFilled {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13384,6 +14086,7 @@ export class RuxIconPauseCircleFilled {
 export declare interface RuxIconPauseCircleOutline extends Components.RuxIconPauseCircleOutline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13404,6 +14107,7 @@ export class RuxIconPauseCircleOutline {
 export declare interface RuxIconPausePresentation extends Components.RuxIconPausePresentation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13424,6 +14128,7 @@ export class RuxIconPausePresentation {
 export declare interface RuxIconPayload extends Components.RuxIconPayload {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13444,6 +14149,7 @@ export class RuxIconPayload {
 export declare interface RuxIconPayment extends Components.RuxIconPayment {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13464,6 +14170,7 @@ export class RuxIconPayment {
 export declare interface RuxIconPeopleOutline extends Components.RuxIconPeopleOutline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13484,6 +14191,7 @@ export class RuxIconPeopleOutline {
 export declare interface RuxIconPermCameraMic extends Components.RuxIconPermCameraMic {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13504,6 +14212,7 @@ export class RuxIconPermCameraMic {
 export declare interface RuxIconPermContactCalendar extends Components.RuxIconPermContactCalendar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13524,6 +14233,7 @@ export class RuxIconPermContactCalendar {
 export declare interface RuxIconPermDataSetting extends Components.RuxIconPermDataSetting {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13544,6 +14254,7 @@ export class RuxIconPermDataSetting {
 export declare interface RuxIconPermDeviceInformation extends Components.RuxIconPermDeviceInformation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13564,6 +14275,7 @@ export class RuxIconPermDeviceInformation {
 export declare interface RuxIconPermIdentity extends Components.RuxIconPermIdentity {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13584,6 +14296,7 @@ export class RuxIconPermIdentity {
 export declare interface RuxIconPermMedia extends Components.RuxIconPermMedia {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13604,6 +14317,7 @@ export class RuxIconPermMedia {
 export declare interface RuxIconPermPhoneMsg extends Components.RuxIconPermPhoneMsg {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13624,6 +14338,7 @@ export class RuxIconPermPhoneMsg {
 export declare interface RuxIconPermScanWifi extends Components.RuxIconPermScanWifi {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13644,6 +14359,7 @@ export class RuxIconPermScanWifi {
 export declare interface RuxIconPerson extends Components.RuxIconPerson {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13664,6 +14380,7 @@ export class RuxIconPerson {
 export declare interface RuxIconPersonAdd extends Components.RuxIconPersonAdd {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13684,6 +14401,7 @@ export class RuxIconPersonAdd {
 export declare interface RuxIconPersonAddDisabled extends Components.RuxIconPersonAddDisabled {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13704,6 +14422,7 @@ export class RuxIconPersonAddDisabled {
 export declare interface RuxIconPersonOutline extends Components.RuxIconPersonOutline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13724,6 +14443,7 @@ export class RuxIconPersonOutline {
 export declare interface RuxIconPersonPin extends Components.RuxIconPersonPin {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13744,6 +14464,7 @@ export class RuxIconPersonPin {
 export declare interface RuxIconPersonPinCircle extends Components.RuxIconPersonPinCircle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13764,6 +14485,7 @@ export class RuxIconPersonPinCircle {
 export declare interface RuxIconPersonalVideo extends Components.RuxIconPersonalVideo {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13784,6 +14506,7 @@ export class RuxIconPersonalVideo {
 export declare interface RuxIconPets extends Components.RuxIconPets {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13804,6 +14527,7 @@ export class RuxIconPets {
 export declare interface RuxIconPhone extends Components.RuxIconPhone {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13824,6 +14548,7 @@ export class RuxIconPhone {
 export declare interface RuxIconPhoneAndroid extends Components.RuxIconPhoneAndroid {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13844,6 +14569,7 @@ export class RuxIconPhoneAndroid {
 export declare interface RuxIconPhoneBluetoothSpeaker extends Components.RuxIconPhoneBluetoothSpeaker {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13864,6 +14590,7 @@ export class RuxIconPhoneBluetoothSpeaker {
 export declare interface RuxIconPhoneCallback extends Components.RuxIconPhoneCallback {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13884,6 +14611,7 @@ export class RuxIconPhoneCallback {
 export declare interface RuxIconPhoneForwarded extends Components.RuxIconPhoneForwarded {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13904,6 +14632,7 @@ export class RuxIconPhoneForwarded {
 export declare interface RuxIconPhoneInTalk extends Components.RuxIconPhoneInTalk {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13924,6 +14653,7 @@ export class RuxIconPhoneInTalk {
 export declare interface RuxIconPhoneIphone extends Components.RuxIconPhoneIphone {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13944,6 +14674,7 @@ export class RuxIconPhoneIphone {
 export declare interface RuxIconPhoneLocked extends Components.RuxIconPhoneLocked {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13964,6 +14695,7 @@ export class RuxIconPhoneLocked {
 export declare interface RuxIconPhoneMissed extends Components.RuxIconPhoneMissed {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -13984,6 +14716,7 @@ export class RuxIconPhoneMissed {
 export declare interface RuxIconPhonePaused extends Components.RuxIconPhonePaused {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14004,6 +14737,7 @@ export class RuxIconPhonePaused {
 export declare interface RuxIconPhonelink extends Components.RuxIconPhonelink {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14024,6 +14758,7 @@ export class RuxIconPhonelink {
 export declare interface RuxIconPhonelinkErase extends Components.RuxIconPhonelinkErase {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14044,6 +14779,7 @@ export class RuxIconPhonelinkErase {
 export declare interface RuxIconPhonelinkLock extends Components.RuxIconPhonelinkLock {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14064,6 +14800,7 @@ export class RuxIconPhonelinkLock {
 export declare interface RuxIconPhonelinkOff extends Components.RuxIconPhonelinkOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14084,6 +14821,7 @@ export class RuxIconPhonelinkOff {
 export declare interface RuxIconPhonelinkRing extends Components.RuxIconPhonelinkRing {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14104,6 +14842,7 @@ export class RuxIconPhonelinkRing {
 export declare interface RuxIconPhonelinkSetup extends Components.RuxIconPhonelinkSetup {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14124,6 +14863,7 @@ export class RuxIconPhonelinkSetup {
 export declare interface RuxIconPhoto extends Components.RuxIconPhoto {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14144,6 +14884,7 @@ export class RuxIconPhoto {
 export declare interface RuxIconPhotoAlbum extends Components.RuxIconPhotoAlbum {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14164,6 +14905,7 @@ export class RuxIconPhotoAlbum {
 export declare interface RuxIconPhotoCamera extends Components.RuxIconPhotoCamera {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14184,6 +14926,7 @@ export class RuxIconPhotoCamera {
 export declare interface RuxIconPhotoFilter extends Components.RuxIconPhotoFilter {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14204,6 +14947,7 @@ export class RuxIconPhotoFilter {
 export declare interface RuxIconPhotoLibrary extends Components.RuxIconPhotoLibrary {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14224,6 +14968,7 @@ export class RuxIconPhotoLibrary {
 export declare interface RuxIconPhotoSizeSelectActual extends Components.RuxIconPhotoSizeSelectActual {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14244,6 +14989,7 @@ export class RuxIconPhotoSizeSelectActual {
 export declare interface RuxIconPhotoSizeSelectLarge extends Components.RuxIconPhotoSizeSelectLarge {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14264,6 +15010,7 @@ export class RuxIconPhotoSizeSelectLarge {
 export declare interface RuxIconPhotoSizeSelectSmall extends Components.RuxIconPhotoSizeSelectSmall {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14284,6 +15031,7 @@ export class RuxIconPhotoSizeSelectSmall {
 export declare interface RuxIconPictureAsPdf extends Components.RuxIconPictureAsPdf {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14304,6 +15052,7 @@ export class RuxIconPictureAsPdf {
 export declare interface RuxIconPictureInPicture extends Components.RuxIconPictureInPicture {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14324,6 +15073,7 @@ export class RuxIconPictureInPicture {
 export declare interface RuxIconPictureInPictureAlt extends Components.RuxIconPictureInPictureAlt {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14344,6 +15094,7 @@ export class RuxIconPictureInPictureAlt {
 export declare interface RuxIconPieChart extends Components.RuxIconPieChart {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14364,6 +15115,7 @@ export class RuxIconPieChart {
 export declare interface RuxIconPinDrop extends Components.RuxIconPinDrop {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14384,6 +15136,7 @@ export class RuxIconPinDrop {
 export declare interface RuxIconPlace extends Components.RuxIconPlace {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14404,6 +15157,7 @@ export class RuxIconPlace {
 export declare interface RuxIconPlayArrow extends Components.RuxIconPlayArrow {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14424,6 +15178,7 @@ export class RuxIconPlayArrow {
 export declare interface RuxIconPlayCircleFilled extends Components.RuxIconPlayCircleFilled {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14444,6 +15199,7 @@ export class RuxIconPlayCircleFilled {
 export declare interface RuxIconPlayCircleFilledWhite extends Components.RuxIconPlayCircleFilledWhite {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14464,6 +15220,7 @@ export class RuxIconPlayCircleFilledWhite {
 export declare interface RuxIconPlayCircleOutline extends Components.RuxIconPlayCircleOutline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14484,6 +15241,7 @@ export class RuxIconPlayCircleOutline {
 export declare interface RuxIconPlayForWork extends Components.RuxIconPlayForWork {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14504,6 +15262,7 @@ export class RuxIconPlayForWork {
 export declare interface RuxIconPlaylistAdd extends Components.RuxIconPlaylistAdd {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14524,6 +15283,7 @@ export class RuxIconPlaylistAdd {
 export declare interface RuxIconPlaylistAddCheck extends Components.RuxIconPlaylistAddCheck {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14544,6 +15304,7 @@ export class RuxIconPlaylistAddCheck {
 export declare interface RuxIconPlaylistPlay extends Components.RuxIconPlaylistPlay {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14564,6 +15325,7 @@ export class RuxIconPlaylistPlay {
 export declare interface RuxIconPlusOne extends Components.RuxIconPlusOne {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14584,6 +15346,7 @@ export class RuxIconPlusOne {
 export declare interface RuxIconPoll extends Components.RuxIconPoll {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14604,6 +15367,7 @@ export class RuxIconPoll {
 export declare interface RuxIconPool extends Components.RuxIconPool {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14624,6 +15388,7 @@ export class RuxIconPool {
 export declare interface RuxIconPortableWifiOff extends Components.RuxIconPortableWifiOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14644,6 +15409,7 @@ export class RuxIconPortableWifiOff {
 export declare interface RuxIconPortrait extends Components.RuxIconPortrait {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14664,6 +15430,7 @@ export class RuxIconPortrait {
 export declare interface RuxIconPower extends Components.RuxIconPower {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14684,6 +15451,7 @@ export class RuxIconPower {
 export declare interface RuxIconPowerInput extends Components.RuxIconPowerInput {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14704,6 +15472,7 @@ export class RuxIconPowerInput {
 export declare interface RuxIconPowerOff extends Components.RuxIconPowerOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14724,6 +15493,7 @@ export class RuxIconPowerOff {
 export declare interface RuxIconPowerSettingsNew extends Components.RuxIconPowerSettingsNew {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14744,6 +15514,7 @@ export class RuxIconPowerSettingsNew {
 export declare interface RuxIconPregnantWoman extends Components.RuxIconPregnantWoman {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14764,6 +15535,7 @@ export class RuxIconPregnantWoman {
 export declare interface RuxIconPresentToAll extends Components.RuxIconPresentToAll {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14784,6 +15556,7 @@ export class RuxIconPresentToAll {
 export declare interface RuxIconPrint extends Components.RuxIconPrint {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14804,6 +15577,7 @@ export class RuxIconPrint {
 export declare interface RuxIconPrintDisabled extends Components.RuxIconPrintDisabled {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14824,6 +15598,7 @@ export class RuxIconPrintDisabled {
 export declare interface RuxIconPriorityHigh extends Components.RuxIconPriorityHigh {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14844,6 +15619,7 @@ export class RuxIconPriorityHigh {
 export declare interface RuxIconProcessor extends Components.RuxIconProcessor {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14864,6 +15640,7 @@ export class RuxIconProcessor {
 export declare interface RuxIconProcessorAlt extends Components.RuxIconProcessorAlt {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14884,6 +15661,7 @@ export class RuxIconProcessorAlt {
 export declare interface RuxIconPropulsionPower extends Components.RuxIconPropulsionPower {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14904,6 +15682,7 @@ export class RuxIconPropulsionPower {
 export declare interface RuxIconPublic extends Components.RuxIconPublic {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14924,6 +15703,7 @@ export class RuxIconPublic {
 export declare interface RuxIconPublish extends Components.RuxIconPublish {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14944,6 +15724,7 @@ export class RuxIconPublish {
 export declare interface RuxIconQueryBuilder extends Components.RuxIconQueryBuilder {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14964,6 +15745,7 @@ export class RuxIconQueryBuilder {
 export declare interface RuxIconQuestionAnswer extends Components.RuxIconQuestionAnswer {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -14984,6 +15766,7 @@ export class RuxIconQuestionAnswer {
 export declare interface RuxIconQueue extends Components.RuxIconQueue {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15004,6 +15787,7 @@ export class RuxIconQueue {
 export declare interface RuxIconQueueMusic extends Components.RuxIconQueueMusic {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15024,6 +15808,7 @@ export class RuxIconQueueMusic {
 export declare interface RuxIconQueuePlayNext extends Components.RuxIconQueuePlayNext {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15044,6 +15829,7 @@ export class RuxIconQueuePlayNext {
 export declare interface RuxIconRadio extends Components.RuxIconRadio {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15064,6 +15850,7 @@ export class RuxIconRadio {
 export declare interface RuxIconRadioButtonChecked extends Components.RuxIconRadioButtonChecked {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15084,6 +15871,7 @@ export class RuxIconRadioButtonChecked {
 export declare interface RuxIconRadioButtonUnchecked extends Components.RuxIconRadioButtonUnchecked {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15104,6 +15892,7 @@ export class RuxIconRadioButtonUnchecked {
 export declare interface RuxIconRateReview extends Components.RuxIconRateReview {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15124,6 +15913,7 @@ export class RuxIconRateReview {
 export declare interface RuxIconReceipt extends Components.RuxIconReceipt {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15144,6 +15934,7 @@ export class RuxIconReceipt {
 export declare interface RuxIconRecentActors extends Components.RuxIconRecentActors {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15164,6 +15955,7 @@ export class RuxIconRecentActors {
 export declare interface RuxIconRecordVoiceOver extends Components.RuxIconRecordVoiceOver {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15184,6 +15976,7 @@ export class RuxIconRecordVoiceOver {
 export declare interface RuxIconRedeem extends Components.RuxIconRedeem {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15204,6 +15997,7 @@ export class RuxIconRedeem {
 export declare interface RuxIconRedo extends Components.RuxIconRedo {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15224,6 +16018,7 @@ export class RuxIconRedo {
 export declare interface RuxIconRefresh extends Components.RuxIconRefresh {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15244,6 +16039,7 @@ export class RuxIconRefresh {
 export declare interface RuxIconRemove extends Components.RuxIconRemove {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15264,6 +16060,7 @@ export class RuxIconRemove {
 export declare interface RuxIconRemoveCircle extends Components.RuxIconRemoveCircle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15284,6 +16081,7 @@ export class RuxIconRemoveCircle {
 export declare interface RuxIconRemoveCircleOutline extends Components.RuxIconRemoveCircleOutline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15304,6 +16102,7 @@ export class RuxIconRemoveCircleOutline {
 export declare interface RuxIconRemoveFromQueue extends Components.RuxIconRemoveFromQueue {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15324,6 +16123,7 @@ export class RuxIconRemoveFromQueue {
 export declare interface RuxIconRemoveRedEye extends Components.RuxIconRemoveRedEye {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15344,6 +16144,7 @@ export class RuxIconRemoveRedEye {
 export declare interface RuxIconRemoveShoppingCart extends Components.RuxIconRemoveShoppingCart {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15364,6 +16165,7 @@ export class RuxIconRemoveShoppingCart {
 export declare interface RuxIconReorder extends Components.RuxIconReorder {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15384,6 +16186,7 @@ export class RuxIconReorder {
 export declare interface RuxIconRepeat extends Components.RuxIconRepeat {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15404,6 +16207,7 @@ export class RuxIconRepeat {
 export declare interface RuxIconRepeatOne extends Components.RuxIconRepeatOne {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15424,6 +16228,7 @@ export class RuxIconRepeatOne {
 export declare interface RuxIconReplay extends Components.RuxIconReplay {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15444,6 +16249,7 @@ export class RuxIconReplay {
 export declare interface RuxIconReplay10 extends Components.RuxIconReplay10 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15464,6 +16270,7 @@ export class RuxIconReplay10 {
 export declare interface RuxIconReplay30 extends Components.RuxIconReplay30 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15484,6 +16291,7 @@ export class RuxIconReplay30 {
 export declare interface RuxIconReplay5 extends Components.RuxIconReplay5 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15504,6 +16312,7 @@ export class RuxIconReplay5 {
 export declare interface RuxIconReply extends Components.RuxIconReply {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15524,6 +16333,7 @@ export class RuxIconReply {
 export declare interface RuxIconReplyAll extends Components.RuxIconReplyAll {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15544,6 +16354,7 @@ export class RuxIconReplyAll {
 export declare interface RuxIconReport extends Components.RuxIconReport {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15564,6 +16375,7 @@ export class RuxIconReport {
 export declare interface RuxIconReportOff extends Components.RuxIconReportOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15584,6 +16396,7 @@ export class RuxIconReportOff {
 export declare interface RuxIconReportProblem extends Components.RuxIconReportProblem {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15604,6 +16417,7 @@ export class RuxIconReportProblem {
 export declare interface RuxIconRestaurant extends Components.RuxIconRestaurant {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15624,6 +16438,7 @@ export class RuxIconRestaurant {
 export declare interface RuxIconRestaurantMenu extends Components.RuxIconRestaurantMenu {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15644,6 +16459,7 @@ export class RuxIconRestaurantMenu {
 export declare interface RuxIconRestore extends Components.RuxIconRestore {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15664,6 +16480,7 @@ export class RuxIconRestore {
 export declare interface RuxIconRestoreFromTrash extends Components.RuxIconRestoreFromTrash {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15684,6 +16501,7 @@ export class RuxIconRestoreFromTrash {
 export declare interface RuxIconRestorePage extends Components.RuxIconRestorePage {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15704,6 +16522,7 @@ export class RuxIconRestorePage {
 export declare interface RuxIconRingVolume extends Components.RuxIconRingVolume {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15724,6 +16543,7 @@ export class RuxIconRingVolume {
 export declare interface RuxIconRoom extends Components.RuxIconRoom {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15744,6 +16564,7 @@ export class RuxIconRoom {
 export declare interface RuxIconRoomService extends Components.RuxIconRoomService {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15764,6 +16585,7 @@ export class RuxIconRoomService {
 export declare interface RuxIconRotate90DegreesCc extends Components.RuxIconRotate90DegreesCc {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15784,6 +16606,7 @@ export class RuxIconRotate90DegreesCc {
 export declare interface RuxIconRotateLeft extends Components.RuxIconRotateLeft {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15804,6 +16627,7 @@ export class RuxIconRotateLeft {
 export declare interface RuxIconRotateRight extends Components.RuxIconRotateRight {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15824,6 +16648,7 @@ export class RuxIconRotateRight {
 export declare interface RuxIconRoundedCorner extends Components.RuxIconRoundedCorner {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15844,6 +16669,7 @@ export class RuxIconRoundedCorner {
 export declare interface RuxIconRouter extends Components.RuxIconRouter {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15864,6 +16690,7 @@ export class RuxIconRouter {
 export declare interface RuxIconRowing extends Components.RuxIconRowing {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15884,6 +16711,7 @@ export class RuxIconRowing {
 export declare interface RuxIconRssFeed extends Components.RuxIconRssFeed {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15904,6 +16732,7 @@ export class RuxIconRssFeed {
 export declare interface RuxIconRvHookup extends Components.RuxIconRvHookup {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15924,6 +16753,7 @@ export class RuxIconRvHookup {
 export declare interface RuxIconSatellite extends Components.RuxIconSatellite {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15944,6 +16774,7 @@ export class RuxIconSatellite {
 export declare interface RuxIconSatelliteOff extends Components.RuxIconSatelliteOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15964,6 +16795,7 @@ export class RuxIconSatelliteOff {
 export declare interface RuxIconSatelliteReceive extends Components.RuxIconSatelliteReceive {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -15984,6 +16816,7 @@ export class RuxIconSatelliteReceive {
 export declare interface RuxIconSatelliteTransmit extends Components.RuxIconSatelliteTransmit {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16004,6 +16837,7 @@ export class RuxIconSatelliteTransmit {
 export declare interface RuxIconSave extends Components.RuxIconSave {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16024,6 +16858,7 @@ export class RuxIconSave {
 export declare interface RuxIconSaveAlt extends Components.RuxIconSaveAlt {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16044,6 +16879,7 @@ export class RuxIconSaveAlt {
 export declare interface RuxIconScanner extends Components.RuxIconScanner {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16064,6 +16900,7 @@ export class RuxIconScanner {
 export declare interface RuxIconScatterPlot extends Components.RuxIconScatterPlot {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16084,6 +16921,7 @@ export class RuxIconScatterPlot {
 export declare interface RuxIconSchedule extends Components.RuxIconSchedule {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16104,6 +16942,7 @@ export class RuxIconSchedule {
 export declare interface RuxIconSchool extends Components.RuxIconSchool {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16124,6 +16963,7 @@ export class RuxIconSchool {
 export declare interface RuxIconScore extends Components.RuxIconScore {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16144,6 +16984,7 @@ export class RuxIconScore {
 export declare interface RuxIconScreenLockLandscape extends Components.RuxIconScreenLockLandscape {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16164,6 +17005,7 @@ export class RuxIconScreenLockLandscape {
 export declare interface RuxIconScreenLockPortrait extends Components.RuxIconScreenLockPortrait {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16184,6 +17026,7 @@ export class RuxIconScreenLockPortrait {
 export declare interface RuxIconScreenLockRotation extends Components.RuxIconScreenLockRotation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16204,6 +17047,7 @@ export class RuxIconScreenLockRotation {
 export declare interface RuxIconScreenRotation extends Components.RuxIconScreenRotation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16224,6 +17068,7 @@ export class RuxIconScreenRotation {
 export declare interface RuxIconScreenShare extends Components.RuxIconScreenShare {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16244,6 +17089,7 @@ export class RuxIconScreenShare {
 export declare interface RuxIconSdCard extends Components.RuxIconSdCard {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16264,6 +17110,7 @@ export class RuxIconSdCard {
 export declare interface RuxIconSdStorage extends Components.RuxIconSdStorage {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16284,6 +17131,7 @@ export class RuxIconSdStorage {
 export declare interface RuxIconSearch extends Components.RuxIconSearch {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16304,6 +17152,7 @@ export class RuxIconSearch {
 export declare interface RuxIconSeat extends Components.RuxIconSeat {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16324,6 +17173,7 @@ export class RuxIconSeat {
 export declare interface RuxIconSecurity extends Components.RuxIconSecurity {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16344,6 +17194,7 @@ export class RuxIconSecurity {
 export declare interface RuxIconSelectAll extends Components.RuxIconSelectAll {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16364,6 +17215,7 @@ export class RuxIconSelectAll {
 export declare interface RuxIconSend extends Components.RuxIconSend {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16384,6 +17236,7 @@ export class RuxIconSend {
 export declare interface RuxIconSentimentDissatisfied extends Components.RuxIconSentimentDissatisfied {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16404,6 +17257,7 @@ export class RuxIconSentimentDissatisfied {
 export declare interface RuxIconSentimentSatisfied extends Components.RuxIconSentimentSatisfied {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16424,6 +17278,7 @@ export class RuxIconSentimentSatisfied {
 export declare interface RuxIconSentimentSatisfiedAlt extends Components.RuxIconSentimentSatisfiedAlt {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16444,6 +17299,7 @@ export class RuxIconSentimentSatisfiedAlt {
 export declare interface RuxIconSentimentVeryDissatisfied extends Components.RuxIconSentimentVeryDissatisfied {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16464,6 +17320,7 @@ export class RuxIconSentimentVeryDissatisfied {
 export declare interface RuxIconSentimentVerySatisfied extends Components.RuxIconSentimentVerySatisfied {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16484,6 +17341,7 @@ export class RuxIconSentimentVerySatisfied {
 export declare interface RuxIconSettings extends Components.RuxIconSettings {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16504,6 +17362,7 @@ export class RuxIconSettings {
 export declare interface RuxIconSettingsApplications extends Components.RuxIconSettingsApplications {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16524,6 +17383,7 @@ export class RuxIconSettingsApplications {
 export declare interface RuxIconSettingsBackupRestore extends Components.RuxIconSettingsBackupRestore {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16544,6 +17404,7 @@ export class RuxIconSettingsBackupRestore {
 export declare interface RuxIconSettingsBluetooth extends Components.RuxIconSettingsBluetooth {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16564,6 +17425,7 @@ export class RuxIconSettingsBluetooth {
 export declare interface RuxIconSettingsBrightness extends Components.RuxIconSettingsBrightness {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16584,6 +17446,7 @@ export class RuxIconSettingsBrightness {
 export declare interface RuxIconSettingsCell extends Components.RuxIconSettingsCell {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16604,6 +17467,7 @@ export class RuxIconSettingsCell {
 export declare interface RuxIconSettingsEthernet extends Components.RuxIconSettingsEthernet {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16624,6 +17488,7 @@ export class RuxIconSettingsEthernet {
 export declare interface RuxIconSettingsInputAntenna extends Components.RuxIconSettingsInputAntenna {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16644,6 +17509,7 @@ export class RuxIconSettingsInputAntenna {
 export declare interface RuxIconSettingsInputComponent extends Components.RuxIconSettingsInputComponent {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16664,6 +17530,7 @@ export class RuxIconSettingsInputComponent {
 export declare interface RuxIconSettingsInputComposite extends Components.RuxIconSettingsInputComposite {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16684,6 +17551,7 @@ export class RuxIconSettingsInputComposite {
 export declare interface RuxIconSettingsInputHdmi extends Components.RuxIconSettingsInputHdmi {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16704,6 +17572,7 @@ export class RuxIconSettingsInputHdmi {
 export declare interface RuxIconSettingsInputSvideo extends Components.RuxIconSettingsInputSvideo {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16724,6 +17593,7 @@ export class RuxIconSettingsInputSvideo {
 export declare interface RuxIconSettingsOverscan extends Components.RuxIconSettingsOverscan {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16744,6 +17614,7 @@ export class RuxIconSettingsOverscan {
 export declare interface RuxIconSettingsPhone extends Components.RuxIconSettingsPhone {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16764,6 +17635,7 @@ export class RuxIconSettingsPhone {
 export declare interface RuxIconSettingsPower extends Components.RuxIconSettingsPower {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16784,6 +17656,7 @@ export class RuxIconSettingsPower {
 export declare interface RuxIconSettingsRemote extends Components.RuxIconSettingsRemote {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16804,6 +17677,7 @@ export class RuxIconSettingsRemote {
 export declare interface RuxIconSettingsSystemDaydream extends Components.RuxIconSettingsSystemDaydream {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16824,6 +17698,7 @@ export class RuxIconSettingsSystemDaydream {
 export declare interface RuxIconSettingsVoice extends Components.RuxIconSettingsVoice {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16844,6 +17719,7 @@ export class RuxIconSettingsVoice {
 export declare interface RuxIconShare extends Components.RuxIconShare {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16864,6 +17740,7 @@ export class RuxIconShare {
 export declare interface RuxIconShop extends Components.RuxIconShop {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16884,6 +17761,7 @@ export class RuxIconShop {
 export declare interface RuxIconShopTwo extends Components.RuxIconShopTwo {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16904,6 +17782,7 @@ export class RuxIconShopTwo {
 export declare interface RuxIconShoppingBasket extends Components.RuxIconShoppingBasket {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16924,6 +17803,7 @@ export class RuxIconShoppingBasket {
 export declare interface RuxIconShoppingCart extends Components.RuxIconShoppingCart {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16944,6 +17824,7 @@ export class RuxIconShoppingCart {
 export declare interface RuxIconShortText extends Components.RuxIconShortText {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16964,6 +17845,7 @@ export class RuxIconShortText {
 export declare interface RuxIconShowChart extends Components.RuxIconShowChart {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -16984,6 +17866,7 @@ export class RuxIconShowChart {
 export declare interface RuxIconShuffle extends Components.RuxIconShuffle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17004,6 +17887,7 @@ export class RuxIconShuffle {
 export declare interface RuxIconShutterSpeed extends Components.RuxIconShutterSpeed {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17024,6 +17908,7 @@ export class RuxIconShutterSpeed {
 export declare interface RuxIconSignalCellular0Bar extends Components.RuxIconSignalCellular0Bar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17044,6 +17929,7 @@ export class RuxIconSignalCellular0Bar {
 export declare interface RuxIconSignalCellular1Bar extends Components.RuxIconSignalCellular1Bar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17064,6 +17950,7 @@ export class RuxIconSignalCellular1Bar {
 export declare interface RuxIconSignalCellular2Bar extends Components.RuxIconSignalCellular2Bar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17084,6 +17971,7 @@ export class RuxIconSignalCellular2Bar {
 export declare interface RuxIconSignalCellular3Bar extends Components.RuxIconSignalCellular3Bar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17104,6 +17992,7 @@ export class RuxIconSignalCellular3Bar {
 export declare interface RuxIconSignalCellular4Bar extends Components.RuxIconSignalCellular4Bar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17124,6 +18013,7 @@ export class RuxIconSignalCellular4Bar {
 export declare interface RuxIconSignalCellularAlt extends Components.RuxIconSignalCellularAlt {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17144,6 +18034,7 @@ export class RuxIconSignalCellularAlt {
 export declare interface RuxIconSignalCellularConnectedNoInternet0Bar extends Components.RuxIconSignalCellularConnectedNoInternet0Bar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17164,6 +18055,7 @@ export class RuxIconSignalCellularConnectedNoInternet0Bar {
 export declare interface RuxIconSignalCellularConnectedNoInternet1Bar extends Components.RuxIconSignalCellularConnectedNoInternet1Bar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17184,6 +18076,7 @@ export class RuxIconSignalCellularConnectedNoInternet1Bar {
 export declare interface RuxIconSignalCellularConnectedNoInternet2Bar extends Components.RuxIconSignalCellularConnectedNoInternet2Bar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17204,6 +18097,7 @@ export class RuxIconSignalCellularConnectedNoInternet2Bar {
 export declare interface RuxIconSignalCellularConnectedNoInternet3Bar extends Components.RuxIconSignalCellularConnectedNoInternet3Bar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17224,6 +18118,7 @@ export class RuxIconSignalCellularConnectedNoInternet3Bar {
 export declare interface RuxIconSignalCellularConnectedNoInternet4Bar extends Components.RuxIconSignalCellularConnectedNoInternet4Bar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17244,6 +18139,7 @@ export class RuxIconSignalCellularConnectedNoInternet4Bar {
 export declare interface RuxIconSignalCellularNoSim extends Components.RuxIconSignalCellularNoSim {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17264,6 +18160,7 @@ export class RuxIconSignalCellularNoSim {
 export declare interface RuxIconSignalCellularNull extends Components.RuxIconSignalCellularNull {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17284,6 +18181,7 @@ export class RuxIconSignalCellularNull {
 export declare interface RuxIconSignalCellularOff extends Components.RuxIconSignalCellularOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17304,6 +18202,7 @@ export class RuxIconSignalCellularOff {
 export declare interface RuxIconSignalWifi0Bar extends Components.RuxIconSignalWifi0Bar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17324,6 +18223,7 @@ export class RuxIconSignalWifi0Bar {
 export declare interface RuxIconSignalWifi1Bar extends Components.RuxIconSignalWifi1Bar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17344,6 +18244,7 @@ export class RuxIconSignalWifi1Bar {
 export declare interface RuxIconSignalWifi1BarLock extends Components.RuxIconSignalWifi1BarLock {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17364,6 +18265,7 @@ export class RuxIconSignalWifi1BarLock {
 export declare interface RuxIconSignalWifi2Bar extends Components.RuxIconSignalWifi2Bar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17384,6 +18286,7 @@ export class RuxIconSignalWifi2Bar {
 export declare interface RuxIconSignalWifi2BarLock extends Components.RuxIconSignalWifi2BarLock {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17404,6 +18307,7 @@ export class RuxIconSignalWifi2BarLock {
 export declare interface RuxIconSignalWifi3Bar extends Components.RuxIconSignalWifi3Bar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17424,6 +18328,7 @@ export class RuxIconSignalWifi3Bar {
 export declare interface RuxIconSignalWifi3BarLock extends Components.RuxIconSignalWifi3BarLock {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17444,6 +18349,7 @@ export class RuxIconSignalWifi3BarLock {
 export declare interface RuxIconSignalWifi4Bar extends Components.RuxIconSignalWifi4Bar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17464,6 +18370,7 @@ export class RuxIconSignalWifi4Bar {
 export declare interface RuxIconSignalWifi4BarLock extends Components.RuxIconSignalWifi4BarLock {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17484,6 +18391,7 @@ export class RuxIconSignalWifi4BarLock {
 export declare interface RuxIconSignalWifiOff extends Components.RuxIconSignalWifiOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17504,6 +18412,7 @@ export class RuxIconSignalWifiOff {
 export declare interface RuxIconSimCard extends Components.RuxIconSimCard {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17524,6 +18433,7 @@ export class RuxIconSimCard {
 export declare interface RuxIconSkipNext extends Components.RuxIconSkipNext {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17544,6 +18454,7 @@ export class RuxIconSkipNext {
 export declare interface RuxIconSkipPrevious extends Components.RuxIconSkipPrevious {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17564,6 +18475,7 @@ export class RuxIconSkipPrevious {
 export declare interface RuxIconSlideshow extends Components.RuxIconSlideshow {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17584,6 +18496,7 @@ export class RuxIconSlideshow {
 export declare interface RuxIconSlowMotionVideo extends Components.RuxIconSlowMotionVideo {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17604,6 +18517,7 @@ export class RuxIconSlowMotionVideo {
 export declare interface RuxIconSmartphone extends Components.RuxIconSmartphone {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17624,6 +18538,7 @@ export class RuxIconSmartphone {
 export declare interface RuxIconSmokeFree extends Components.RuxIconSmokeFree {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17644,6 +18559,7 @@ export class RuxIconSmokeFree {
 export declare interface RuxIconSmokingRooms extends Components.RuxIconSmokingRooms {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17664,6 +18580,7 @@ export class RuxIconSmokingRooms {
 export declare interface RuxIconSms extends Components.RuxIconSms {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17684,6 +18601,7 @@ export class RuxIconSms {
 export declare interface RuxIconSmsFailed extends Components.RuxIconSmsFailed {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17704,6 +18622,7 @@ export class RuxIconSmsFailed {
 export declare interface RuxIconSnooze extends Components.RuxIconSnooze {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17724,6 +18643,7 @@ export class RuxIconSnooze {
 export declare interface RuxIconSolar extends Components.RuxIconSolar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17744,6 +18664,7 @@ export class RuxIconSolar {
 export declare interface RuxIconSort extends Components.RuxIconSort {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17764,6 +18685,7 @@ export class RuxIconSort {
 export declare interface RuxIconSortByAlpha extends Components.RuxIconSortByAlpha {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17784,6 +18706,7 @@ export class RuxIconSortByAlpha {
 export declare interface RuxIconSpa extends Components.RuxIconSpa {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17804,6 +18727,7 @@ export class RuxIconSpa {
 export declare interface RuxIconSpaceBar extends Components.RuxIconSpaceBar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17824,6 +18748,7 @@ export class RuxIconSpaceBar {
 export declare interface RuxIconSpeaker extends Components.RuxIconSpeaker {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17844,6 +18769,7 @@ export class RuxIconSpeaker {
 export declare interface RuxIconSpeakerGroup extends Components.RuxIconSpeakerGroup {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17864,6 +18790,7 @@ export class RuxIconSpeakerGroup {
 export declare interface RuxIconSpeakerNotes extends Components.RuxIconSpeakerNotes {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17884,6 +18811,7 @@ export class RuxIconSpeakerNotes {
 export declare interface RuxIconSpeakerNotesOff extends Components.RuxIconSpeakerNotesOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17904,6 +18832,7 @@ export class RuxIconSpeakerNotesOff {
 export declare interface RuxIconSpeakerPhone extends Components.RuxIconSpeakerPhone {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17924,6 +18853,7 @@ export class RuxIconSpeakerPhone {
 export declare interface RuxIconSpellcheck extends Components.RuxIconSpellcheck {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17944,6 +18874,7 @@ export class RuxIconSpellcheck {
 export declare interface RuxIconStar extends Components.RuxIconStar {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17964,6 +18895,7 @@ export class RuxIconStar {
 export declare interface RuxIconStarBorder extends Components.RuxIconStarBorder {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -17984,6 +18916,7 @@ export class RuxIconStarBorder {
 export declare interface RuxIconStarHalf extends Components.RuxIconStarHalf {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18004,6 +18937,7 @@ export class RuxIconStarHalf {
 export declare interface RuxIconStarRate extends Components.RuxIconStarRate {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18024,6 +18958,7 @@ export class RuxIconStarRate {
 export declare interface RuxIconStars extends Components.RuxIconStars {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18044,6 +18979,7 @@ export class RuxIconStars {
 export declare interface RuxIconStayCurrentLandscape extends Components.RuxIconStayCurrentLandscape {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18064,6 +19000,7 @@ export class RuxIconStayCurrentLandscape {
 export declare interface RuxIconStayCurrentPortrait extends Components.RuxIconStayCurrentPortrait {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18084,6 +19021,7 @@ export class RuxIconStayCurrentPortrait {
 export declare interface RuxIconStayPrimaryLandscape extends Components.RuxIconStayPrimaryLandscape {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18104,6 +19042,7 @@ export class RuxIconStayPrimaryLandscape {
 export declare interface RuxIconStayPrimaryPortrait extends Components.RuxIconStayPrimaryPortrait {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18124,6 +19063,7 @@ export class RuxIconStayPrimaryPortrait {
 export declare interface RuxIconStop extends Components.RuxIconStop {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18144,6 +19084,7 @@ export class RuxIconStop {
 export declare interface RuxIconStopScreenShare extends Components.RuxIconStopScreenShare {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18164,6 +19105,7 @@ export class RuxIconStopScreenShare {
 export declare interface RuxIconStorage extends Components.RuxIconStorage {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18184,6 +19126,7 @@ export class RuxIconStorage {
 export declare interface RuxIconStore extends Components.RuxIconStore {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18204,6 +19147,7 @@ export class RuxIconStore {
 export declare interface RuxIconStoreMallDirectory extends Components.RuxIconStoreMallDirectory {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18224,6 +19168,7 @@ export class RuxIconStoreMallDirectory {
 export declare interface RuxIconStraighten extends Components.RuxIconStraighten {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18244,6 +19189,7 @@ export class RuxIconStraighten {
 export declare interface RuxIconStreetview extends Components.RuxIconStreetview {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18264,6 +19210,7 @@ export class RuxIconStreetview {
 export declare interface RuxIconStrikethroughS extends Components.RuxIconStrikethroughS {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18284,6 +19231,7 @@ export class RuxIconStrikethroughS {
 export declare interface RuxIconStyle extends Components.RuxIconStyle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18304,6 +19252,7 @@ export class RuxIconStyle {
 export declare interface RuxIconSubdirectoryArrowLeft extends Components.RuxIconSubdirectoryArrowLeft {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18324,6 +19273,7 @@ export class RuxIconSubdirectoryArrowLeft {
 export declare interface RuxIconSubdirectoryArrowRight extends Components.RuxIconSubdirectoryArrowRight {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18344,6 +19294,7 @@ export class RuxIconSubdirectoryArrowRight {
 export declare interface RuxIconSubject extends Components.RuxIconSubject {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18364,6 +19315,7 @@ export class RuxIconSubject {
 export declare interface RuxIconSubscriptions extends Components.RuxIconSubscriptions {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18384,6 +19336,7 @@ export class RuxIconSubscriptions {
 export declare interface RuxIconSubtitles extends Components.RuxIconSubtitles {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18404,6 +19357,7 @@ export class RuxIconSubtitles {
 export declare interface RuxIconSubway extends Components.RuxIconSubway {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18424,6 +19378,7 @@ export class RuxIconSubway {
 export declare interface RuxIconSupervisedUserCircle extends Components.RuxIconSupervisedUserCircle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18444,6 +19399,7 @@ export class RuxIconSupervisedUserCircle {
 export declare interface RuxIconSupervisorAccount extends Components.RuxIconSupervisorAccount {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18464,6 +19420,7 @@ export class RuxIconSupervisorAccount {
 export declare interface RuxIconSurroundSound extends Components.RuxIconSurroundSound {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18484,6 +19441,7 @@ export class RuxIconSurroundSound {
 export declare interface RuxIconSwapCalls extends Components.RuxIconSwapCalls {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18504,6 +19462,7 @@ export class RuxIconSwapCalls {
 export declare interface RuxIconSwapHoriz extends Components.RuxIconSwapHoriz {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18524,6 +19483,7 @@ export class RuxIconSwapHoriz {
 export declare interface RuxIconSwapHorizontalCircle extends Components.RuxIconSwapHorizontalCircle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18544,6 +19504,7 @@ export class RuxIconSwapHorizontalCircle {
 export declare interface RuxIconSwapVert extends Components.RuxIconSwapVert {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18564,6 +19525,7 @@ export class RuxIconSwapVert {
 export declare interface RuxIconSwapVerticalCircle extends Components.RuxIconSwapVerticalCircle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18584,6 +19546,7 @@ export class RuxIconSwapVerticalCircle {
 export declare interface RuxIconSwitchCamera extends Components.RuxIconSwitchCamera {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18604,6 +19567,7 @@ export class RuxIconSwitchCamera {
 export declare interface RuxIconSwitchVideo extends Components.RuxIconSwitchVideo {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18624,6 +19588,7 @@ export class RuxIconSwitchVideo {
 export declare interface RuxIconSync extends Components.RuxIconSync {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18644,6 +19609,7 @@ export class RuxIconSync {
 export declare interface RuxIconSyncDisabled extends Components.RuxIconSyncDisabled {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18664,6 +19630,7 @@ export class RuxIconSyncDisabled {
 export declare interface RuxIconSyncProblem extends Components.RuxIconSyncProblem {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18684,6 +19651,7 @@ export class RuxIconSyncProblem {
 export declare interface RuxIconSystemUpdate extends Components.RuxIconSystemUpdate {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18704,6 +19672,7 @@ export class RuxIconSystemUpdate {
 export declare interface RuxIconTab extends Components.RuxIconTab {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18724,6 +19693,7 @@ export class RuxIconTab {
 export declare interface RuxIconTabUnselected extends Components.RuxIconTabUnselected {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18744,6 +19714,7 @@ export class RuxIconTabUnselected {
 export declare interface RuxIconTableChart extends Components.RuxIconTableChart {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18764,6 +19735,7 @@ export class RuxIconTableChart {
 export declare interface RuxIconTablet extends Components.RuxIconTablet {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18784,6 +19756,7 @@ export class RuxIconTablet {
 export declare interface RuxIconTabletAndroid extends Components.RuxIconTabletAndroid {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18804,6 +19777,7 @@ export class RuxIconTabletAndroid {
 export declare interface RuxIconTabletMac extends Components.RuxIconTabletMac {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18824,6 +19798,7 @@ export class RuxIconTabletMac {
 export declare interface RuxIconTagFaces extends Components.RuxIconTagFaces {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18844,6 +19819,7 @@ export class RuxIconTagFaces {
 export declare interface RuxIconTapAndPlay extends Components.RuxIconTapAndPlay {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18864,6 +19840,7 @@ export class RuxIconTapAndPlay {
 export declare interface RuxIconTerrain extends Components.RuxIconTerrain {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18884,6 +19861,7 @@ export class RuxIconTerrain {
 export declare interface RuxIconTextFields extends Components.RuxIconTextFields {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18904,6 +19882,7 @@ export class RuxIconTextFields {
 export declare interface RuxIconTextFormat extends Components.RuxIconTextFormat {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18924,6 +19903,7 @@ export class RuxIconTextFormat {
 export declare interface RuxIconTextRotateUp extends Components.RuxIconTextRotateUp {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18944,6 +19924,7 @@ export class RuxIconTextRotateUp {
 export declare interface RuxIconTextRotateVertical extends Components.RuxIconTextRotateVertical {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18964,6 +19945,7 @@ export class RuxIconTextRotateVertical {
 export declare interface RuxIconTextRotationNone extends Components.RuxIconTextRotationNone {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -18984,6 +19966,7 @@ export class RuxIconTextRotationNone {
 export declare interface RuxIconTextsms extends Components.RuxIconTextsms {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19004,6 +19987,7 @@ export class RuxIconTextsms {
 export declare interface RuxIconTexture extends Components.RuxIconTexture {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19024,6 +20008,7 @@ export class RuxIconTexture {
 export declare interface RuxIconTheaters extends Components.RuxIconTheaters {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19044,6 +20029,7 @@ export class RuxIconTheaters {
 export declare interface RuxIconThermal extends Components.RuxIconThermal {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19064,6 +20050,7 @@ export class RuxIconThermal {
 export declare interface RuxIconThumbDown extends Components.RuxIconThumbDown {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19084,6 +20071,7 @@ export class RuxIconThumbDown {
 export declare interface RuxIconThumbDownAlt extends Components.RuxIconThumbDownAlt {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19104,6 +20092,7 @@ export class RuxIconThumbDownAlt {
 export declare interface RuxIconThumbUp extends Components.RuxIconThumbUp {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19124,6 +20113,7 @@ export class RuxIconThumbUp {
 export declare interface RuxIconThumbUpAlt extends Components.RuxIconThumbUpAlt {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19144,6 +20134,7 @@ export class RuxIconThumbUpAlt {
 export declare interface RuxIconThumbsUpDown extends Components.RuxIconThumbsUpDown {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19164,6 +20155,7 @@ export class RuxIconThumbsUpDown {
 export declare interface RuxIconTimeToLeave extends Components.RuxIconTimeToLeave {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19184,6 +20176,7 @@ export class RuxIconTimeToLeave {
 export declare interface RuxIconTimelapse extends Components.RuxIconTimelapse {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19204,6 +20197,7 @@ export class RuxIconTimelapse {
 export declare interface RuxIconTimeline extends Components.RuxIconTimeline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19224,6 +20218,7 @@ export class RuxIconTimeline {
 export declare interface RuxIconTimer extends Components.RuxIconTimer {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19244,6 +20239,7 @@ export class RuxIconTimer {
 export declare interface RuxIconTimer10 extends Components.RuxIconTimer10 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19264,6 +20260,7 @@ export class RuxIconTimer10 {
 export declare interface RuxIconTimer3 extends Components.RuxIconTimer3 {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19284,6 +20281,7 @@ export class RuxIconTimer3 {
 export declare interface RuxIconTimerOff extends Components.RuxIconTimerOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19304,6 +20302,7 @@ export class RuxIconTimerOff {
 export declare interface RuxIconTitle extends Components.RuxIconTitle {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19324,6 +20323,7 @@ export class RuxIconTitle {
 export declare interface RuxIconToc extends Components.RuxIconToc {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19344,6 +20344,7 @@ export class RuxIconToc {
 export declare interface RuxIconToday extends Components.RuxIconToday {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19364,6 +20365,7 @@ export class RuxIconToday {
 export declare interface RuxIconToggleOff extends Components.RuxIconToggleOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19384,6 +20386,7 @@ export class RuxIconToggleOff {
 export declare interface RuxIconToggleOn extends Components.RuxIconToggleOn {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19404,6 +20407,7 @@ export class RuxIconToggleOn {
 export declare interface RuxIconToll extends Components.RuxIconToll {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19424,6 +20428,7 @@ export class RuxIconToll {
 export declare interface RuxIconTonality extends Components.RuxIconTonality {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19444,6 +20449,7 @@ export class RuxIconTonality {
 export declare interface RuxIconTouchApp extends Components.RuxIconTouchApp {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19464,6 +20470,7 @@ export class RuxIconTouchApp {
 export declare interface RuxIconToys extends Components.RuxIconToys {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19484,6 +20491,7 @@ export class RuxIconToys {
 export declare interface RuxIconTrackChanges extends Components.RuxIconTrackChanges {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19504,6 +20512,7 @@ export class RuxIconTrackChanges {
 export declare interface RuxIconTraffic extends Components.RuxIconTraffic {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19524,6 +20533,7 @@ export class RuxIconTraffic {
 export declare interface RuxIconTrain extends Components.RuxIconTrain {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19544,6 +20554,7 @@ export class RuxIconTrain {
 export declare interface RuxIconTram extends Components.RuxIconTram {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19564,6 +20575,7 @@ export class RuxIconTram {
 export declare interface RuxIconTransferWithinAStation extends Components.RuxIconTransferWithinAStation {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19584,6 +20596,7 @@ export class RuxIconTransferWithinAStation {
 export declare interface RuxIconTransform extends Components.RuxIconTransform {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19604,6 +20617,7 @@ export class RuxIconTransform {
 export declare interface RuxIconTransitEnterexit extends Components.RuxIconTransitEnterexit {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19624,6 +20638,7 @@ export class RuxIconTransitEnterexit {
 export declare interface RuxIconTranslate extends Components.RuxIconTranslate {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19644,6 +20659,7 @@ export class RuxIconTranslate {
 export declare interface RuxIconTrendingDown extends Components.RuxIconTrendingDown {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19664,6 +20680,7 @@ export class RuxIconTrendingDown {
 export declare interface RuxIconTrendingFlat extends Components.RuxIconTrendingFlat {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19684,6 +20701,7 @@ export class RuxIconTrendingFlat {
 export declare interface RuxIconTrendingUp extends Components.RuxIconTrendingUp {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19704,6 +20722,7 @@ export class RuxIconTrendingUp {
 export declare interface RuxIconTripOrigin extends Components.RuxIconTripOrigin {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19724,6 +20743,7 @@ export class RuxIconTripOrigin {
 export declare interface RuxIconTune extends Components.RuxIconTune {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19744,6 +20764,7 @@ export class RuxIconTune {
 export declare interface RuxIconTurnedIn extends Components.RuxIconTurnedIn {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19764,6 +20785,7 @@ export class RuxIconTurnedIn {
 export declare interface RuxIconTurnedInNot extends Components.RuxIconTurnedInNot {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19784,6 +20806,7 @@ export class RuxIconTurnedInNot {
 export declare interface RuxIconTv extends Components.RuxIconTv {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19804,6 +20827,7 @@ export class RuxIconTv {
 export declare interface RuxIconTvOff extends Components.RuxIconTvOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19824,6 +20848,7 @@ export class RuxIconTvOff {
 export declare interface RuxIconUnarchive extends Components.RuxIconUnarchive {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19844,6 +20869,7 @@ export class RuxIconUnarchive {
 export declare interface RuxIconUndo extends Components.RuxIconUndo {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19864,6 +20890,7 @@ export class RuxIconUndo {
 export declare interface RuxIconUnfoldLess extends Components.RuxIconUnfoldLess {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19884,6 +20911,7 @@ export class RuxIconUnfoldLess {
 export declare interface RuxIconUnfoldMore extends Components.RuxIconUnfoldMore {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19904,6 +20932,7 @@ export class RuxIconUnfoldMore {
 export declare interface RuxIconUnsubscribe extends Components.RuxIconUnsubscribe {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19924,6 +20953,7 @@ export class RuxIconUnsubscribe {
 export declare interface RuxIconUpdate extends Components.RuxIconUpdate {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19944,6 +20974,7 @@ export class RuxIconUpdate {
 export declare interface RuxIconUsb extends Components.RuxIconUsb {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19964,6 +20995,7 @@ export class RuxIconUsb {
 export declare interface RuxIconVerifiedUser extends Components.RuxIconVerifiedUser {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -19984,6 +21016,7 @@ export class RuxIconVerifiedUser {
 export declare interface RuxIconVerticalAlignBottom extends Components.RuxIconVerticalAlignBottom {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20004,6 +21037,7 @@ export class RuxIconVerticalAlignBottom {
 export declare interface RuxIconVerticalAlignCenter extends Components.RuxIconVerticalAlignCenter {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20024,6 +21058,7 @@ export class RuxIconVerticalAlignCenter {
 export declare interface RuxIconVerticalAlignTop extends Components.RuxIconVerticalAlignTop {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20044,6 +21079,7 @@ export class RuxIconVerticalAlignTop {
 export declare interface RuxIconVerticalSplit extends Components.RuxIconVerticalSplit {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20064,6 +21100,7 @@ export class RuxIconVerticalSplit {
 export declare interface RuxIconVibration extends Components.RuxIconVibration {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20084,6 +21121,7 @@ export class RuxIconVibration {
 export declare interface RuxIconVideoCall extends Components.RuxIconVideoCall {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20104,6 +21142,7 @@ export class RuxIconVideoCall {
 export declare interface RuxIconVideoLabel extends Components.RuxIconVideoLabel {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20124,6 +21163,7 @@ export class RuxIconVideoLabel {
 export declare interface RuxIconVideoLibrary extends Components.RuxIconVideoLibrary {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20144,6 +21184,7 @@ export class RuxIconVideoLibrary {
 export declare interface RuxIconVideocam extends Components.RuxIconVideocam {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20164,6 +21205,7 @@ export class RuxIconVideocam {
 export declare interface RuxIconVideocamOff extends Components.RuxIconVideocamOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20184,6 +21226,7 @@ export class RuxIconVideocamOff {
 export declare interface RuxIconVideogameAsset extends Components.RuxIconVideogameAsset {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20204,6 +21247,7 @@ export class RuxIconVideogameAsset {
 export declare interface RuxIconViewAgenda extends Components.RuxIconViewAgenda {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20224,6 +21268,7 @@ export class RuxIconViewAgenda {
 export declare interface RuxIconViewArray extends Components.RuxIconViewArray {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20244,6 +21289,7 @@ export class RuxIconViewArray {
 export declare interface RuxIconViewCarousel extends Components.RuxIconViewCarousel {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20264,6 +21310,7 @@ export class RuxIconViewCarousel {
 export declare interface RuxIconViewColumn extends Components.RuxIconViewColumn {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20284,6 +21331,7 @@ export class RuxIconViewColumn {
 export declare interface RuxIconViewComfy extends Components.RuxIconViewComfy {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20304,6 +21352,7 @@ export class RuxIconViewComfy {
 export declare interface RuxIconViewCompact extends Components.RuxIconViewCompact {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20324,6 +21373,7 @@ export class RuxIconViewCompact {
 export declare interface RuxIconViewDay extends Components.RuxIconViewDay {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20344,6 +21394,7 @@ export class RuxIconViewDay {
 export declare interface RuxIconViewHeadline extends Components.RuxIconViewHeadline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20364,6 +21415,7 @@ export class RuxIconViewHeadline {
 export declare interface RuxIconViewList extends Components.RuxIconViewList {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20384,6 +21436,7 @@ export class RuxIconViewList {
 export declare interface RuxIconViewModule extends Components.RuxIconViewModule {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20404,6 +21457,7 @@ export class RuxIconViewModule {
 export declare interface RuxIconViewQuilt extends Components.RuxIconViewQuilt {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20424,6 +21478,7 @@ export class RuxIconViewQuilt {
 export declare interface RuxIconViewStream extends Components.RuxIconViewStream {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20444,6 +21499,7 @@ export class RuxIconViewStream {
 export declare interface RuxIconViewWeek extends Components.RuxIconViewWeek {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20464,6 +21520,7 @@ export class RuxIconViewWeek {
 export declare interface RuxIconVignette extends Components.RuxIconVignette {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20484,6 +21541,7 @@ export class RuxIconVignette {
 export declare interface RuxIconVisibility extends Components.RuxIconVisibility {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20504,6 +21562,7 @@ export class RuxIconVisibility {
 export declare interface RuxIconVisibilityOff extends Components.RuxIconVisibilityOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20524,6 +21583,7 @@ export class RuxIconVisibilityOff {
 export declare interface RuxIconVoiceChat extends Components.RuxIconVoiceChat {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20544,6 +21604,7 @@ export class RuxIconVoiceChat {
 export declare interface RuxIconVoiceOverOff extends Components.RuxIconVoiceOverOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20564,6 +21625,7 @@ export class RuxIconVoiceOverOff {
 export declare interface RuxIconVoicemail extends Components.RuxIconVoicemail {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20584,6 +21646,7 @@ export class RuxIconVoicemail {
 export declare interface RuxIconVolumeDown extends Components.RuxIconVolumeDown {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20604,6 +21667,7 @@ export class RuxIconVolumeDown {
 export declare interface RuxIconVolumeMute extends Components.RuxIconVolumeMute {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20624,6 +21688,7 @@ export class RuxIconVolumeMute {
 export declare interface RuxIconVolumeOff extends Components.RuxIconVolumeOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20644,6 +21709,7 @@ export class RuxIconVolumeOff {
 export declare interface RuxIconVolumeUp extends Components.RuxIconVolumeUp {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20664,6 +21730,7 @@ export class RuxIconVolumeUp {
 export declare interface RuxIconVpnKey extends Components.RuxIconVpnKey {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20684,6 +21751,7 @@ export class RuxIconVpnKey {
 export declare interface RuxIconVpnLock extends Components.RuxIconVpnLock {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20704,6 +21772,7 @@ export class RuxIconVpnLock {
 export declare interface RuxIconWallpaper extends Components.RuxIconWallpaper {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20724,6 +21793,7 @@ export class RuxIconWallpaper {
 export declare interface RuxIconWarning extends Components.RuxIconWarning {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20744,6 +21814,7 @@ export class RuxIconWarning {
 export declare interface RuxIconWatch extends Components.RuxIconWatch {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20764,6 +21835,7 @@ export class RuxIconWatch {
 export declare interface RuxIconWatchLater extends Components.RuxIconWatchLater {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20784,6 +21856,7 @@ export class RuxIconWatchLater {
 export declare interface RuxIconWaves extends Components.RuxIconWaves {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20804,6 +21877,7 @@ export class RuxIconWaves {
 export declare interface RuxIconWbAuto extends Components.RuxIconWbAuto {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20824,6 +21898,7 @@ export class RuxIconWbAuto {
 export declare interface RuxIconWbCloudy extends Components.RuxIconWbCloudy {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20844,6 +21919,7 @@ export class RuxIconWbCloudy {
 export declare interface RuxIconWbIncandescent extends Components.RuxIconWbIncandescent {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20864,6 +21940,7 @@ export class RuxIconWbIncandescent {
 export declare interface RuxIconWbIridescent extends Components.RuxIconWbIridescent {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20884,6 +21961,7 @@ export class RuxIconWbIridescent {
 export declare interface RuxIconWbSunny extends Components.RuxIconWbSunny {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20904,6 +21982,7 @@ export class RuxIconWbSunny {
 export declare interface RuxIconWc extends Components.RuxIconWc {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20924,6 +22003,7 @@ export class RuxIconWc {
 export declare interface RuxIconWeb extends Components.RuxIconWeb {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20944,6 +22024,7 @@ export class RuxIconWeb {
 export declare interface RuxIconWebAsset extends Components.RuxIconWebAsset {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20964,6 +22045,7 @@ export class RuxIconWebAsset {
 export declare interface RuxIconWeekend extends Components.RuxIconWeekend {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -20984,6 +22066,7 @@ export class RuxIconWeekend {
 export declare interface RuxIconWhatshot extends Components.RuxIconWhatshot {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21004,6 +22087,7 @@ export class RuxIconWhatshot {
 export declare interface RuxIconWhereToVote extends Components.RuxIconWhereToVote {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21024,6 +22108,7 @@ export class RuxIconWhereToVote {
 export declare interface RuxIconWidgets extends Components.RuxIconWidgets {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21044,6 +22129,7 @@ export class RuxIconWidgets {
 export declare interface RuxIconWifi extends Components.RuxIconWifi {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21064,6 +22150,7 @@ export class RuxIconWifi {
 export declare interface RuxIconWifiLock extends Components.RuxIconWifiLock {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21084,6 +22171,7 @@ export class RuxIconWifiLock {
 export declare interface RuxIconWifiOff extends Components.RuxIconWifiOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21104,6 +22192,7 @@ export class RuxIconWifiOff {
 export declare interface RuxIconWifiTethering extends Components.RuxIconWifiTethering {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21124,6 +22213,7 @@ export class RuxIconWifiTethering {
 export declare interface RuxIconWork extends Components.RuxIconWork {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21144,6 +22234,7 @@ export class RuxIconWork {
 export declare interface RuxIconWorkOff extends Components.RuxIconWorkOff {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21164,6 +22255,7 @@ export class RuxIconWorkOff {
 export declare interface RuxIconWorkOutline extends Components.RuxIconWorkOutline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21184,6 +22276,7 @@ export class RuxIconWorkOutline {
 export declare interface RuxIconWrapText extends Components.RuxIconWrapText {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21204,6 +22297,7 @@ export class RuxIconWrapText {
 export declare interface RuxIconYoutubeSearchedFor extends Components.RuxIconYoutubeSearchedFor {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21224,6 +22318,7 @@ export class RuxIconYoutubeSearchedFor {
 export declare interface RuxIconZoomIn extends Components.RuxIconZoomIn {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21244,6 +22339,7 @@ export class RuxIconZoomIn {
 export declare interface RuxIconZoomInMap extends Components.RuxIconZoomInMap {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21264,6 +22360,7 @@ export class RuxIconZoomInMap {
 export declare interface RuxIconZoomOut extends Components.RuxIconZoomOut {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21284,6 +22381,7 @@ export class RuxIconZoomOut {
 export declare interface RuxIconZoomOutMap extends Components.RuxIconZoomOutMap {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['size']
 })
 @Component({
@@ -21322,6 +22420,7 @@ export declare interface RuxInput extends Components.RuxInput {
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['autocomplete', 'disabled', 'errorText', 'helpText', 'invalid', 'label', 'max', 'min', 'name', 'placeholder', 'readonly', 'required', 'size', 'spellcheck', 'step', 'type', 'value']
 })
 @Component({
@@ -21343,6 +22442,7 @@ export class RuxInput {
 export declare interface RuxLog extends Components.RuxLog {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['data', 'filter', 'timezone']
 })
 @Component({
@@ -21369,6 +22469,7 @@ export declare interface RuxMenuItem extends Components.RuxMenuItem {
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['disabled', 'download', 'href', 'rel', 'target', 'value']
 })
 @Component({
@@ -21389,7 +22490,9 @@ export class RuxMenuItem {
 
 export declare interface RuxMenuItemDivider extends Components.RuxMenuItemDivider {}
 
-
+@ProxyCmp({
+  defineCustomElementFn: undefined
+})
 @Component({
   selector: 'rux-menu-item-divider',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21417,6 +22520,7 @@ export declare interface RuxModal extends Components.RuxModal {
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['confirmText', 'denyText', 'modalMessage', 'modalTitle', 'open']
 })
 @Component({
@@ -21438,6 +22542,7 @@ export class RuxModal {
 export declare interface RuxMonitoringIcon extends Components.RuxMonitoringIcon {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['icon', 'label', 'notifications', 'status', 'sublabel']
 })
 @Component({
@@ -21458,6 +22563,7 @@ export class RuxMonitoringIcon {
 export declare interface RuxMonitoringProgressIcon extends Components.RuxMonitoringProgressIcon {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['label', 'max', 'min', 'notifications', 'progress', 'range', 'sublabel']
 })
 @Component({
@@ -21484,6 +22590,7 @@ export declare interface RuxNotification extends Components.RuxNotification {
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['closeAfter', 'message', 'open', 'small', 'status']
 })
 @Component({
@@ -21505,6 +22612,7 @@ export class RuxNotification {
 export declare interface RuxOption extends Components.RuxOption {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['disabled', 'label', 'value']
 })
 @Component({
@@ -21525,6 +22633,7 @@ export class RuxOption {
 export declare interface RuxOptionGroup extends Components.RuxOptionGroup {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['label']
 })
 @Component({
@@ -21563,6 +22672,7 @@ export declare interface RuxPopUpMenu extends Components.RuxPopUpMenu {
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['anchorEl', 'open', 'triggerEl'],
   methods: ['isOpen', 'show', 'close', 'toggle']
 })
@@ -21585,6 +22695,7 @@ export class RuxPopUpMenu {
 export declare interface RuxProgress extends Components.RuxProgress {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['hideLabel', 'max', 'value']
 })
 @Component({
@@ -21615,6 +22726,7 @@ export declare interface RuxPushButton extends Components.RuxPushButton {
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['checked', 'disabled', 'icon', 'iconOnly', 'label', 'name', 'size', 'value']
 })
 @Component({
@@ -21642,6 +22754,7 @@ export declare interface RuxRadio extends Components.RuxRadio {
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['checked', 'disabled', 'label', 'name', 'value']
 })
 @Component({
@@ -21669,6 +22782,7 @@ export declare interface RuxRadioGroup extends Components.RuxRadioGroup {
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['errorText', 'helpText', 'invalid', 'label', 'name', 'required', 'value']
 })
 @Component({
@@ -21689,7 +22803,9 @@ export class RuxRadioGroup {
 
 export declare interface RuxRuler extends Components.RuxRuler {}
 
-
+@ProxyCmp({
+  defineCustomElementFn: undefined
+})
 @Component({
   selector: 'rux-ruler',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21713,6 +22829,7 @@ export declare interface RuxSegmentedButton extends Components.RuxSegmentedButto
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['data', 'disabled', 'selected', 'size']
 })
 @Component({
@@ -21744,6 +22861,7 @@ export declare interface RuxSelect extends Components.RuxSelect {
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['disabled', 'errorText', 'helpText', 'inputId', 'invalid', 'label', 'labelId', 'multiple', 'name', 'required', 'size', 'value']
 })
 @Component({
@@ -21775,6 +22893,7 @@ export declare interface RuxSlider extends Components.RuxSlider {
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['axisLabels', 'disabled', 'errorText', 'helpText', 'label', 'max', 'min', 'name', 'step', 'ticksOnly', 'value']
 })
 @Component({
@@ -21796,6 +22915,7 @@ export class RuxSlider {
 export declare interface RuxStatus extends Components.RuxStatus {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['status']
 })
 @Component({
@@ -21830,6 +22950,7 @@ export declare interface RuxSwitch extends Components.RuxSwitch {
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['checked', 'disabled', 'label', 'name', 'value']
 })
 @Component({
@@ -21851,6 +22972,7 @@ export class RuxSwitch {
 export declare interface RuxTab extends Components.RuxTab {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['disabled', 'selected']
 })
 @Component({
@@ -21870,7 +22992,9 @@ export class RuxTab {
 
 export declare interface RuxTabPanel extends Components.RuxTabPanel {}
 
-
+@ProxyCmp({
+  defineCustomElementFn: undefined
+})
 @Component({
   selector: 'rux-tab-panel',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21893,7 +23017,9 @@ export declare interface RuxTabPanels extends Components.RuxTabPanels {
 
 }
 
-
+@ProxyCmp({
+  defineCustomElementFn: undefined
+})
 @Component({
   selector: 'rux-tab-panels',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21911,7 +23037,9 @@ export class RuxTabPanels {
 
 export declare interface RuxTable extends Components.RuxTable {}
 
-
+@ProxyCmp({
+  defineCustomElementFn: undefined
+})
 @Component({
   selector: 'rux-table',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21928,7 +23056,9 @@ export class RuxTable {
 
 export declare interface RuxTableBody extends Components.RuxTableBody {}
 
-
+@ProxyCmp({
+  defineCustomElementFn: undefined
+})
 @Component({
   selector: 'rux-table-body',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21945,7 +23075,9 @@ export class RuxTableBody {
 
 export declare interface RuxTableCell extends Components.RuxTableCell {}
 
-
+@ProxyCmp({
+  defineCustomElementFn: undefined
+})
 @Component({
   selector: 'rux-table-cell',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21962,7 +23094,9 @@ export class RuxTableCell {
 
 export declare interface RuxTableHeader extends Components.RuxTableHeader {}
 
-
+@ProxyCmp({
+  defineCustomElementFn: undefined
+})
 @Component({
   selector: 'rux-table-header',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21979,7 +23113,9 @@ export class RuxTableHeader {
 
 export declare interface RuxTableHeaderCell extends Components.RuxTableHeaderCell {}
 
-
+@ProxyCmp({
+  defineCustomElementFn: undefined
+})
 @Component({
   selector: 'rux-table-header-cell',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21996,7 +23132,9 @@ export class RuxTableHeaderCell {
 
 export declare interface RuxTableHeaderRow extends Components.RuxTableHeaderRow {}
 
-
+@ProxyCmp({
+  defineCustomElementFn: undefined
+})
 @Component({
   selector: 'rux-table-header-row',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -22014,6 +23152,7 @@ export class RuxTableHeaderRow {
 export declare interface RuxTableRow extends Components.RuxTableRow {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['selected']
 })
 @Component({
@@ -22040,6 +23179,7 @@ export declare interface RuxTabs extends Components.RuxTabs {
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['small']
 })
 @Component({
@@ -22061,6 +23201,7 @@ export class RuxTabs {
 export declare interface RuxTag extends Components.RuxTag {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['status']
 })
 @Component({
@@ -22095,6 +23236,7 @@ export declare interface RuxTextarea extends Components.RuxTextarea {
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['disabled', 'errorText', 'helpText', 'invalid', 'label', 'maxLength', 'minLength', 'name', 'placeholder', 'required', 'rows', 'size', 'value']
 })
 @Component({
@@ -22116,6 +23258,7 @@ export class RuxTextarea {
 export declare interface RuxTimeRegion extends Components.RuxTimeRegion {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['end', 'hideTimestamp', 'selected', 'start', 'status']
 })
 @Component({
@@ -22136,6 +23279,7 @@ export class RuxTimeRegion {
 export declare interface RuxTimeline extends Components.RuxTimeline {}
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['end', 'interval', 'playhead', 'start', 'timezone', 'zoom']
 })
 @Component({
@@ -22155,7 +23299,9 @@ export class RuxTimeline {
 
 export declare interface RuxTrack extends Components.RuxTrack {}
 
-
+@ProxyCmp({
+  defineCustomElementFn: undefined
+})
 @Component({
   selector: 'rux-track',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -22172,7 +23318,9 @@ export class RuxTrack {
 
 export declare interface RuxTree extends Components.RuxTree {}
 
-
+@ProxyCmp({
+  defineCustomElementFn: undefined
+})
 @Component({
   selector: 'rux-tree',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -22196,6 +23344,7 @@ export declare interface RuxTreeNode extends Components.RuxTreeNode {
 }
 
 @ProxyCmp({
+  defineCustomElementFn: undefined,
   inputs: ['expanded', 'selected'],
   methods: ['setExpanded', 'setSelected']
 })

--- a/packages/react/src/components.tsx
+++ b/packages/react/src/components.tsx
@@ -39,6 +39,10 @@ export const RuxDatetime = /*@__PURE__*/ createReactComponent<
   JSX.RuxDatetime,
   HTMLRuxDatetimeElement
 >("rux-datetime");
+export const RuxDialog = /*@__PURE__*/ createReactComponent<
+  JSX.RuxDialog,
+  HTMLRuxDialogElement
+>("rux-dialog");
 export const RuxGlobalStatusBar = /*@__PURE__*/ createReactComponent<
   JSX.RuxGlobalStatusBar,
   HTMLRuxGlobalStatusBarElement

--- a/packages/web-components/.storybook/preview-head.html
+++ b/packages/web-components/.storybook/preview-head.html
@@ -60,11 +60,13 @@
         color: var(--color-text-primary);
     }
 
+    .sbdocs #story--components-dialog--dialog,
     .sbdocs #story--components-modal--modal {
         display: block;
         min-height: 500px;
     }
 
+    .sbdocs #story--components-dialog--dialog rux-dialog::part(container),
     .sbdocs #story--components-modal--modal rux-modal::part(wrapper) {
         position: absolute;
         top: 0px;
@@ -73,11 +75,13 @@
         height: 100%;
     }
 
+    .sbdocs #story--components-dialog--with-slots,
     .sbdocs #story--components-modal--with-slots {
         display: block;
         min-height: 500px;
     }
 
+    .sbdocs #story--components-dialog--with-slots rux-dialog::part(container),
     .sbdocs #story--components-modal--with-slots rux-modal::part(wrapper) {
         position: absolute;
         top: 0px;

--- a/packages/web-components/cypress/support/index.js
+++ b/packages/web-components/cypress/support/index.js
@@ -35,7 +35,7 @@ Cypress.on('window:before:load', (win) => {
         throw new Error(msg)
     })
 
-    cy.stub(win.console, 'warn', (msg) => {
-        cy.now('task', 'warn', msg)
-    })
+    // cy.stub(win.console, 'warn', (msg) => {
+    //     cy.now('task', 'warn', msg)
+    // })
 })

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -204,6 +204,28 @@ export namespace Components {
          */
         "year"?: 'numeric' | '2-digit';
     }
+    interface RuxDialog {
+        /**
+          * Text for confirmation button
+         */
+        "confirmText": string;
+        /**
+          * Text for close button
+         */
+        "denyText": string;
+        /**
+          * Dialog body message
+         */
+        "modalMessage"?: string;
+        /**
+          * Dialog header title
+         */
+        "modalTitle"?: string;
+        /**
+          * Shows and hides dialog
+         */
+        "open": boolean;
+    }
     interface RuxGlobalStatusBar {
         /**
           * Sets the domain of the application to be displayed in the app-meta element
@@ -12598,6 +12620,12 @@ declare global {
         prototype: HTMLRuxDatetimeElement;
         new (): HTMLRuxDatetimeElement;
     };
+    interface HTMLRuxDialogElement extends Components.RuxDialog, HTMLStencilElement {
+    }
+    var HTMLRuxDialogElement: {
+        prototype: HTMLRuxDialogElement;
+        new (): HTMLRuxDialogElement;
+    };
     interface HTMLRuxGlobalStatusBarElement extends Components.RuxGlobalStatusBar, HTMLStencilElement {
     }
     var HTMLRuxGlobalStatusBarElement: {
@@ -19182,6 +19210,7 @@ declare global {
         "rux-classification-marking": HTMLRuxClassificationMarkingElement;
         "rux-clock": HTMLRuxClockElement;
         "rux-datetime": HTMLRuxDatetimeElement;
+        "rux-dialog": HTMLRuxDialogElement;
         "rux-global-status-bar": HTMLRuxGlobalStatusBarElement;
         "rux-icon": HTMLRuxIconElement;
         "rux-icon-360": HTMLRuxIcon360Element;
@@ -20486,6 +20515,36 @@ declare namespace LocalJSX {
           * Format options for year
          */
         "year"?: 'numeric' | '2-digit';
+    }
+    interface RuxDialog {
+        /**
+          * Text for confirmation button
+         */
+        "confirmText"?: string;
+        /**
+          * Text for close button
+         */
+        "denyText"?: string;
+        /**
+          * Dialog body message
+         */
+        "modalMessage"?: string;
+        /**
+          * Dialog header title
+         */
+        "modalTitle"?: string;
+        /**
+          * Event that is fired when dialog closes
+         */
+        "onRuxdialogclosed"?: (event: CustomEvent<boolean | null>) => void;
+        /**
+          * Event that is fired when dialog opens
+         */
+        "onRuxdialogopened"?: (event: CustomEvent<void>) => void;
+        /**
+          * Shows and hides dialog
+         */
+        "open"?: boolean;
     }
     interface RuxGlobalStatusBar {
         /**
@@ -32941,6 +33000,7 @@ declare namespace LocalJSX {
         "rux-classification-marking": RuxClassificationMarking;
         "rux-clock": RuxClock;
         "rux-datetime": RuxDatetime;
+        "rux-dialog": RuxDialog;
         "rux-global-status-bar": RuxGlobalStatusBar;
         "rux-icon": RuxIcon;
         "rux-icon-360": RuxIcon360;
@@ -34050,6 +34110,7 @@ declare module "@stencil/core" {
             "rux-classification-marking": LocalJSX.RuxClassificationMarking & JSXBase.HTMLAttributes<HTMLRuxClassificationMarkingElement>;
             "rux-clock": LocalJSX.RuxClock & JSXBase.HTMLAttributes<HTMLRuxClockElement>;
             "rux-datetime": LocalJSX.RuxDatetime & JSXBase.HTMLAttributes<HTMLRuxDatetimeElement>;
+            "rux-dialog": LocalJSX.RuxDialog & JSXBase.HTMLAttributes<HTMLRuxDialogElement>;
             "rux-global-status-bar": LocalJSX.RuxGlobalStatusBar & JSXBase.HTMLAttributes<HTMLRuxGlobalStatusBarElement>;
             "rux-icon": LocalJSX.RuxIcon & JSXBase.HTMLAttributes<HTMLRuxIconElement>;
             "rux-icon-360": LocalJSX.RuxIcon360 & JSXBase.HTMLAttributes<HTMLRuxIcon360Element>;

--- a/packages/web-components/src/components/rux-button-group/readme.md
+++ b/packages/web-components/src/components/rux-button-group/readme.md
@@ -54,11 +54,13 @@ By default button group aligns buttons to the left. Alternatively an `h-align` p
 
 ### Used by
 
+ - [rux-dialog](../rux-dialog)
  - [rux-modal](../rux-modal)
 
 ### Graph
 ```mermaid
 graph TD;
+  rux-dialog --> rux-button-group
   rux-modal --> rux-button-group
   style rux-button-group fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/web-components/src/components/rux-button/readme.md
+++ b/packages/web-components/src/components/rux-button/readme.md
@@ -168,6 +168,7 @@ For more information about AstroUXDS usage outside of a Web Component environmen
 
 ### Used by
 
+ - [rux-dialog](../rux-dialog)
  - [rux-input](../rux-input)
  - [rux-modal](../rux-modal)
 
@@ -179,6 +180,7 @@ For more information about AstroUXDS usage outside of a Web Component environmen
 ```mermaid
 graph TD;
   rux-button --> rux-icon
+  rux-dialog --> rux-button
   rux-input --> rux-button
   rux-modal --> rux-button
   style rux-button fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/web-components/src/components/rux-dialog/readme.md
+++ b/packages/web-components/src/components/rux-dialog/readme.md
@@ -1,10 +1,10 @@
-# rux-modal
+# rux-dialog
 
-A Rux Modal interrupts the app experience to prompt a user to confirm an action or acknowledge a piece of information. It displays information along with a set of buttons allowing users to “Accept or Cancel” the actions presented within the Rux Modal.
+A Rux dialog interrupts the app experience to prompt a user to confirm an action or acknowledge a piece of information. It displays information along with a set of buttons allowing users to “Accept or Cancel” the actions presented within the Rux dialog.
 
 ## Guidelines
 
--   [Astro UXDS: Rux Modal](https://astrouxds.com/ui-components/dialog-box)
+-   [Astro UXDS: Rux Dialog](https://astrouxds.com/ui-components/dialog-box)
 
 ## Web Components Usage
 
@@ -20,32 +20,39 @@ git clone https://github.com/RocketCommunicationsInc/astro-components.git
 
 Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
-### 2. Import the Astro Rux Modal Web Component
+### 2. Import the Astro Rux Dialog Web Component
 
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxModal } from '@astrouxds/rux-modal/rux-modal.js'
+import { RuxDialog } from '@astrouxds/rux-dialog/rux-dialog.js'
 ```
 
-### 3. Render the Astro Rux Modal Web Component
+### 3. Render the Astro Rux Dialog Web Component
 
-At a minimum, Astro UXDS Rux Modal requires a message. In this instance, a single button labeled "Cancel" will be automatically rendered.
-
-```xml
-<rux-modal message="This is a message"></rux-modal>
-```
-
-Pass properties as attributes of the Astro Rux Modal custom element:
+Pass properties as attributes of the Astro Rux Dialog custom element:
 
 ```xml
-<rux-modal
-  title="Modal title"
-  message="Modal message"
+<rux-dialog
+  title="dialog title"
+  message="dialog message"
   confirmText="Ok"
   denyText="Cancel"
   customEvent="listen-for-me">
-</rux-modal>
+</rux-dialog>
+```
+
+Or use slots to render the header, content and footer.
+
+```xml
+<rux-dialog>
+  <span slot="header">Slot Header</span>
+  <p>Dialog Content as a slot</p>
+  <div slot="footer">
+    <rux-button secondary>Cancel</rux-button>
+    <rux-button>Confrim</rux-button>
+  </div>
+</rux-dialog>
 ```
 
 <!-- Auto Generated Below -->
@@ -57,8 +64,8 @@ Pass properties as attributes of the Astro Rux Modal custom element:
 | -------------- | --------------- | ---------------------------- | --------------------- | ----------- |
 | `confirmText`  | `confirm-text`  | Text for confirmation button | `string`              | `'Confirm'` |
 | `denyText`     | `deny-text`     | Text for close button        | `string`              | `'Cancel'`  |
-| `modalMessage` | `modal-message` | Dialog body message          | `string \| undefined` | `undefined` |
-| `modalTitle`   | `modal-title`   | Dialog header title          | `string \| undefined` | `undefined` |
+| `dialogMessage` | `dialog-message` | Dialog body message          | `string \| undefined` | `undefined` |
+| `dialogTitle`   | `dialog-title`   | Dialog header title          | `string \| undefined` | `undefined` |
 | `open`         | `open`          | Shows and hides dialog       | `boolean`             | `false`     |
 
 
@@ -90,15 +97,6 @@ Pass properties as attributes of the Astro Rux Modal custom element:
 | `"footer"`         | the footer of the dialog    |
 | `"header"`         | the header of the dialog    |
 | `"message"`        | the message of the dialog   |
-
-
-## CSS Custom Properties
-
-| Name                       | Description                         |
-| -------------------------- | ----------------------------------- |
-| `--modal-background-color` | [DEPRECATED] Modal background color |
-| `--modal-border-color`     | [DEPRECATED] Modal border color     |
-| `--modal-title-color`      | [DEPRECATED] Modal title color      |
 
 
 ## Dependencies

--- a/packages/web-components/src/components/rux-dialog/readme.md
+++ b/packages/web-components/src/components/rux-dialog/readme.md
@@ -1,0 +1,122 @@
+# rux-modal
+
+A Rux Modal interrupts the app experience to prompt a user to confirm an action or acknowledge a piece of information. It displays information along with a set of buttons allowing users to “Accept or Cancel” the actions presented within the Rux Modal.
+
+## Guidelines
+
+-   [Astro UXDS: Rux Modal](https://astrouxds.com/ui-components/dialog-box)
+
+## Web Components Usage
+
+### 1. Installation
+
+#### Download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components) source to your project.
+
+Via CLI:
+
+```sh
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
+```
+
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
+
+### 2. Import the Astro Rux Modal Web Component
+
+This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
+
+```javascript
+import { RuxModal } from '@astrouxds/rux-modal/rux-modal.js'
+```
+
+### 3. Render the Astro Rux Modal Web Component
+
+At a minimum, Astro UXDS Rux Modal requires a message. In this instance, a single button labeled "Cancel" will be automatically rendered.
+
+```xml
+<rux-modal message="This is a message"></rux-modal>
+```
+
+Pass properties as attributes of the Astro Rux Modal custom element:
+
+```xml
+<rux-modal
+  title="Modal title"
+  message="Modal message"
+  confirmText="Ok"
+  denyText="Cancel"
+  customEvent="listen-for-me">
+</rux-modal>
+```
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property       | Attribute       | Description                  | Type                  | Default     |
+| -------------- | --------------- | ---------------------------- | --------------------- | ----------- |
+| `confirmText`  | `confirm-text`  | Text for confirmation button | `string`              | `'Confirm'` |
+| `denyText`     | `deny-text`     | Text for close button        | `string`              | `'Cancel'`  |
+| `modalMessage` | `modal-message` | Dialog body message          | `string \| undefined` | `undefined` |
+| `modalTitle`   | `modal-title`   | Dialog header title          | `string \| undefined` | `undefined` |
+| `open`         | `open`          | Shows and hides dialog       | `boolean`             | `false`     |
+
+
+## Events
+
+| Event             | Description                            | Type                           |
+| ----------------- | -------------------------------------- | ------------------------------ |
+| `ruxdialogclosed` | Event that is fired when dialog closes | `CustomEvent<boolean \| null>` |
+| `ruxdialogopened` | Event that is fired when dialog opens  | `CustomEvent<void>`            |
+
+
+## Slots
+
+| Slot          | Description                     |
+| ------------- | ------------------------------- |
+| `"(default)"` | the dialog's message or content |
+| `"footer"`    | the footer of the dialog        |
+| `"header"`    | the header of the dialog        |
+
+
+## Shadow Parts
+
+| Part               | Description                 |
+| ------------------ | --------------------------- |
+| `"confirm-button"` | the dialog's confirm button |
+| `"container"`      | the dialog container        |
+| `"deny-button"`    | the dialog's deny button    |
+| `"dialog"`         | the native dialog element   |
+| `"footer"`         | the footer of the dialog    |
+| `"header"`         | the header of the dialog    |
+| `"message"`        | the message of the dialog   |
+
+
+## CSS Custom Properties
+
+| Name                       | Description                         |
+| -------------------------- | ----------------------------------- |
+| `--modal-background-color` | [DEPRECATED] Modal background color |
+| `--modal-border-color`     | [DEPRECATED] Modal border color     |
+| `--modal-title-color`      | [DEPRECATED] Modal title color      |
+
+
+## Dependencies
+
+### Depends on
+
+- [rux-button-group](../rux-button-group)
+- [rux-button](../rux-button)
+
+### Graph
+```mermaid
+graph TD;
+  rux-dialog --> rux-button-group
+  rux-dialog --> rux-button
+  rux-button --> rux-icon
+  style rux-dialog fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/web-components/src/components/rux-dialog/rux-dialog.scss
+++ b/packages/web-components/src/components/rux-dialog/rux-dialog.scss
@@ -1,0 +1,120 @@
+@use '../../global/mixins';
+
+:host {
+    display: contents;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: inherit;
+}
+
+//  this styling is only used in storybook up for presentational purposes
+//  default flex position takes up the entire body element en spills overlay
+//  on top of the docs page
+
+:host([hidden]) {
+    display: none;
+}
+
+rux-button-group {
+    margin-top: auto;
+    margin-left: auto;
+    align-self: flex-end;
+}
+
+.rux-dialog {
+    &__wrapper {
+        position: fixed;
+        top: 0;
+        left: 0;
+        height: 100vh;
+        width: 100vw;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        z-index: 1100;
+        background-color: rgba(0, 0, 0, 0.5);
+        @include mixins.animation(fadeIn, 0.5s);
+    }
+    &__dialog {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        background-color: var(--color-background-surface-default);
+        width: 28rem;
+        border: 0;
+        margin: auto;
+        padding: 0;
+        user-select: none;
+        box-shadow: var(--shadow-outer-dialog);
+    }
+
+    &__header {
+        display: flex;
+        flex-grow: 0;
+        flex-shrink: 0;
+        align-items: center;
+        width: 100%;
+        padding: 16px 20px;
+        background-color: var(--color-background-surface-header);
+        color: var(--color-text-primary);
+        user-select: none;
+        font-family: var(--font-heading-2-font-family);
+        font-size: var(--font-heading-2-font-size);
+        font-weight: var(--font-heading-2-font-weight);
+        letter-spacing: var(--font-heading-2-letter-spacing);
+        ::slotted(h6),
+        ::slotted(h5),
+        ::slotted(h4),
+        ::slotted(h3),
+        ::slotted(h2),
+        ::slotted(h1) {
+            margin-block-start: 0;
+            margin-block-end: 0;
+        }
+    }
+
+    &__content {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        padding: 1rem 1rem 0 1rem;
+        color: var(--color-text-primary);
+    }
+    &__footer {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        padding: 0 1rem 1rem 1rem;
+        color: var(--color-text-primary);
+    }
+
+    &__message {
+        margin: 0.5rem 1.875rem 2.5rem 1.875rem;
+    }
+    .rux-button {
+        box-shadow: none !important;
+    }
+    &__header.hidden {
+        display: none;
+    }
+    &__message.hidden {
+        display: none;
+    }
+}
+
+rux-icon {
+    margin-right: 0.75rem;
+}
+
+@include mixins.keyframes(fadeIn) {
+    0% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+}

--- a/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
+++ b/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
@@ -14,36 +14,34 @@ import {
 import { hasSlot } from '../../utils/utils'
 
 /**
- * @deprecated Use `RuxDialog` instead.
- * @part wrapper - the modal wrapper overlay ! DEPRECATED IN FAVOR OF CONTAINER !
- * @part container - the modal container
+ * @part container - the dialog container
  * @part dialog - the native dialog element
- * @part header - the header of the modal
- * @part message - the message of the modal
- * @part confirm-button - the modal's confirm button
- * @part deny-button - the modal's deny button
- * @part footer - the footer of the modal
+ * @part header - the header of the dialog
+ * @part message - the message of the dialog
+ * @part confirm-button - the dialog's confirm button
+ * @part deny-button - the dialog's deny button
+ * @part footer - the footer of the dialog
  *
- * @slot header - the header of the modal
- * @slot (default) - the modal's message or content
- * @slot footer - the footer of the modal
+ * @slot header - the header of the dialog
+ * @slot (default) - the dialog's message or content
+ * @slot footer - the footer of the dialog
  */
 @Component({
-    tag: 'rux-modal',
-    styleUrl: 'rux-modal.scss',
+    tag: 'rux-dialog',
+    styleUrl: 'rux-dialog.scss',
     shadow: true,
 })
-export class RuxModal {
+export class RuxDialog {
     /**
-     * Shows and hides modal
+     * Shows and hides dialog
      */
     @Prop({ reflect: true, mutable: true }) open: boolean = false
     /**
-     * Modal body message
+     * Dialog body message
      */
     @Prop() modalMessage?: string
     /**
-     * Modal header title
+     * Dialog header title
      */
     @Prop() modalTitle?: string
     /**
@@ -55,25 +53,25 @@ export class RuxModal {
      */
     @Prop() denyText: string = 'Cancel'
     /**
-     * Event that is fired when modal opens
+     * Event that is fired when dialog opens
      */
     @Event({
-        eventName: 'ruxmodalopened',
+        eventName: 'ruxdialogopened',
         composed: true,
         bubbles: true,
     })
-    ruxModalOpened!: EventEmitter<void>
+    ruxDialogOpened!: EventEmitter<void>
     /**
-     * Event that is fired when modal closes
+     * Event that is fired when dialog closes
      */
     @Event({
-        eventName: 'ruxmodalclosed',
+        eventName: 'ruxdialogclosed',
         composed: true,
         bubbles: true,
     })
-    ruxModalClosed!: EventEmitter<boolean | null>
+    ruxDialogClosed!: EventEmitter<boolean | null>
 
-    @Element() element!: HTMLRuxModalElement
+    @Element() element!: HTMLRuxDialogElement
 
     @State() hasFooter = hasSlot(this.element, 'footer')
     @State() hasHeader = hasSlot(this.element, 'header')
@@ -111,17 +109,11 @@ export class RuxModal {
             }, 0)
         }
         this.open
-            ? this.ruxModalOpened.emit()
-            : this.ruxModalClosed.emit(this._userInput)
+            ? this.ruxDialogOpened.emit()
+            : this.ruxDialogClosed.emit(this._userInput)
     }
 
-    componentWillLoad() {
-        console.warn(
-            'RuxModal is deprecated and will be removed in 7.0. Use RuxDialog instead.'
-        )
-    }
-
-    private _handleModalChoice(e: MouseEvent) {
+    private _handleDialogChoice(e: MouseEvent) {
         // convert string value to boolean
         const target = e.currentTarget as HTMLElement
         const choice = target.dataset.value === 'true'
@@ -146,7 +138,7 @@ export class RuxModal {
 
     private _getWrapper(): HTMLElement | null {
         const wrapper = this.element?.shadowRoot?.querySelector(
-            '.rux-modal__wrapper'
+            '.rux-dialog__wrapper'
         ) as HTMLElement
 
         if (wrapper) {
@@ -156,7 +148,7 @@ export class RuxModal {
     }
 
     connectedCallback() {
-        this._handleModalChoice = this._handleModalChoice.bind(this)
+        this._handleDialogChoice = this._handleDialogChoice.bind(this)
         this._handleSlotChange = this._handleSlotChange.bind(this)
     }
 
@@ -178,15 +170,15 @@ export class RuxModal {
             modalTitle,
             confirmText,
             denyText,
-            _handleModalChoice,
+            _handleDialogChoice,
         } = this
 
         return (
             open && (
                 <Host>
-                    <div part="wrapper container" class="rux-modal__wrapper">
+                    <div part="container" class="rux-dialog__wrapper">
                         <dialog
-                            class="rux-modal__dialog"
+                            class="rux-dialog__dialog"
                             role="dialog"
                             part="dialog"
                         >
@@ -195,7 +187,7 @@ export class RuxModal {
                                     hidden:
                                         !this.hasHeader &&
                                         modalTitle === undefined,
-                                    'rux-modal__header': true,
+                                    'rux-dialog__header': true,
                                 }}
                                 part="header"
                             >
@@ -207,13 +199,13 @@ export class RuxModal {
                                 </slot>
                             </header>
 
-                            <div class="rux-modal__content" part="message">
+                            <div class="rux-dialog__content" part="message">
                                 <div
                                     class={{
                                         hidden:
                                             !this.hasMessage &&
                                             modalMessage === undefined,
-                                        'rux-modal__message': true,
+                                        'rux-dialog__message': true,
                                     }}
                                     part="message"
                                 >
@@ -224,7 +216,7 @@ export class RuxModal {
                             </div>
                             <footer
                                 class={{
-                                    'rux-modal__footer': true,
+                                    'rux-dialog__footer': true,
                                 }}
                                 part="footer"
                             >
@@ -240,7 +232,7 @@ export class RuxModal {
                                                 secondary={
                                                     confirmText.length > 0
                                                 }
-                                                onClick={_handleModalChoice}
+                                                onClick={_handleDialogChoice}
                                                 data-value="false"
                                                 hidden={!denyText}
                                                 tabindex="-1"
@@ -249,7 +241,7 @@ export class RuxModal {
                                                 {denyText}
                                             </rux-button>
                                             <rux-button
-                                                onClick={_handleModalChoice}
+                                                onClick={_handleDialogChoice}
                                                 hidden={!confirmText}
                                                 data-value="true"
                                                 tabindex="0"

--- a/packages/web-components/src/components/rux-dialog/test/__snapshots__/rux-dialog.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-dialog/test/__snapshots__/rux-dialog.spec.tsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rux-dialog renders with a mix of slots and props 1`] = `
+<rux-dialog modal-title="Title">
+  <mock:shadow-root></mock:shadow-root>
+  <div slot="message">
+    Message
+  </div>
+  <div slot="footer">
+    Footer
+  </div>
+</rux-dialog>
+`;
+
+exports[`rux-dialog renders with slots 1`] = `
+<rux-dialog>
+  <mock:shadow-root></mock:shadow-root>
+  <span slot="header">
+    Header
+  </span>
+  <div slot="message">
+    Message
+  </div>
+  <div slot="footer">
+    Footer
+  </div>
+</rux-dialog>
+`;

--- a/packages/web-components/src/components/rux-dialog/test/index.html
+++ b/packages/web-components/src/components/rux-dialog/test/index.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+        />
+        <title>Stencil Component Starter</title>
+
+        <link rel="preconnect" href="https://fonts.gstatic.com" />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@100;300;400&family=Roboto:wght@100;300;400;500;700;900&display=swap"
+            rel="stylesheet"
+        />
+        <script type="module" src="/build/astro-web-components.esm.js"></script>
+        <script nomodule src="/build/astro-web-components.js"></script>
+
+        <link rel="stylesheet" href="/build/astro-web-components.css" />
+    </head>
+
+    <body>
+        <section>
+            <rux-dialog
+                open
+                modal-title="hello"
+                modal-message="world"
+            ></rux-dialog>
+        </section>
+        <section>
+            <rux-dialog
+                id="props"
+                modal-message="Props Message"
+                modal-title="Props Title"
+            ></rux-dialog>
+            <rux-button id="openprops">Open Props Version</rux-button>
+        </section>
+        <section>
+            <rux-dialog id="slots">
+                <span slot="header">Slot Header</span>
+                <div slot="message">
+                    <span>Slot Message</span>
+                    <rux-input placeholder="input time"></rux-input>
+                </div>
+                <div slot="footer">
+                    <rux-button-group h-align="right">
+                        <rux-button secondary>Slot Cancel</rux-button>
+                        <rux-button id="slotconfirm">Slot Confirm</rux-button>
+                    </rux-button-group>
+                </div>
+            </rux-dialog>
+            <rux-button id="openslots" style="padding: 15px 0px"
+                >Open Slots Version</rux-button
+            >
+        </section>
+        <section>
+            <rux-dialog
+                id="mix"
+                modal-title="Mixed"
+                deny-text="Custom Deny Text"
+            >
+                <div slot="message">
+                    <span>Slot Message</span>
+                    <rux-input placeholder="input time"></rux-input>
+                </div>
+                <div slot="footer">
+                    <rux-button-group h-align="right">
+                        <rux-button secondary>Slot Cancel</rux-button>
+                        <rux-button id="confirm">Slot Confirm</rux-button>
+                    </rux-button-group>
+                </div>
+            </rux-dialog>
+            <rux-button id="openmix">Open Mixed Version</rux-button>
+        </section>
+        <section>
+            <rux-button id="dyn" style="padding: 15px 0px"
+                >Open changing slot</rux-button
+            >
+            <rux-dialog id="change" modal-title="Title"> </rux-dialog>
+        </section>
+        <script>
+            const props = document.getElementById('props')
+            const openProps = document.getElementById('openprops')
+
+            openProps.addEventListener('click', () => {
+                props.open = !props.open
+            })
+
+            props.addEventListener('ruxmodalopened', () =>
+                console.log('props ruxmodalopened')
+            )
+            props.addEventListener('ruxmodalclosed', () =>
+                console.log('props ruxmodalclosed')
+            )
+
+            const slots = document.getElementById('slots')
+            const openSlots = document.getElementById('openslots')
+            const slotconfirm = document.getElementById('slotconfirm')
+
+            slotconfirm.addEventListener('click', () => {
+                slots.open = false
+            })
+
+            openSlots.addEventListener('click', () => {
+                slots.open = !slots.open
+            })
+            slots.addEventListener('ruxmodalopened', () =>
+                console.log('heard ruxmodalopened')
+            )
+            slots.addEventListener('ruxmodalclosed', () =>
+                console.log('heard ruxmodalclosed')
+            )
+
+            const mixed = document.getElementById('mix')
+            const openMixed = document.getElementById('openmix')
+            openMixed.addEventListener('click', () => {
+                mixed.open = !mixed.open
+            })
+
+            //Focus the confirm button on mixed modal
+
+            const confirmBtn = document.getElementById('confirm')
+            mixed.addEventListener('ruxmodalopened', () => {
+                const shadowBtn = confirmBtn.shadowRoot.querySelector('button')
+                setTimeout(() => shadowBtn.focus())
+            })
+
+            const dyn = document.getElementById('dyn')
+            const changeModal = document.getElementById('change')
+
+            const newFooter = document.createElement('span')
+            const newMessage = document.createElement('span')
+
+            newFooter.innerHTML = 'Slot Footer'
+            newFooter.slot = 'footer'
+            newMessage.innerHTML = 'Slot Message'
+            newMessage.classList.add('test')
+
+            dyn.addEventListener('click', () => {
+                changeModal.open = true
+            })
+            changeModal.addEventListener('ruxmodalopened', () => {
+                setTimeout(() => {
+                    changeModal.append(newFooter)
+                    changeModal.append(newMessage)
+                    //The assertion in the e2e test will timeout after 4000 ms of not finding the appended stuff
+                }, 500)
+            })
+        </script>
+    </body>
+</html>

--- a/packages/web-components/src/components/rux-dialog/test/rux-dialog.e2e.js
+++ b/packages/web-components/src/components/rux-dialog/test/rux-dialog.e2e.js
@@ -1,0 +1,162 @@
+describe('Modal', () => {
+    beforeEach(() => {
+        cy.visitComponent('rux-modal')
+    })
+    it('renders', () => {
+        cy.get('rux-modal').should('have.class', 'hydrated')
+    })
+
+    it('should close and open the modal', () => {
+        cy.get('rux-modal').then(($modal) => {
+            $modal[0].setAttribute('open', false)
+        })
+        cy.get('rux-modal').then(($modal) => {
+            $modal[0].setAttribute('open', true)
+        })
+        cy.get('rux-modal').shadow().find('.rux-modal__wrapper').should('exist')
+    })
+
+    it('should display new modal title in the dialog when changed', () => {
+        cy.get('rux-modal').then(($modal) => {
+            $modal[0].setAttribute('modal-title', 'This is a test title')
+        })
+        cy.get('rux-modal')
+            .shadow()
+            .find('.rux-modal__header')
+            .contains('This is a test title')
+    })
+
+    it('should display new modal message in the dialog when changed', () => {
+        cy.get('rux-modal').then(($modal) => {
+            $modal[0].setAttribute('modal-message', 'This is a test message')
+        })
+        cy.get('rux-modal')
+            .shadow()
+            .find('.rux-modal__message')
+            .contains('This is a test message')
+    })
+
+    it('should display new confirmation text in the dialog when changed', () => {
+        cy.get('rux-modal').then(($modal) => {
+            $modal[0].setAttribute('confirm-text', 'Test Confirm Text')
+        })
+        cy.get('rux-modal')
+            .shadow()
+            .find('rux-button-group')
+            .find('rux-button')
+            .next()
+            .contains('Test Confirm Text')
+    })
+
+    it('should display new deny text in the dialog when changed', () => {
+        cy.get('rux-modal').then(($modal) => {
+            $modal[0].setAttribute('deny-text', 'Test Deny Text')
+        })
+        cy.get('rux-modal')
+            .shadow()
+            .find('rux-button-group')
+            .find('rux-button')
+            .first()
+            .contains('Test Deny Text')
+    })
+
+    it('should close the modal when deny clicked', () => {
+        cy.get('rux-modal')
+            .shadow()
+            .find('rux-button-group')
+            .find('rux-button')
+            .first()
+            .click()
+        cy.get('rux-modal')
+            .shadow()
+            .find('.rux-modal__wrapper')
+            .should('not.exist')
+    })
+
+    it('should close the modal when confirm clicked', () => {
+        cy.get('rux-modal')
+            .shadow()
+            .find('rux-button-group')
+            .find('rux-button')
+            .next()
+            .click()
+        cy.get('rux-modal')
+            .shadow()
+            .find('.rux-modal__wrapper')
+            .should('not.exist')
+    })
+
+    it('should close when enter key pressed', () => {
+        cy.get('rux-modal').shadow().find('dialog').click()
+        cy.get('body').type('{enter}')
+        cy.get('rux-modal')
+            .shadow()
+            .find('.rux-modal__wrapper')
+            .should('not.exist')
+    })
+
+    it('should close the modal when click occurs outside modal', () => {
+        cy.get('rux-modal')
+            .shadow()
+            .find('.rux-modal__wrapper')
+            .click('topLeft')
+        cy.get('rux-modal')
+            .shadow()
+            .find('.rux-modal__wrapper')
+            .should('not.exist')
+    })
+    it('should be able to dynamically add slots', () => {
+        cy.get('rux-modal').then(($modal) => {
+            $modal[0].setAttribute('open', false)
+        })
+        cy.get('#dyn').click()
+        cy.get('#change').find('.test')
+        cy.get('#change')
+            .shadow()
+            .find('.rux-modal__wrapper')
+            .find('dialog')
+            .find('.rux-modal__footer')
+            .children()
+            .should('have.length', '1')
+    })
+    it('should emit ruxmodalclosed with a detail of false when default deny button is clicked', () => {
+        cy.get('rux-modal').then(($modal) => {
+            $modal[0].setAttribute('open', true)
+        })
+        cy.document().invoke(
+            'addEventListener',
+            'ruxmodalclosed',
+            cy.stub().as('ruxmodalclosed')
+        )
+        cy.get('rux-modal')
+            .shadow()
+            .find('rux-button-group')
+            .find('rux-button')
+            .first()
+            .click()
+        cy.get('@ruxmodalclosed')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', false)
+    })
+    it('should emit ruxmodalclosed with a detail of true when default confirm button is clicked', () => {
+        cy.get('rux-modal').then(($modal) => {
+            $modal[0].setAttribute('open', true)
+        })
+        cy.document().invoke(
+            'addEventListener',
+            'ruxmodalclosed',
+            cy.stub().as('ruxmodalclosed')
+        )
+        cy.get('rux-modal')
+            .shadow()
+            .find('rux-button-group')
+            .find('rux-button')
+            .next()
+            .click()
+        cy.get('@ruxmodalclosed')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', true)
+    })
+})

--- a/packages/web-components/src/components/rux-dialog/test/rux-dialog.spec.tsx
+++ b/packages/web-components/src/components/rux-dialog/test/rux-dialog.spec.tsx
@@ -1,0 +1,48 @@
+import { newSpecPage } from '@stencil/core/testing'
+import { RuxDialog } from '../rux-dialog'
+
+describe('rux-dialog', () => {
+    it('builds', async () => {
+        const modal: RuxDialog = new RuxDialog()
+        const { open, modalMessage, modalTitle, confirmText, denyText } = modal
+        expect(modal).toBeTruthy()
+        expect({
+            open,
+            modalMessage,
+            modalTitle,
+            confirmText,
+            denyText,
+        }).toEqual({
+            open: false,
+            modalMessage: undefined,
+            modalTitle: undefined,
+            confirmText: 'Confirm',
+            denyText: 'Cancel',
+        })
+    })
+    it('renders with slots', async () => {
+        const page = await newSpecPage({
+            components: [RuxDialog],
+            html: `
+            <rux-dialog>
+                <span slot="header">Header</span>
+                <div slot="message">Message</div>
+                <div slot="footer">Footer</div>
+            </rux-dialog>
+            `,
+        })
+        expect(page.root).toMatchSnapshot()
+    })
+    it('renders with a mix of slots and props', async () => {
+        const page = await newSpecPage({
+            components: [RuxDialog],
+            html: `
+            <rux-dialog modal-title="Title">
+                <div slot="message">Message</div>
+                <div slot="footer">Footer</div>
+            </rux-dialog>
+            `,
+        })
+        expect(page.root).toMatchSnapshot()
+    })
+})

--- a/packages/web-components/src/stories/dialog.stories.mdx
+++ b/packages/web-components/src/stories/dialog.stories.mdx
@@ -68,7 +68,7 @@ export const WithSlots = (args) => {
     ?open="${args.open}"
 >
     <span slot="header">Slot Header</span>
-    <div slot="message" style="display: flex; flex-direction: column;">
+    <div style="display: flex; flex-direction: column;">
         <span style="margin-bottom: 10px;">Slot Message</span>
         <rux-input label="Input"></rux-input>
     </div>
@@ -115,7 +115,7 @@ using a `rux-button` to open the Dialog, and another `rux-button` in the `footer
 <rux-button id="open">Open Dialog</rux-button>
 <rux-dialog id="dialog" open>
     <div slot="header">Dialog Header</div>
-    <span slot="message">Dialog message here!</span>
+    <span>Dialog message here!</span>
     <div slot="footer">
         <rux-button id="confirm">Confirm</rux-button>
     </div>
@@ -142,7 +142,7 @@ Here's a simple way to do that if you're using slots to customize the footer.
 <rux-button id="open">Open Dialog</rux-button>
 <rux-dialog id="dialog">
     <div slot="header">Dialog Header</div>
-    <p slot="message">Dialog message here!</p>
+    <p>Dialog message here!</p>
     <div slot="footer">
         <rux-button id="confirm">Confirm</rux-button>
     </div>

--- a/packages/web-components/src/stories/dialog.stories.mdx
+++ b/packages/web-components/src/stories/dialog.stories.mdx
@@ -2,72 +2,35 @@ import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil'
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
 import { html, render } from 'lit-html'
 
-import { styled } from '@storybook/theming'
-export const StyledDiv = styled.div`
-    position: relative;
-    margin: 1rem 0;
-    border-left: 20px solid var(--color-status-serious);
-    background: white;
-    color: var(--color-status-serious);
-    padding: 19px;
-    font-family: var(--font-body-1-bold-font-family);
-    font-size: var(--font-body-1-bold-font-size);
-    font-weight: var(--font-body-1-bold-font-weight);
-    letter-spacing: var(--font-body-1-bold-letter-spacing);
-    .banner-text {
-        margin-top: 1rem;
-        color: var(--color-text-inverse);
-    }
-`
-
-export const BetaTag = styled.div`
-  display: inline-block;
-  padding: 7px;
-  color: var(--color-palette-neutral-1000);
-  border-radius: var(--radius-base);
-  background: var(--color-status-serious);
-      font-family: var(--font-body-2-bold-font-family);
-    font-size: var(--font-body-2-bold-font-size);
-    font-weight: var(--font-body-2-bold-font-weight);
-    letter-spacing: var(--font-body-2-bold-letter-spacing);
-`
-
 <Meta
-    title="Components/Modal"
-    component="rux-modal"
-    argTypes={extractArgTypes('rux-modal')}
+    title="Components/Dialog"
+    component="rux-dialog"
+    argTypes={extractArgTypes('rux-dialog')}
     parameters={{
         actions: {
-            handles: ['ruxmodalclosed rux-modal', 'ruxmodalopened rux-modal'],
+            handles: ['ruxdialogclosed rux-dialog', 'ruxdialogopened rux-dialog'],
         },
     }}
 />
 
-# Modal <BetaTag>Deprecated</BetaTag>
+# Dialog
 
-<StyledDiv>
-    <div>Deprecation Warning</div>
-    <p class="banner-text">
-        Modal has been renamed to Dialog and will be removed in 7.0.
-    </p>
-</StyledDiv>
-
-A Modal interrupts the app experience to prompt a user to confirm an action or acknowledge a piece of information. It displays information along with a set of Buttons allowing users to “Accept or Cancel” the actions presented within the Rux Modal.
+A Dialog interrupts the app experience to prompt a user to confirm an action or acknowledge a piece of information. It displays information along with a set of Buttons allowing users to “Accept or Cancel” the actions presented within the Rux Dialog.
 
 ## Guidelines
 
--   [Astro UXDS: Modal](https://astrouxds.com/ui-components/dialog-box)
+-   [Astro UXDS: Dialog](https://astrouxds.com/ui-components/dialog-box)
 
-export const Modal = (args) => {
+export const Dialog = (args) => {
     return html`
 <div style="display: flex; flex-flow: column; justify-content: center;">
-    <rux-modal
+    <rux-dialog
         ?open="${args.open}"
         modal-message="${args.modalMessage}"
         modal-title="${args.modalTitle}"
         confirm-text="${args.confirmText}"
         deny-text="${args.denyText}"
-    ></rux-modal>
+    ></rux-dialog>
 </div
     `
 }
@@ -76,32 +39,32 @@ export const Modal = (args) => {
     <Story
         args={{
             open: true,
-            modalMessage: 'Modal message',
-            modalTitle: 'Modal title',
+            modalMessage: 'Dialog message',
+            modalTitle: 'Dialog title',
             confirmText: 'Release',
             denyText: 'Cancel',
         }}
-        name="Modal"
+        name="Dialog"
     >
-        {Modal.bind()}
+        {Dialog.bind()}
     </Story>
 </Canvas>
 
 ## API
 
-<ArgsTable of="rux-modal" />
+<ArgsTable of="rux-dialog" />
 
 ### Variants
 
 export const WithSlots = (args) => {
     return html`
     <style>
-        rux-modal::part(message){
+        rux-dialog::part(message){
             padding: 0.5rem;
         }
     </style>
 <div style="display: flex; flex-direction: column; justify-content: center;">
-<rux-modal
+<rux-dialog
     ?open="${args.open}"
 >
     <span slot="header">Slot Header</span>
@@ -116,7 +79,7 @@ export const WithSlots = (args) => {
             <rux-button>Confirm</rux-button>
         </rux-button-group>
     </div>
-</rux-modal>
+</rux-dialog>
 </div>
     `
 }
@@ -140,56 +103,56 @@ export const WithSlots = (args) => {
 
 ## Opening, Closing and Focusing with Slots
 
-Using slots in the Modal allows for near complete customization of the component, but also requires a bit more
+Using slots in the Dialog allows for near complete customization of the component, but also requires a bit more
 boilerplate for some things that are built in with the default method. 
 
 ### Opening and Closing
 
-The `open` prop of `rux-modal` is mutable and can be changed accordingly. Here's an example of how you could do that 
-using a `rux-button` to open the Modal, and another `rux-button` in the `footer` slot to close it.
+The `open` prop of `rux-dialog` is mutable and can be changed accordingly. Here's an example of how you could do that 
+using a `rux-button` to open the Dialog, and another `rux-button` in the `footer` slot to close it.
 
 ```js
-<rux-button id="open">Open Modal</rux-button>
-<rux-modal id="modal" open>
-    <div slot="header">Modal Header</div>
-    <span slot="message">Modal message here!</span>
+<rux-button id="open">Open Dialog</rux-button>
+<rux-dialog id="dialog" open>
+    <div slot="header">Dialog Header</div>
+    <span slot="message">Dialog message here!</span>
     <div slot="footer">
         <rux-button id="confirm">Confirm</rux-button>
     </div>
-</rux-modal>
+</rux-dialog>
 <script>
-    const openModal = document.getElementById('open')
-    const modal = document.getElementById('modal');
+    const openDialog = document.getElementById('open')
+    const dialog = document.getElementById('dialog');
     const confirm = document.getElementById('confirm')
-    openModal.addEventListener('click', () => { 
-        modal.open = true;
+    openDialog.addEventListener('click', () => { 
+        dialog.open = true;
     })
     confirm.addEventListener('click', () => {
-        modal.open = false;
+        dialog.open = false;
     })
 </script>
 ```
 
 ### Applying Focus
 
-Often times when a Modal opens, you want to focus a specific element like a confirm or cancel button. 
+Often times when a Dialog opens, you want to focus a specific element like a confirm or cancel button. 
 Here's a simple way to do that if you're using slots to customize the footer.
 
 ```js
-<rux-button id="open">Open Modal</rux-button>
-<rux-modal id="modal">
-    <div slot="header">Modal Header</div>
-    <p slot="message">Modal message here!</p>
+<rux-button id="open">Open Dialog</rux-button>
+<rux-dialog id="dialog">
+    <div slot="header">Dialog Header</div>
+    <p slot="message">Dialog message here!</p>
     <div slot="footer">
         <rux-button id="confirm">Confirm</rux-button>
     </div>
-</rux-modal>
+</rux-dialog>
 
 <script>
-    const modal = document.getElementById('modal')
+    const dialog = document.getElementById('dialog')
     const open = document.getElementById('open')
     const confirm = document.getElementById('confirm')
-    modal.addEventListener('ruxmodalopened', () => {
+    dialog.addEventListener('ruxdialogopened', () => {
         //Find the native button that is in the shadow dom
         const shadowBtn = confirm.shadowRoot.querySelector('button');
         setTimeout(() => {
@@ -197,10 +160,10 @@ Here's a simple way to do that if you're using slots to customize the footer.
         })
     })
     confirm.addEventListener('click', () => {
-        modal.open = false
+        dialog.open = false
     })
     open.addEventListener('click', () => {
-        modal.open = true
+        dialog.open = true
     })
 </script>
 ```
@@ -210,10 +173,10 @@ Here's a simple way to do that if you're using slots to customize the footer.
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import { RuxModal } from '@astrouxds/astro-web-components/dist/components/rux-modal.js'
+import { RuxDialog } from '@astrouxds/astro-web-components/dist/components/rux-dialog.js'
 import { RuxButton } from '@astrouxds/astro-web-components/dist/components/rux-button.js'
 import { RuxButtonGroup } from '@astrouxds/astro-web-components/dist/components/rux-button-group.js'
-customElements.define('rux-modal', RuxModal)
+customElements.define('rux-dialog', RuxDialog)
 customElements.define('rux-button', RuxButton)
 customElements.define('rux-button-group', RuxButtonGroup)
 ```

--- a/packages/web-components/src/stories/dialog.stories.mdx
+++ b/packages/web-components/src/stories/dialog.stories.mdx
@@ -69,8 +69,8 @@ export const WithSlots = (args) => {
 >
     <span slot="header">Slot Header</span>
     <div style="display: flex; flex-direction: column;">
-        <span style="margin-bottom: 10px;">Slot Message</span>
-        <rux-input label="Input"></rux-input>
+        <span style="margin-bottom: 1rem;">Default Slot Content</span>
+        <rux-input label="Input Label" placeholder="Dialog Input"></rux-input>
     </div>
     <div slot="footer" style="display: flex; justify-content: space-between; align-items: center;">
         <a href="astrouxds.com">Link</a>

--- a/packages/web-components/src/stories/modal.stories.mdx
+++ b/packages/web-components/src/stories/modal.stories.mdx
@@ -105,7 +105,7 @@ export const WithSlots = (args) => {
     ?open="${args.open}"
 >
     <span slot="header">Slot Header</span>
-    <div slot="message" style="display: flex; flex-direction: column;">
+    <div style="display: flex; flex-direction: column;">
         <span style="margin-bottom: 10px;">Slot Message</span>
         <rux-input label="Input"></rux-input>
     </div>
@@ -152,7 +152,7 @@ using a `rux-button` to open the Modal, and another `rux-button` in the `footer`
 <rux-button id="open">Open Modal</rux-button>
 <rux-modal id="modal" open>
     <div slot="header">Modal Header</div>
-    <span slot="message">Modal message here!</span>
+    <span>Modal message here!</span>
     <div slot="footer">
         <rux-button id="confirm">Confirm</rux-button>
     </div>
@@ -179,7 +179,7 @@ Here's a simple way to do that if you're using slots to customize the footer.
 <rux-button id="open">Open Modal</rux-button>
 <rux-modal id="modal">
     <div slot="header">Modal Header</div>
-    <p slot="message">Modal message here!</p>
+    <p>Modal message here!</p>
     <div slot="footer">
         <rux-button id="confirm">Confirm</rux-button>
     </div>

--- a/packages/web-components/src/stories/timeline.stories.mdx
+++ b/packages/web-components/src/stories/timeline.stories.mdx
@@ -4,9 +4,9 @@ import { styled } from '@storybook/theming'
 export const StyledDiv = styled.div`
     position: relative;
     margin: 1rem 0;
-    border-left: 20px solid var(--status-symbol-color-fill-serious);
+    border-left: 20px solid var(--color-status-serious);
     background: white;
-    color: var(--status-symbol-color-fill-serious);
+    color: var(--color-status-serious);
     padding: 19px;
     font-family: var(--font-body-1-bold-font-family);
     font-size: var(--font-body-1-bold-font-size);


### PR DESCRIPTION
## Brief Description

creates a dialog component and deprecates modal

## JIRA Link

ASTRO-3893

## Motivation and Context

Dev started calling this component Modal awhile ago, but it's called 'Dialog' in design. It's time to rip the bandaid off. 

Although it is slightly weird we will ship both for now 

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
