### PR TITLE
feat(): remove custom-elements-bundle

### DIFF
--- a/.changeset/heavy-ducks-pump.md
+++ b/.changeset/heavy-ducks-pump.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": major
+"@astrouxds/angular": major
+"astro-website": major
+"@astrouxds/react": major
+"@astrouxds/astro-web-components": major
+---
+
+Our /dist/custom-elements build has been removed in favor of a faster treeshakeable /dist/components build. We anticipate very few people are using this build. To check if your project is affected, you can do a global find for 'astro-web-components/dist/custom-elements' in your project. If you are using this build, switch to 'astro-web-components/dist/loader' instead.

--- a/packages/angular-workspace/projects/angular/src/directives/proxies-list.ts
+++ b/packages/angular-workspace/projects/angular/src/directives/proxies-list.ts
@@ -5,6 +5,8 @@
 //@ts-nocheck
 //@ts-nocheck
 //@ts-nocheck
+//@ts-nocheck
+//@ts-nocheck
 
 import * as d from './proxies';
 

--- a/packages/starter-kits/svelte-starter/README.md
+++ b/packages/starter-kits/svelte-starter/README.md
@@ -24,7 +24,7 @@ import App from './App.svelte';
 // Import Astro's base styles
 import "../node_modules/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css";
 // Define the Astro Components
-import { defineCustomElements } from '@astrouxds/astro-web-components/dist/custom-elements';
+import { defineCustomElements } from '@astrouxds/astro-web-components/loader';
 defineCustomElements();
 
 

--- a/packages/starter-kits/vue-starter/src/main.js
+++ b/packages/starter-kits/vue-starter/src/main.js
@@ -2,7 +2,7 @@ import { createApp } from "vue";
 import App from "./App.vue";
 
 import "@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css";
-import { defineCustomElements } from "@astrouxds/astro-web-components/dist/custom-elements";
+import { defineCustomElements } from "@astrouxds/astro-web-components/loader";
 defineCustomElements();
 
 createApp(App).mount("#app");

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@astrouxds/astro-web-components",
-    "version": "6.9.1",
+    "version": "7.0.0-beta.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@astrouxds/astro-web-components",
-            "version": "6.9.1",
+            "version": "7.0.0-beta.2",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "~0.4.4",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -3,7 +3,7 @@
     "version": "7.0.0-beta.2",
     "description": "Astro Web Components",
     "main": "dist/index.cjs.js",
-    "module": "dist/custom-elements/index.js",
+    "module": "dist/index.js",
     "es2015": "dist/esm/index.mjs",
     "es2017": "dist/esm/index.mjs",
     "types": "dist/types/index.d.ts",

--- a/packages/web-components/src/stories/astro-sandboxes/forms/vue/validation/src/main.js
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/vue/validation/src/main.js
@@ -4,7 +4,7 @@ import App from './App.vue'
 import '@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css'
 
 // import './index.css'
-import { defineCustomElements } from '@astrouxds/astro-web-components/dist/custom-elements'
+import { defineCustomElements } from '@astrouxds/astro-web-components/loader'
 defineCustomElements()
 
 createApp(App).mount('#app')

--- a/packages/web-components/stencil.config.ts
+++ b/packages/web-components/stencil.config.ts
@@ -38,9 +38,6 @@ export const config: Config = {
             esmLoaderPath: '../loader',
         },
         {
-            type: 'dist-custom-elements-bundle',
-        },
-        {
             type: 'docs-json',
             file: './docs.json',
         },


### PR DESCRIPTION
## Brief Description

removes the dist-custom-elements-bundle. Restores like 5 seconds to our build process

## Motivation and Context

[Stencil is deprecating the dist custom elements bundle](https://stenciljs.com/docs/custom-elements-bundle). dist-custom-elements is way superior for treeshaking anyway. 

This has to be a breaking change because our own docs were still referencing the old custom-elements build for Vue and Svelte so there's a chance someone out there is still using it in their project. 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [x] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
