### PR TITLE
fix(astro-uxds): increase card height in story preview

### DIFF
--- a/packages/astro-uxds/_content/components/card.md
+++ b/packages/astro-uxds/_content/components/card.md
@@ -7,7 +7,7 @@ title: Card
 demo: components-card--full-example
 storybook: components-card--full-example
 git: rux-card
-height: 300
+height: 330
 theme: true
 ---
 


### PR DESCRIPTION
## Brief Description

on astrouxds the card page sb preview cuts off

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
