### PR TITLE
Astro 3999 glossary update

### DIFF
--- a/packages/astro-uxds/_content/_data/navigation.json
+++ b/packages/astro-uxds/_content/_data/navigation.json
@@ -104,6 +104,10 @@
       {
         "label": "Forms and Validation",
         "url": "/patterns/forms-and-validation"
+      },
+      {
+        "label": "Sign In",
+        "url": "/patterns/sign-in"
       }
     ]
   },
@@ -206,10 +210,6 @@
       {
         "label": "Segmented Button",
         "url": "/components/segmented-button"
-      },
-      {
-        "label": "Sign In",
-        "url": "/components/sign-in"
       },
       {
         "label": "Select Menu",

--- a/packages/astro-uxds/_content/design-guidelines/glossary.md
+++ b/packages/astro-uxds/_content/design-guidelines/glossary.md
@@ -28,7 +28,7 @@ title: Glossary
 - Close Button - A UI component that, when activated, dismisses a [Dialog](/components/dialog).
 - [Color Palettes](/design-guidelines/color) - The list of color values used in and approved by the Astro design system.
 - [Compliance](/design-guidelines/compliance) - A list of rules used to determine if products align with Astro design and usage patterns.
-- Containers - Used to group multiple components into a specific area that allows them to flow in a flexible/responsive manner. Containers can be used to help manage lists, tables, dialogs, modals, slide out panels, content containers (top and bottom), and other components.
+- [Containers](/components/container) - Used to group multiple components into a specific area that allows them to flow in a flexible/responsive manner. Containers can be used to help manage lists, tables, dialogs, modals, slide out panels, content containers (top and bottom), and other components.
 - [Concept Sketch](/design-process/ui-design) - A sketch on paper that lays out the main content workspace and controls and clarifies the flow of user interaction from screen-to-screen.
 
 ### D

--- a/packages/astro-uxds/_content/design-guidelines/glossary.md
+++ b/packages/astro-uxds/_content/design-guidelines/glossary.md
@@ -13,6 +13,7 @@ title: Glossary
 - Activation - The manner in which users invoke an action on the currently selected object(s).
 - Alarm - The most critical alert category. Indicates that a condition exists which requires immediate operator action.
 - Alert - Indication of a condition regarding people, systems, or the mission, categorized into alarms, warnings, events, and informational messages.
+- [Application State](/components/application-state/) - A tag on the Global Status Bar that presents what state the application is in, such as Production, Review, or Testing.
 
 ### B
 
@@ -20,6 +21,7 @@ title: Glossary
 
 ### C
 
+- Cards - A container for short, related pieces of information.
 - [Checkbox](/components/checkbox) - A Checkbox allows a user to select a value from a small set of options.
 - [Classification & Control Markings](/components/classification-markings) - Markings required to be present on software that includes controlled or classified information.
 - [Clock](/components/clock) - Clock shows the current date and time, and optional AOS and LOS timers.
@@ -27,13 +29,19 @@ title: Glossary
 - [Color Palettes](/design-guidelines/color) - The list of color values used in and approved by the Astro design system.
 - [Compliance](/design-guidelines/compliance) - A list of rules used to determine if products align with Astro design and usage patterns.
 - Container - An object that holds other objects.
+- Containers - Used to group multiple components into a specific area that allows them to flow in a flexible/responsive manner. Containers can be used to help manage lists, tables, dialogs, modals, slide out panels, content containers (top and bottom), and other components.
 - [Concept Sketch](/design-process/ui-design) - A sketch on paper that lays out the main content workspace and controls and clarifies the flow of user interaction from screen-to-screen.
 
 ### D
 
 - [Data Visualization](/patterns/data-visualization) - The goal of Data Visualization is to make complex information accessible and easy to digest in a visual manner.
 - Default Action - The action that users would most likely want to execute in the window with focus.
+- [Design Tokens](design-tokens/getting-started) - A pairing of the same code and visual properties in a format that is deployable across all platforms, acting as a single source of truth for both designers and developers.
 - [Dialog](/components/dialog) - A Dialog interrupts app processing to prompt a user to confirm an action or acknowledge a piece of information. It displays information along with a set of buttons allowing users to accept or cancel the actions presented within the Dialog.
+
+### F
+
+- [Forms](patterns/forms-and-validation/) - A text field, input, or inputs which require interaction with the user to complete an action such as signing up for an account.
 
 ### G
 
@@ -68,7 +76,7 @@ title: Glossary
 ### P
 
 - [Pagination](/components/pagination) - The process of dividing content for display on multiple pages. It is utilized when content, such as Search results, does not fit onto one page and must be split across multiple pages.
-- [Pop-Up Menu](/components/pop-up) - A Pop-Up Menu provides users with a quick way to access common actions for a highlighted item.
+- [Pop-Up](/components/pop-up) - A dialogue that provides users with a quick way to access additional information or actions.
 - [Progress Indicator](/components/progress) - A Progress Indicator signals that an application is busy performing an operation.
 - [Push Button](/components/push-button) - A control that initiates an action.
 
@@ -82,9 +90,12 @@ title: Glossary
 - [Search](/components/search) - A specialized text field for entering search terms.
 - [Segmented Button](/components/segmented-button) - Allows users to select one item at a time from two to four options.
 - [Select Menu](/components/select) - A UI control that allows users to select a value from a list of values.
+- [Sign In](/patterns/sign-in) - A form input in which a user enters authenticating information to gain access to specific information or usage of an application.
 - [Slider](/components/slider) - A graphical control element that allows users to choose from a range of continuous and discrete values.
 - [Spectrum Analyzer](/components/spectrum-analyzer) - Often called “Spec-A”, Spectrum Analysis diagrams display power levels over a specific band.
 - [Status Indicator](/components/status-symbol) - Indicates the state of a device or feature in a standard and consistent way using color, shapes, labeling, and badging.
+- [Status System](/patterns/status-system) - A combination of colors and symbols to convey the status of a system.
+- Status Tags - A version of tags using colors and keywords to denote critical system information.
 - [Switch](/components/switch) - A Switch which describes a state or value. It allows users to change a setting between two states such as “On" and "Off."
 - [Symbols](/components/icons-and-symbols) - A graphical representation or glyph associated with actions, concepts, or objects such as an asterisk.
 
@@ -92,6 +103,8 @@ title: Glossary
 
 - [Tabs](/components/tabs) - Tabs in Astro Applications are used to divide major areas of content and to indicate work process.
 - [Tables](/patterns/table) - A UX design mechanism comprised of rows and columns used for displaying content.
+- Tags - Small markers which often use color to identify important information at a glance, as well as filter and categorize items by keywords.
+- Textareas - A multi-line text input control often used in a form to collect user inputs like comments or reviews.
 - [Theme](/design-guidelines/theme) - A preset set of colors applied as a group to the design system.
 - [Timeline](/components/timeline) - Displays event information within a specified time period.
 - Title Bar - A component that displays the name for a table or window.

--- a/packages/astro-uxds/_content/design-guidelines/glossary.md
+++ b/packages/astro-uxds/_content/design-guidelines/glossary.md
@@ -28,7 +28,6 @@ title: Glossary
 - Close Button - A UI component that, when activated, dismisses a [Dialog](/components/dialog).
 - [Color Palettes](/design-guidelines/color) - The list of color values used in and approved by the Astro design system.
 - [Compliance](/design-guidelines/compliance) - A list of rules used to determine if products align with Astro design and usage patterns.
-- Container - An object that holds other objects.
 - Containers - Used to group multiple components into a specific area that allows them to flow in a flexible/responsive manner. Containers can be used to help manage lists, tables, dialogs, modals, slide out panels, content containers (top and bottom), and other components.
 - [Concept Sketch](/design-process/ui-design) - A sketch on paper that lays out the main content workspace and controls and clarifies the flow of user interaction from screen-to-screen.
 

--- a/packages/astro-uxds/_content/patterns/sign-in.md
+++ b/packages/astro-uxds/_content/patterns/sign-in.md
@@ -1,6 +1,6 @@
 ---
-tags: components
-path: /components/sign-in
+tags: patterns
+path: /patterns/sign-in
 date: Last Modified
 layout: components.template.njk
 title: Sign In

--- a/packages/astro-uxds/_content/patterns/sign-in.md
+++ b/packages/astro-uxds/_content/patterns/sign-in.md
@@ -4,12 +4,6 @@ path: /patterns/sign-in
 date: Last Modified
 layout: components.template.njk
 title: Sign In
-demo: astro-uxds-patterns-sign-in--page
-storybook: astro-uxds-patterns-sign-in--page
-git: rux-sign-in
-height: 400px
-theme: true
-scrolling: yes
 ---
 
 # Sign In

--- a/packages/astro-uxds/netlify.toml
+++ b/packages/astro-uxds/netlify.toml
@@ -105,3 +105,9 @@ command = "npm run build"
 	to = "/components/dialog"
 	status = 301
 	force = true
+
+[[redirects]]
+	from = "/components/sign-in"
+	to = "/patterns/sign-in"
+	status = 301
+	force = true


### PR DESCRIPTION
## Brief Description

Updates the glossary page of astrouxds with new copy/terms. Moves the sign-in pattern to be in /patterns instead of /components.

With that sign in move, I'm thinking we can get rid of the SB iframe and convert it to the 'internal.template.njk' that the other patterns are using. Thoughts? 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-3999

## Related Issue

## General Notes

## Motivation and Context

Glossary update

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
