### PR TITLE
docs(modal, dialog): updated ruxmodalclosed event description

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,9 @@ jobs:
       - uses: actions/cache@v2
         id: cache-node-modules
         with:
-          path: ./packages/web-components/node_modules
+          path: |
+            ./packages/web-components/node_modules
+            ~/.cache/Cypress
           key: node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm run web-comps.install
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -46,14 +48,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Cache NPM and Cypress 📦
         uses: actions/cache@v2
-        id: cache-modules-and-cypress
         with:
           path: |
             ./packages/web-components/node_modules
             ~/.cache/Cypress
           key: node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm i cypress@8.0.0
-        if: steps.cache-modules-and-cypress.outputs.cache-hit != 'true'
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
       - name: Cypress tests 🧪
         uses: cypress-io/github-action@v4
         with:

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -20534,7 +20534,7 @@ declare namespace LocalJSX {
          */
         "modalTitle"?: string;
         /**
-          * Event that is fired when dialog closes
+          * Event that is fired when dialog closes. If dialog is closed by clicking on the default confirm or deny buttons (when no footer slot is provided), then true or false will be emitted respectively.
          */
         "onRuxdialogclosed"?: (event: CustomEvent<boolean | null>) => void;
         /**
@@ -32363,7 +32363,7 @@ declare namespace LocalJSX {
          */
         "modalTitle"?: string;
         /**
-          * Event that is fired when modal closes
+          * Event that is fired when modal closes. If modal is closed by clicking on the default confirm or deny buttons (when no footer slot is provided), then true or false will be emitted respectively.
          */
         "onRuxmodalclosed"?: (event: CustomEvent<boolean | null>) => void;
         /**

--- a/packages/web-components/src/components/rux-dialog/readme.md
+++ b/packages/web-components/src/components/rux-dialog/readme.md
@@ -71,10 +71,10 @@ Or use slots to render the header, content and footer.
 
 ## Events
 
-| Event             | Description                            | Type                           |
-| ----------------- | -------------------------------------- | ------------------------------ |
-| `ruxdialogclosed` | Event that is fired when dialog closes | `CustomEvent<boolean \| null>` |
-| `ruxdialogopened` | Event that is fired when dialog opens  | `CustomEvent<void>`            |
+| Event             | Description                                                                                                                                                                                        | Type                           |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `ruxdialogclosed` | Event that is fired when dialog closes. If dialog is closed by clicking on the default confirm or deny buttons (when no footer slot is provided), then true or false will be emitted respectively. | `CustomEvent<boolean \| null>` |
+| `ruxdialogopened` | Event that is fired when dialog opens                                                                                                                                                              | `CustomEvent<void>`            |
 
 
 ## Slots

--- a/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
+++ b/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
@@ -62,7 +62,7 @@ export class RuxDialog {
     })
     ruxDialogOpened!: EventEmitter<void>
     /**
-     * Event that is fired when dialog closes
+     * Event that is fired when dialog closes. If dialog is closed by clicking on the default confirm or deny buttons (when no footer slot is provided), then true or false will be emitted respectively.
      */
     @Event({
         eventName: 'ruxdialogclosed',

--- a/packages/web-components/src/components/rux-modal/readme.md
+++ b/packages/web-components/src/components/rux-modal/readme.md
@@ -66,10 +66,10 @@ Pass properties as attributes of the Astro Rux Modal custom element:
 
 ## Events
 
-| Event            | Description                           | Type                           |
-| ---------------- | ------------------------------------- | ------------------------------ |
-| `ruxmodalclosed` | Event that is fired when modal closes | `CustomEvent<boolean \| null>` |
-| `ruxmodalopened` | Event that is fired when modal opens  | `CustomEvent<void>`            |
+| Event            | Description                                                                                                                                                                                      | Type                           |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ |
+| `ruxmodalclosed` | Event that is fired when modal closes. If modal is closed by clicking on the default confirm or deny buttons (when no footer slot is provided), then true or false will be emitted respectively. | `CustomEvent<boolean \| null>` |
+| `ruxmodalopened` | Event that is fired when modal opens                                                                                                                                                             | `CustomEvent<void>`            |
 
 
 ## Slots

--- a/packages/web-components/src/components/rux-modal/rux-modal.tsx
+++ b/packages/web-components/src/components/rux-modal/rux-modal.tsx
@@ -64,7 +64,7 @@ export class RuxModal {
     })
     ruxModalOpened!: EventEmitter<void>
     /**
-     * Event that is fired when modal closes
+     * Event that is fired when modal closes. If modal is closed by clicking on the default confirm or deny buttons (when no footer slot is provided), then true or false will be emitted respectively.
      */
     @Event({
         eventName: 'ruxmodalclosed',


### PR DESCRIPTION
## Brief Description

Adds a better description on how the ruxmodalclosed event works for modal/dialog. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4078

## Related Issue

## General Notes

I only updated the event decorator (and by extension the readmes). I could also add something to the SB if we think it's needed.

## Motivation and Context

The ruxmodalclosed event was ambiguous in that it returns either boolean or null.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
