### PR TITLE
Astro 4081 tree event

### DIFF
--- a/.changeset/silver-emus-arrive.md
+++ b/.changeset/silver-emus-arrive.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/angular": minor
+"@astrouxds/astro-web-components": minor
+"astro-website": minor
+"@astrouxds/react": minor
+---
+
+Added two new events to rux-tree-node: ruxtreenodeexpanded and ruxtreenodecollapsed.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -52,7 +52,7 @@ jobs:
             ./packages/web-components/node_modules
             ~/.cache/Cypress
           key: node-modules-${{ hashFiles('package-lock.json') }}
-      - run: npm i cypress@8.0.0
+      - run: npm i cypress@8.0.0 & npm i @stencil/core@2.5.2
         if: steps.cache-modules-and-cypress.outputs.cache-hit != 'true'
       - name: Cypress tests 🧪
         uses: cypress-io/github-action@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,9 @@ jobs:
       - uses: actions/cache@v2
         id: cache-node-modules
         with:
-          path: ./packages/web-components/node_modules
+          path: |
+            ./packages/web-components/node_modules
+            ~/.cache/Cypress
           key: node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm run web-comps.install
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -46,14 +48,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Cache NPM and Cypress 📦
         uses: actions/cache@v2
-        id: cache-modules-and-cypress
         with:
           path: |
             ./packages/web-components/node_modules
             ~/.cache/Cypress
           key: node-modules-${{ hashFiles('package-lock.json') }}
-      - run: npm i cypress@8.0.0 & npm i @stencil/core@2.5.2
-        if: steps.cache-modules-and-cypress.outputs.cache-hit != 'true'
+      - run: npm i cypress@8.0.0
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
       - name: Cypress tests 🧪
         uses: cypress-io/github-action@v4
         with:

--- a/packages/angular/src/directives/proxies.ts
+++ b/packages/angular/src/directives/proxies.ts
@@ -22223,6 +22223,14 @@ export declare interface RuxTreeNode extends Components.RuxTreeNode {
    * Emit when user selects a tree node 
    */
   ruxtreenodeselected: EventEmitter<CustomEvent<string>>;
+  /**
+   * Emit when user expands a tree node 
+   */
+  ruxtreenodeexpanded: EventEmitter<CustomEvent<string>>;
+  /**
+   * Emit when user collapses a tree node 
+   */
+  ruxtreenodecollapsed: EventEmitter<CustomEvent<string>>;
 
 }
 
@@ -22241,6 +22249,6 @@ export class RuxTreeNode {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['ruxtreenodeselected']);
+    proxyOutputs(this, this.el, ['ruxtreenodeselected', 'ruxtreenodeexpanded', 'ruxtreenodecollapsed']);
   }
 }

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@astrouxds/astro-web-components",
-    "version": "6.9.1",
+    "version": "6.10.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@astrouxds/astro-web-components",
-            "version": "6.9.1",
+            "version": "6.10.0",
             "license": "MIT",
             "dependencies": {
                 "@stencil/core": "~2.5.2",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -32984,6 +32984,14 @@ declare namespace LocalJSX {
          */
         "expanded"?: boolean;
         /**
+          * Emit when user collapses a tree node
+         */
+        "onRuxtreenodecollapsed"?: (event: CustomEvent<string>) => void;
+        /**
+          * Emit when user expands a tree node
+         */
+        "onRuxtreenodeexpanded"?: (event: CustomEvent<string>) => void;
+        /**
           * Emit when user selects a tree node
          */
         "onRuxtreenodeselected"?: (event: CustomEvent<string>) => void;

--- a/packages/web-components/src/components/rux-tree-node/readme.md
+++ b/packages/web-components/src/components/rux-tree-node/readme.md
@@ -13,9 +13,11 @@
 
 ## Events
 
-| Event                 | Description                        | Type                  |
-| --------------------- | ---------------------------------- | --------------------- |
-| `ruxtreenodeselected` | Emit when user selects a tree node | `CustomEvent<string>` |
+| Event                  | Description                          | Type                  |
+| ---------------------- | ------------------------------------ | --------------------- |
+| `ruxtreenodecollapsed` | Emit when user collapses a tree node | `CustomEvent<string>` |
+| `ruxtreenodeexpanded`  | Emit when user expands a tree node   | `CustomEvent<string>` |
+| `ruxtreenodeselected`  | Emit when user selects a tree node   | `CustomEvent<string>` |
 
 
 ## Methods

--- a/packages/web-components/src/components/rux-tree-node/rux-tree-node.tsx
+++ b/packages/web-components/src/components/rux-tree-node/rux-tree-node.tsx
@@ -45,6 +45,18 @@ export class RuxTreeNode {
     @Event({ eventName: 'ruxtreenodeselected' })
     ruxTreeNodeSelected!: EventEmitter<string>
 
+    /**
+     * Emit when user expands a tree node
+     */
+    @Event({ eventName: 'ruxtreenodeexpanded' })
+    ruxTreeNodeExpanded!: EventEmitter<string>
+
+    /**
+     * Emit when user collapses a tree node
+     */
+    @Event({ eventName: 'ruxtreenodecollapsed' })
+    ruxTreeNodeCollapsed!: EventEmitter<string>
+
     @Watch('expanded')
     handleExpandedChange(newValue: boolean) {
         this.setExpanded(newValue)
@@ -168,6 +180,9 @@ export class RuxTreeNode {
     private _handleArrowClick(e: MouseEvent) {
         e.stopPropagation()
         this.setExpanded(!this.expanded)
+        this.expanded
+            ? this.ruxTreeNodeExpanded.emit(this.componentId)
+            : this.ruxTreeNodeCollapsed.emit(this.componentId)
     }
 
     private _handleTreeNodeClick(e: MouseEvent) {

--- a/packages/web-components/src/components/rux-tree/test/index.html
+++ b/packages/web-components/src/components/rux-tree/test/index.html
@@ -315,6 +315,12 @@
             document.addEventListener('ruxtreenodeexpanded', function (event) {
                 console.log('rux-tree-node-expanded', event.detail)
             })
+            document.addEventListener('ruxtreenodecollapsed', function (event) {
+                console.log('rux-tree-node-collapsed', event.detail)
+            })
+            document.addEventListener('ruxtreenodeselected', function (event) {
+                console.log('rux-tree-node-selected', event.detail)
+            })
         </script>
     </body>
 </html>

--- a/packages/web-components/src/components/rux-tree/test/index.html
+++ b/packages/web-components/src/components/rux-tree/test/index.html
@@ -18,6 +18,7 @@
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
+
     <body>
         <rux-tree role="tree" class="hydrated">
             <rux-tree-node
@@ -28,8 +29,7 @@
                 aria-level="1"
                 class="hydrated"
             >
-                <!--?lit$4710966951$-->Tree item 1
-                <!--?lit$4710966951$--><!---->
+                Tree item 1
                 <rux-tree-node
                     slot="node"
                     role="treeitem"
@@ -39,8 +39,7 @@
                     aria-level="2"
                     class="hydrated"
                 >
-                    <!--?lit$4710966951$-->Tree item 1.1
-                    <!--?lit$4710966951$--><!---->
+                    Tree item 1.1
                     <rux-tree-node
                         slot="node"
                         role="treeitem"
@@ -49,10 +48,8 @@
                         class="hydrated"
                         aria-level="3"
                     >
-                        <!--?lit$4710966951$-->Tree item 1.1.1
-                        <!--?lit$4710966951$-->
+                        Tree item 1.1.1
                     </rux-tree-node>
-                    <!----><!---->
                     <rux-tree-node
                         slot="node"
                         role="treeitem"
@@ -62,10 +59,8 @@
                         class="hydrated"
                         aria-level="3"
                     >
-                        <!--?lit$4710966951$-->Tree item 1.1.2
-                        <!--?lit$4710966951$-->
+                        Tree item 1.1.2
                     </rux-tree-node>
-                    <!----><!---->
                     <rux-tree-node
                         slot="node"
                         role="treeitem"
@@ -74,12 +69,9 @@
                         class="hydrated"
                         aria-level="3"
                     >
-                        <!--?lit$4710966951$-->Tree item 1.1.3
-                        <!--?lit$4710966951$-->
+                        Tree item 1.1.3
                     </rux-tree-node>
-                    <!---->
                 </rux-tree-node>
-                <!----><!---->
                 <rux-tree-node
                     slot="node"
                     role="treeitem"
@@ -88,10 +80,8 @@
                     class="hydrated"
                     aria-level="2"
                 >
-                    <!--?lit$4710966951$-->Tree item 1.2
-                    <!--?lit$4710966951$-->
+                    Tree item 1.2
                 </rux-tree-node>
-                <!----><!---->
                 <rux-tree-node
                     slot="node"
                     role="treeitem"
@@ -100,8 +90,7 @@
                     aria-level="2"
                     class="hydrated"
                 >
-                    <!--?lit$4710966951$-->Tree item 1.3
-                    <!--?lit$4710966951$--><!---->
+                    Tree item 1.3
                     <rux-tree-node
                         slot="node"
                         role="treeitem"
@@ -110,8 +99,7 @@
                         aria-level="3"
                         class="hydrated"
                     >
-                        <!--?lit$4710966951$-->Tree item 1.3.1
-                        <!--?lit$4710966951$--><!---->
+                        Tree item 1.3.1
                         <rux-tree-node
                             slot="node"
                             role="treeitem"
@@ -120,9 +108,8 @@
                             class="hydrated"
                             aria-level="4"
                         >
-                            <!--?lit$4710966951$-->Tree item 1.1.1
+                            Tree item 1.1.1
                         </rux-tree-node>
-                        <!----><!---->
                         <rux-tree-node
                             slot="node"
                             role="treeitem"
@@ -131,9 +118,8 @@
                             class="hydrated"
                             aria-level="4"
                         >
-                            <!--?lit$4710966951$-->Tree item 1.1.2
+                            Tree item 1.1.2
                         </rux-tree-node>
-                        <!----><!---->
                         <rux-tree-node
                             slot="node"
                             role="treeitem"
@@ -142,11 +128,9 @@
                             class="hydrated"
                             aria-level="4"
                         >
-                            <!--?lit$4710966951$-->Tree item 1.1.3
+                            Tree item 1.1.3
                         </rux-tree-node>
-                        <!---->
                     </rux-tree-node>
-                    <!----><!---->
                     <rux-tree-node
                         slot="node"
                         role="treeitem"
@@ -155,8 +139,7 @@
                         aria-level="3"
                         class="hydrated"
                     >
-                        <!--?lit$4710966951$-->Tree item 1.3.2
-                        <!--?lit$4710966951$--><!---->
+                        Tree item 1.3.2
                         <rux-tree-node
                             slot="node"
                             role="treeitem"
@@ -165,9 +148,8 @@
                             class="hydrated"
                             aria-level="4"
                         >
-                            <!--?lit$4710966951$-->Tree item 1.1.1
+                            Tree item 1.1.1
                         </rux-tree-node>
-                        <!----><!---->
                         <rux-tree-node
                             slot="node"
                             role="treeitem"
@@ -176,9 +158,8 @@
                             class="hydrated"
                             aria-level="4"
                         >
-                            <!--?lit$4710966951$-->Tree item 1.1.2
+                            Tree item 1.1.2
                         </rux-tree-node>
-                        <!----><!---->
                         <rux-tree-node
                             slot="node"
                             role="treeitem"
@@ -187,11 +168,9 @@
                             class="hydrated"
                             aria-level="4"
                         >
-                            <!--?lit$4710966951$-->Tree item 1.1.3
+                            Tree item 1.1.3
                         </rux-tree-node>
-                        <!---->
                     </rux-tree-node>
-                    <!----><!---->
                     <rux-tree-node
                         slot="node"
                         role="treeitem"
@@ -201,8 +180,7 @@
                         aria-level="3"
                         class="hydrated"
                     >
-                        <!--?lit$4710966951$-->Tree item 1.3.3
-                        <!--?lit$4710966951$--><!---->
+                        Tree item 1.3.3
                         <rux-tree-node
                             slot="node"
                             role="treeitem"
@@ -211,9 +189,8 @@
                             class="hydrated"
                             aria-level="4"
                         >
-                            <!--?lit$4710966951$-->Tree item 1.3.3.1
+                            Tree item 1.3.3.1
                         </rux-tree-node>
-                        <!----><!---->
                         <rux-tree-node
                             slot="node"
                             role="treeitem"
@@ -222,9 +199,8 @@
                             class="hydrated"
                             aria-level="4"
                         >
-                            <!--?lit$4710966951$-->Tree item 1.3.3.2
+                            Tree item 1.3.3.2
                         </rux-tree-node>
-                        <!----><!---->
                         <rux-tree-node
                             slot="node"
                             role="treeitem"
@@ -233,13 +209,10 @@
                             class="hydrated"
                             aria-level="4"
                         >
-                            <!--?lit$4710966951$-->Tree item 1.3.3.3
+                            Tree item 1.3.3.3
                         </rux-tree-node>
-                        <!---->
                     </rux-tree-node>
-                    <!---->
                 </rux-tree-node>
-                <!----><!---->
                 <rux-tree-node
                     slot="node"
                     role="treeitem"
@@ -248,8 +221,7 @@
                     aria-level="2"
                     class="hydrated"
                 >
-                    <!--?lit$4710966951$-->Tree item 1.4
-                    <!--?lit$4710966951$--><!---->
+                    Tree item 1.4
                     <rux-tree-node
                         slot="node"
                         role="treeitem"
@@ -258,10 +230,8 @@
                         class="hydrated"
                         aria-level="3"
                     >
-                        <!--?lit$4710966951$-->Tree item 1.4.1
-                        <!--?lit$4710966951$-->
+                        Tree item 1.4.1
                     </rux-tree-node>
-                    <!----><!---->
                     <rux-tree-node
                         slot="node"
                         role="treeitem"
@@ -270,10 +240,8 @@
                         class="hydrated"
                         aria-level="3"
                     >
-                        <!--?lit$4710966951$-->Tree item 1.4.2
-                        <!--?lit$4710966951$-->
+                        Tree item 1.4.2
                     </rux-tree-node>
-                    <!----><!---->
                     <rux-tree-node
                         slot="node"
                         role="treeitem"
@@ -282,12 +250,9 @@
                         class="hydrated"
                         aria-level="3"
                     >
-                        <!--?lit$4710966951$-->Tree item 1.4.3
-                        <!--?lit$4710966951$-->
+                        Tree item 1.4.3
                     </rux-tree-node>
-                    <!---->
                 </rux-tree-node>
-                <!----><!---->
                 <rux-tree-node
                     slot="node"
                     role="treeitem"
@@ -295,22 +260,26 @@
                     aria-selected="false"
                     class="hydrated"
                     aria-level="2"
-                >
-                    <!--?lit$4710966951$-->Tree item 1.5
-                    <!--?lit$4710966951$-->
+                    >Tree item 1.5
                 </rux-tree-node>
-                <!---->
             </rux-tree-node>
-            <!----><!---->
             <rux-tree-node
+                id="test-expanded"
                 role="treeitem"
                 aria-expanded="false"
                 aria-selected="false"
                 aria-level="1"
                 class="hydrated"
-            >
-                <!--?lit$4710966951$-->Tree item 2
-                <!--?lit$4710966951$--><!---->
+                >Tree item 2
+                <rux-tree-node
+                    slot="node"
+                    role="treeitem"
+                    aria-expanded="false"
+                    aria-selected="false"
+                    class="hydrated"
+                    aria-level="2"
+                    >Tree item 2.1
+                </rux-tree-node>
                 <rux-tree-node
                     slot="node"
                     role="treeitem"
@@ -319,10 +288,8 @@
                     class="hydrated"
                     aria-level="2"
                 >
-                    <!--?lit$4710966951$-->Tree item 2.1
-                    <!--?lit$4710966951$-->
+                    Tree item 2.2
                 </rux-tree-node>
-                <!----><!---->
                 <rux-tree-node
                     slot="node"
                     role="treeitem"
@@ -331,24 +298,9 @@
                     class="hydrated"
                     aria-level="2"
                 >
-                    <!--?lit$4710966951$-->Tree item 2.2
-                    <!--?lit$4710966951$-->
+                    Tree item 2.3
                 </rux-tree-node>
-                <!----><!---->
-                <rux-tree-node
-                    slot="node"
-                    role="treeitem"
-                    aria-expanded="false"
-                    aria-selected="false"
-                    class="hydrated"
-                    aria-level="2"
-                >
-                    <!--?lit$4710966951$-->Tree item 2.3
-                    <!--?lit$4710966951$-->
-                </rux-tree-node>
-                <!---->
             </rux-tree-node>
-            <!----><!---->
             <rux-tree-node
                 role="treeitem"
                 aria-expanded="false"
@@ -356,10 +308,13 @@
                 class="hydrated"
                 aria-level="1"
             >
-                <!--?lit$4710966951$-->Tree item 3
-                <!--?lit$4710966951$-->
+                Tree item 3
             </rux-tree-node>
-            <!---->
         </rux-tree>
+        <script>
+            document.addEventListener('ruxtreenodeexpanded', function (event) {
+                console.log('rux-tree-node-expanded', event.detail)
+            })
+        </script>
     </body>
 </html>

--- a/packages/web-components/src/components/rux-tree/test/rux-tree.e2e.js
+++ b/packages/web-components/src/components/rux-tree/test/rux-tree.e2e.js
@@ -16,4 +16,39 @@ describe('Tree', () => {
         cy.realPress('ArrowLeft')
         cy.focused().should('not.have.attr', 'expanded')
     })
+    it('emits ruxtreenodeselected event', () => {
+        cy.document().invoke(
+            'addEventListener',
+            'ruxtreenodeselected',
+            cy.stub().as('ruxtreenodeselected')
+        )
+        cy.get('rux-tree-node').first().shadow().find('.parent').click()
+        cy.get('@ruxtreenodeselected').should('be.calledOnce')
+    })
+    it('emits ruxtreenodeexpanded', () => {
+        cy.document().invoke(
+            'addEventListener',
+            'ruxtreenodeexpanded',
+            cy.stub().as('ruxtreenodeexpanded')
+        )
+        cy.get('#test-expanded').shadow().find('.parent').find('.arrow').click()
+        cy.get('@ruxtreenodeexpanded')
+            .should('be.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('include', 'node')
+    })
+    it('emits ruxtreenodecollapsed', () => {
+        cy.document().invoke(
+            'addEventListener',
+            'ruxtreenodecollapsed',
+            cy.stub().as('ruxtreenodecollapsed')
+        )
+        // Need to open it first to test
+        cy.get('#test-expanded').shadow().find('.parent').find('.arrow').click()
+        cy.get('#test-expanded').shadow().find('.parent').find('.arrow').click()
+        cy.get('@ruxtreenodecollapsed')
+            .should('be.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('include', 'node')
+    })
 })

--- a/packages/web-components/src/stories/tree.stories.mdx
+++ b/packages/web-components/src/stories/tree.stories.mdx
@@ -9,7 +9,7 @@ import { html, render } from 'lit-html'
     argTypes={extractArgTypes('rux-tree')}
     parameters={{
         actions: {
-            handles: ['ruxtreenodeselected rux-tree-node'],
+            handles: ['ruxtreenodeselected rux-tree-node', 'ruxtreenodeexpanded rux-tree-node', 'ruxtreenodecollapsed rux-tree-node'],
         },
     }}
 />


### PR DESCRIPTION
## Brief Description

Adds `ruxtreenodeexpanded` and `ruxtreenodecollapsed` events to rux-tree-node. This event emits the node ID, similar to how the existing expanded event works. 
Tests were added to cover all events, including selected. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4081

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/571
## General Notes

## Motivation and Context

Issue raised by user. Allows for easier saving of state when using rux-tree.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
