### PR TITLE
[DRAFT] fix(web-components): fix shadow dom encapsulation

### DIFF
--- a/.changeset/thirty-apes-report.md
+++ b/.changeset/thirty-apes-report.md
@@ -1,0 +1,22 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Checkbox Group - Label's text color and typography are now fully shadow dom encapsulated.
+
+Clock - timesetamps text color are now fully shadow dom encapsulated.
+
+GSB - app version text color and typography are now fully shadow dom encapsulated.
+
+Notification - message text color and typography are now fully shadow dom encapsulated.
+
+Progress - value typography is now fully shadow dom encapsulated.
+
+Tree Node - text color and typography are now fully shadow dom encapsulated.
+
+Monitoring Progress Icon - label text color is now fully shadow dom encapsulated.
+
+Radio Group - Label's text color and typography are now fully shadow dom encapsulated.

--- a/packages/web-components/.storybook/preview-head.html
+++ b/packages/web-components/.storybook/preview-head.html
@@ -17,6 +17,63 @@
     /**
     * See [Theming](https://github.com/storybookjs/storybook/blob/next/addons/docs/docs/theming.md)
     */
+
+    rux-button,
+    rux-button-group,
+    rux-card,
+    rux-checkbox,
+    rux-checkbox-group,
+    rux-classification-marking,
+    rux-clock,
+    rux-container,
+    rux-datetime,
+    rux-dialog,
+    rux-global-status-bar,
+    rux-icon,
+    rux-indeterminate-progress,
+    rux-input,
+    rux-log,
+    rux-menu,
+    rux-menu-item,
+    rux-menu-item-divider,
+    rux-monitoring-icon,
+    rux-monitoring-progress-icon,
+    rux-notification,
+    rux-option,
+    rux-option-group,
+    rux-pop-up-menu,
+    rux-progress,
+    rux-push-button,
+    rux-radio,
+    rux-radio-group,
+    rux-ruler,
+    rux-segmented-button,
+    rux-select,
+    rux-slider,
+    rux-status,
+    rux-switch,
+    rux-tab,
+    rux-tab-panel,
+    rux-tab-panels,
+    rux-table,
+    rux-table-body,
+    rux-table-cell,
+    rux-table-header,
+    rux-table-header-cell,
+    rux-table-header-row,
+    rux-table-row,
+    rux-tabs,
+    rux-tag,
+    rux-textarea,
+    rux-time-region,
+    rux-timeline,
+    rux-track,
+    rux-tree,
+    rux-tree-node {
+        color: blue;
+        font: 700 2.5rem system-ui;
+    }
+
     .sbdocs.sbdocs-wrapper {
         background: var(--color-background-base-default);
     }

--- a/packages/web-components/src/components/rux-checkbox-group/rux-checkbox-group.scss
+++ b/packages/web-components/src/components/rux-checkbox-group/rux-checkbox-group.scss
@@ -22,6 +22,12 @@
 }
 
 .rux-label {
+    color: var(--color-text-primary);
+    font-family: var(--font-body-1-font-family);
+    font-size: var(--font-body-1-font-size);
+    font-weight: var(--font-body-1-font-weight);
+    letter-spacing: var(--font-body-1-letter-spacing);
+    line-height: var(--font-body-1-line-height);
     margin-bottom: var(--spacing-input-label-top);
     &__asterisk {
         margin-left: 4px;

--- a/packages/web-components/src/components/rux-clock/rux-clock.scss
+++ b/packages/web-components/src/components/rux-clock/rux-clock.scss
@@ -42,6 +42,7 @@
 .rux-clock__segment__value {
     display: flex;
     align-items: center;
+    color: var(--gsb-color-text);
     font-family: var(--font-monospace-1-font-family);
     font-weight: var(--font-monospace-1-font-weight);
     font-size: var(--font-monospace-1-font-size);
@@ -77,5 +78,5 @@
 }
 
 .rux-clock__aos {
-    margin-left: 1.063em;
+    margin-left: 1.25rem; //20px
 }

--- a/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.scss
+++ b/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.scss
@@ -91,8 +91,11 @@ slot[name='left-side'] > .shifted-up,
 
 .app-version {
     display: inline-block;
+    font-family: var(--font-heading-6-font-family);
     font-size: var(--font-heading-6-font-size);
     font-weight: var(--font-heading-6-font-weight);
+    letter-spacing: var(--font-heading-6-letter-spacing);
+    line-height: var(--font-heading-6-line-height);
 }
 
 .app-state-wrapper {

--- a/packages/web-components/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.scss
+++ b/packages/web-components/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.scss
@@ -133,6 +133,7 @@ svg.rux-status--critical {
 }
 
 .rux-advanced-status__progress {
+    color: var(--color-text-primary);
     font-family: var(--font-monospace-1-font-family);
     font-size: var(--font-body-3-font-size);
     font-weight: var(--font-monospace-1-font-weight);

--- a/packages/web-components/src/components/rux-notification/rux-notification.scss
+++ b/packages/web-components/src/components/rux-notification/rux-notification.scss
@@ -60,6 +60,13 @@
     }
 }
 .rux-notification__message {
+    color: var(--notification-text-color);
+    font-family: var(--font-heading-5-font-family);
+    font-weight: var(--font-heading-5-font-weight);
+    font-size: var(--font-heading-5-font-size);
+    letter-spacing: var(--font-heading-5-letter-spacing);
+    line-height: var(--font-heading-5-line-height);
+    font-weight: var(--font-heading-5-font-weight);
     padding: 1.063rem 0; //17 0
 }
 

--- a/packages/web-components/src/components/rux-progress/rux-progress.scss
+++ b/packages/web-components/src/components/rux-progress/rux-progress.scss
@@ -101,6 +101,11 @@
     }
 }
 .rux-progress__value {
+    font-family: var(--font-body-1-font-family);
+    font-weight: var(--font-body-1-font-weight);
+    font-size: var(--font-body-1-font-size);
+    letter-spacing: var(--font-body-1-letter-spacing);
+    line-height: var(--font-body-1-line-height);
     margin-left: 0.5rem;
     text-align: right;
     color: var(--progress-label-color);

--- a/packages/web-components/src/components/rux-radio-group/rux-radio-group.scss
+++ b/packages/web-components/src/components/rux-radio-group/rux-radio-group.scss
@@ -31,6 +31,12 @@
 }
 
 .rux-label {
+    color: var(--color-text-primary);
+    font-family: var(--font-body-1-font-family);
+    font-size: var(--font-body-1-font-size);
+    font-weight: var(--font-body-1-font-weight);
+    letter-spacing: var(--font-body-1-letter-spacing);
+    line-height: var(--font-body-1-line-height);
     margin-bottom: var(--spacing-input-label-top);
     &__asterisk {
         margin-left: 4px;

--- a/packages/web-components/src/components/rux-tree-node/rux-tree-node.scss
+++ b/packages/web-components/src/components/rux-tree-node/rux-tree-node.scss
@@ -34,16 +34,17 @@
     width: 100%;
     padding: 0;
     margin: 0;
-    font-family: var(--font-body-1-font-family);
-    font-size: var(--font-body-1-font-size);
-    font-weight: var(--font-body-1-font-weight);
-    letter-spacing: var(--font-body-1-letter-spacing);
-    color: var(--tree-text-color);
     user-select: none;
     display: block;
 }
 
 .tree-node {
+    color: var(--color-text-primary);
+    font-family: var(--font-body-1-font-family);
+    font-size: var(--font-body-1-font-size);
+    font-weight: var(--font-body-1-font-weight);
+    letter-spacing: var(--font-body-1-letter-spacing);
+    line-height: var(--font-body-1-line-height);
     border-top: 1px solid var(--color-border-interactive-muted);
     .parent {
         border-left: 1px solid var(--color-border-interactive-muted);


### PR DESCRIPTION
## Brief Description

This PR fixes a number of bugs where components were not properly being shadow dom encapsulated.

Check changeset for more detailed list of what's been changed

This is gonna probably become a monster PR and very difficult to review so I wanted to open it up as a draft as early as possible. how would ya'll prefer to review this? I could alternatively do separate PRs for every component but the changes are going to be the same mostly. 

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Motivation and Context

Noticed that when I removed our light dom stylesheet that a bunch of components broke because we were either not explicitly setting properties or styling :host. 

To test this, I ran two snapshots--one with main as baseline and another I added the following overrides:

```    
rux-button, rux-tree-node, ...rux-every-single-component {
        color: blue;
        font: 700 2.5rem/2 system-ui;
}
```

This tests that text colors, font size, font weight, line height, and font family can't be simply inherited from their parents. I originally had background color in there as well, but realized that there's some cases where this would be appropriate (secondary button, icons, where the bg should be transparent). 

This led to totally wild and unexpected results, particularly in components that were using ems for things like margin.

## Issues and Limitations

- ignoring tables for now because the docs state its ok to style host and they're already problematic. 

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
