### PR TITLE
fix(rux-tabs): can no longer change shadow dom typography styles

### DIFF
--- a/.changeset/loud-planes-accept.md
+++ b/.changeset/loud-planes-accept.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": minor
+"@astrouxds/angular": minor
+"astro-website": minor
+"@astrouxds/react": minor
+"@astrouxds/astro-web-components": minor
+---
+
+Tab - Added new explicit `small` attribute

--- a/.changeset/pink-mangos-switch.md
+++ b/.changeset/pink-mangos-switch.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": major
+"@astrouxds/angular": major
+"astro-website": major
+"@astrouxds/react": major
+"@astrouxds/astro-web-components": major
+---
+
+Tabs - Fixed an issue where light dom styles could override the shadow dom. Check to make sure you aren't explicitly styling `rux-tab` elements. If you are, use parts instead

--- a/.changeset/violet-buttons-arrive.md
+++ b/.changeset/violet-buttons-arrive.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": major
+"@astrouxds/angular": major
+"astro-website": major
+"@astrouxds/react": major
+"@astrouxds/astro-web-components": major
+---
+
+Tabs - Individual tab components are now large by default. If you are using rux-tab outside the tabs component, you may need to manually add the new `small` attribute

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -8,7 +8,6 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { Classification, Status, StatusTags } from "./common/commonTypes.module";
 import { LogRow } from "./components/rux-log/rux-log.model";
 import { RangeItem } from "./components/rux-monitoring-progress-icon/rux-monitoring-progress-icon";
-import { Placement } from "@floating-ui/dom";
 import { SegmentedButton } from "./components/rux-segmented-button/rux-segmented-button.model";
 export namespace Components {
     interface RuxButton {
@@ -46,8 +45,6 @@ export namespace Components {
           * The horizontal alignment of buttons within the group
          */
         "hAlign": 'left' | 'center' | 'right';
-    }
-    interface RuxCard {
     }
     interface RuxCheckbox {
         /**
@@ -152,8 +149,6 @@ export namespace Components {
           * Accepts the [IANA timezone string format](https://www.iana.org/time-zones) such as `'America/Los_Angeles'` or any single-character designation for a [military timezones](https://en.wikipedia.org/wiki/List_of_military_time_zones) (`'A'` through `'Z'`, excluding `'J'`), both case-insensitive. If no value for timezone is provided, the clock will use `'UTC'`. See [`toLocaleString()` on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString#Parameters) for more details.
          */
         "timezone": string;
-    }
-    interface RuxContainer {
     }
     interface RuxDatetime {
         /**
@@ -11889,8 +11884,6 @@ export namespace Components {
         | 'auto'
         | string;
     }
-    interface RuxIndeterminateProgress {
-    }
     interface RuxInput {
         /**
           * The input's autocomplete attribute
@@ -11984,23 +11977,55 @@ export namespace Components {
          */
         "timezone": string;
     }
-    interface RuxMenu {
-    }
     interface RuxMenuItem {
         /**
-          * sets the menu item as disabled
+          * Disables the item
          */
         "disabled": boolean;
         /**
-          * sets the menu item as selected
+          * This attribute instructs browsers to download a URL instead of navigating to it, so the user will be prompted to save it as a local file. If the attribute has a value, it is used as the pre-filled file name in the Save prompt (the user can still change the file name if they want).
          */
-        "selected": boolean;
+        "download": string | undefined;
         /**
-          * the value returned when item is selected. If no value is given, the text content will be used.
+          * Contains a URL or a URL fragment that the hyperlink points to. If this property is set, an anchor tag will be rendered.
+         */
+        "href": string | undefined;
+        /**
+          * Specifies the relationship of the target object to the link object. The value is a space-separated list of [link types](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types).
+         */
+        "rel": string | undefined;
+        /**
+          * Specifies where to display the linked URL. Only applies when an `href` is provided. Special keywords: `"_blank"`, `"_self"`, `"_parent"`, `"_top"`.
+         */
+        "target": string | undefined;
+        /**
+          * Value returned when item is selected. If no value is given, the text content will be used.
          */
         "value": any;
     }
     interface RuxMenuItemDivider {
+    }
+    interface RuxModal {
+        /**
+          * Text for confirmation button
+         */
+        "confirmText": string;
+        /**
+          * Text for close button
+         */
+        "denyText": string;
+        /**
+          * Modal body message
+         */
+        "modalMessage"?: string;
+        /**
+          * Modal header title
+         */
+        "modalTitle"?: string;
+        /**
+          * Shows and hides modal
+         */
+        "open": boolean;
     }
     interface RuxMonitoringIcon {
         /**
@@ -12060,10 +12085,6 @@ export namespace Components {
          */
         "closeAfter"?: number;
         /**
-          * Prevents the user from dismissing the notification. Hides the `actions` slot.
-         */
-        "hideClose": boolean;
-        /**
           * Message for the notification banner.
          */
         "message": string;
@@ -12078,7 +12099,7 @@ export namespace Components {
         /**
           * The background color. Possible values include 'off', 'standby', 'normal', 'caution', 'serious' and 'critical'. See [Astro UXDS Status System](https://astrouxds.com/patterns/status-system/).
          */
-        "status"?: Status;
+        "status": Status;
     }
     interface RuxOption {
         /**
@@ -12102,25 +12123,33 @@ export namespace Components {
     }
     interface RuxPopUpMenu {
         /**
-          * Closes the pop up menu and returns false.
+          * Element to anchor the menu to. If none is given the menu will anchor to the trigger element where aria-controls === menu id
          */
-        "hide": () => Promise<false>;
+        "anchorEl"?: HTMLElement;
         /**
-          * determines if the pop up is open or closed
+          * Closes the menu. If the menu is already closed it returns 'false'.
+         */
+        "close": () => Promise<boolean>;
+        /**
+          * Returns 'true' if the menu is open, 'false' if it is not.
+         */
+        "isOpen": () => Promise<boolean>;
+        /**
+          * Boolean which controls when to show the menu
          */
         "open": boolean;
         /**
-          * the placement of the pop up relative to it's slotted trigger element.
+          * Opens the menu. If the menu is already open it returns 'false'.
          */
-        "placement": Placement;
+        "show": () => Promise<boolean>;
         /**
-          * Opens the pop up menu and returns true.
+          * Toggles the menu open or close. Will return 'true' on menu open and 'false' on menu close
          */
-        "show": () => Promise<true>;
+        "toggle": () => Promise<boolean>;
         /**
-          * The position strategy of the popup, either absolute or fixed.
+          * Optional element to trigger opening and closing of the menu. If none is supplied the element where aria-controls === menu id will be assigned
          */
-        "strategy": 'absolute' | 'fixed';
+        "triggerEl"?: HTMLElement;
     }
     interface RuxProgress {
         /**
@@ -12379,6 +12408,10 @@ export namespace Components {
           * If present, overrides which tab is selected on load / mount. By default, the first <rux-tab> item is selected.
          */
         "selected": boolean;
+        /**
+          * If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses.
+         */
+        "small": boolean;
     }
     interface RuxTabPanel {
     }
@@ -12561,12 +12594,6 @@ declare global {
         prototype: HTMLRuxButtonGroupElement;
         new (): HTMLRuxButtonGroupElement;
     };
-    interface HTMLRuxCardElement extends Components.RuxCard, HTMLStencilElement {
-    }
-    var HTMLRuxCardElement: {
-        prototype: HTMLRuxCardElement;
-        new (): HTMLRuxCardElement;
-    };
     interface HTMLRuxCheckboxElement extends Components.RuxCheckbox, HTMLStencilElement {
     }
     var HTMLRuxCheckboxElement: {
@@ -12590,12 +12617,6 @@ declare global {
     var HTMLRuxClockElement: {
         prototype: HTMLRuxClockElement;
         new (): HTMLRuxClockElement;
-    };
-    interface HTMLRuxContainerElement extends Components.RuxContainer, HTMLStencilElement {
-    }
-    var HTMLRuxContainerElement: {
-        prototype: HTMLRuxContainerElement;
-        new (): HTMLRuxContainerElement;
     };
     interface HTMLRuxDatetimeElement extends Components.RuxDatetime, HTMLStencilElement {
     }
@@ -18951,12 +18972,6 @@ declare global {
         prototype: HTMLRuxIconZoomOutMapElement;
         new (): HTMLRuxIconZoomOutMapElement;
     };
-    interface HTMLRuxIndeterminateProgressElement extends Components.RuxIndeterminateProgress, HTMLStencilElement {
-    }
-    var HTMLRuxIndeterminateProgressElement: {
-        prototype: HTMLRuxIndeterminateProgressElement;
-        new (): HTMLRuxIndeterminateProgressElement;
-    };
     interface HTMLRuxInputElement extends Components.RuxInput, HTMLStencilElement {
     }
     var HTMLRuxInputElement: {
@@ -18969,12 +18984,6 @@ declare global {
         prototype: HTMLRuxLogElement;
         new (): HTMLRuxLogElement;
     };
-    interface HTMLRuxMenuElement extends Components.RuxMenu, HTMLStencilElement {
-    }
-    var HTMLRuxMenuElement: {
-        prototype: HTMLRuxMenuElement;
-        new (): HTMLRuxMenuElement;
-    };
     interface HTMLRuxMenuItemElement extends Components.RuxMenuItem, HTMLStencilElement {
     }
     var HTMLRuxMenuItemElement: {
@@ -18986,6 +18995,12 @@ declare global {
     var HTMLRuxMenuItemDividerElement: {
         prototype: HTMLRuxMenuItemDividerElement;
         new (): HTMLRuxMenuItemDividerElement;
+    };
+    interface HTMLRuxModalElement extends Components.RuxModal, HTMLStencilElement {
+    }
+    var HTMLRuxModalElement: {
+        prototype: HTMLRuxModalElement;
+        new (): HTMLRuxModalElement;
     };
     interface HTMLRuxMonitoringIconElement extends Components.RuxMonitoringIcon, HTMLStencilElement {
     }
@@ -19194,12 +19209,10 @@ declare global {
     interface HTMLElementTagNameMap {
         "rux-button": HTMLRuxButtonElement;
         "rux-button-group": HTMLRuxButtonGroupElement;
-        "rux-card": HTMLRuxCardElement;
         "rux-checkbox": HTMLRuxCheckboxElement;
         "rux-checkbox-group": HTMLRuxCheckboxGroupElement;
         "rux-classification-marking": HTMLRuxClassificationMarkingElement;
         "rux-clock": HTMLRuxClockElement;
-        "rux-container": HTMLRuxContainerElement;
         "rux-datetime": HTMLRuxDatetimeElement;
         "rux-dialog": HTMLRuxDialogElement;
         "rux-global-status-bar": HTMLRuxGlobalStatusBarElement;
@@ -20259,12 +20272,11 @@ declare global {
         "rux-icon-zoom-in-map": HTMLRuxIconZoomInMapElement;
         "rux-icon-zoom-out": HTMLRuxIconZoomOutElement;
         "rux-icon-zoom-out-map": HTMLRuxIconZoomOutMapElement;
-        "rux-indeterminate-progress": HTMLRuxIndeterminateProgressElement;
         "rux-input": HTMLRuxInputElement;
         "rux-log": HTMLRuxLogElement;
-        "rux-menu": HTMLRuxMenuElement;
         "rux-menu-item": HTMLRuxMenuItemElement;
         "rux-menu-item-divider": HTMLRuxMenuItemDividerElement;
+        "rux-modal": HTMLRuxModalElement;
         "rux-monitoring-icon": HTMLRuxMonitoringIconElement;
         "rux-monitoring-progress-icon": HTMLRuxMonitoringProgressIconElement;
         "rux-notification": HTMLRuxNotificationElement;
@@ -20337,8 +20349,6 @@ declare namespace LocalJSX {
           * The horizontal alignment of buttons within the group
          */
         "hAlign"?: 'left' | 'center' | 'right';
-    }
-    interface RuxCard {
     }
     interface RuxCheckbox {
         /**
@@ -20455,8 +20465,6 @@ declare namespace LocalJSX {
           * Accepts the [IANA timezone string format](https://www.iana.org/time-zones) such as `'America/Los_Angeles'` or any single-character designation for a [military timezones](https://en.wikipedia.org/wiki/List_of_military_time_zones) (`'A'` through `'Z'`, excluding `'J'`), both case-insensitive. If no value for timezone is provided, the clock will use `'UTC'`. See [`toLocaleString()` on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString#Parameters) for more details.
          */
         "timezone"?: string;
-    }
-    interface RuxContainer {
     }
     interface RuxDatetime {
         /**
@@ -32200,8 +32208,6 @@ declare namespace LocalJSX {
         | 'auto'
         | string;
     }
-    interface RuxIndeterminateProgress {
-    }
     interface RuxInput {
         /**
           * The input's autocomplete attribute
@@ -32311,27 +32317,67 @@ declare namespace LocalJSX {
          */
         "timezone"?: string;
     }
-    interface RuxMenu {
-    }
     interface RuxMenuItem {
         /**
-          * sets the menu item as disabled
+          * Disables the item
          */
         "disabled"?: boolean;
         /**
-          * When a rux-menu item is selected, emits the value of that item.
+          * This attribute instructs browsers to download a URL instead of navigating to it, so the user will be prompted to save it as a local file. If the attribute has a value, it is used as the pre-filled file name in the Save prompt (the user can still change the file name if they want).
+         */
+        "download"?: string | undefined;
+        /**
+          * Contains a URL or a URL fragment that the hyperlink points to. If this property is set, an anchor tag will be rendered.
+         */
+        "href"?: string | undefined;
+        /**
+          * Emitted when item is clicked. Ex `{value : 10}`
          */
         "onRuxmenuitemselected"?: (event: CustomEvent<object>) => void;
         /**
-          * sets the menu item as selected
+          * Specifies the relationship of the target object to the link object. The value is a space-separated list of [link types](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types).
          */
-        "selected"?: boolean;
+        "rel"?: string | undefined;
         /**
-          * the value returned when item is selected. If no value is given, the text content will be used.
+          * Specifies where to display the linked URL. Only applies when an `href` is provided. Special keywords: `"_blank"`, `"_self"`, `"_parent"`, `"_top"`.
+         */
+        "target"?: string | undefined;
+        /**
+          * Value returned when item is selected. If no value is given, the text content will be used.
          */
         "value"?: any;
     }
     interface RuxMenuItemDivider {
+    }
+    interface RuxModal {
+        /**
+          * Text for confirmation button
+         */
+        "confirmText"?: string;
+        /**
+          * Text for close button
+         */
+        "denyText"?: string;
+        /**
+          * Modal body message
+         */
+        "modalMessage"?: string;
+        /**
+          * Modal header title
+         */
+        "modalTitle"?: string;
+        /**
+          * Event that is fired when modal closes. If modal is closed by clicking on the default confirm or deny buttons (when no footer slot is provided), then true or false will be emitted respectively.
+         */
+        "onRuxmodalclosed"?: (event: CustomEvent<boolean | null>) => void;
+        /**
+          * Event that is fired when modal opens
+         */
+        "onRuxmodalopened"?: (event: CustomEvent<void>) => void;
+        /**
+          * Shows and hides modal
+         */
+        "open"?: boolean;
     }
     interface RuxMonitoringIcon {
         /**
@@ -32391,10 +32437,6 @@ declare namespace LocalJSX {
          */
         "closeAfter"?: number;
         /**
-          * Prevents the user from dismissing the notification. Hides the `actions` slot.
-         */
-        "hideClose"?: boolean;
-        /**
           * Message for the notification banner.
          */
         "message"?: string;
@@ -32439,21 +32481,33 @@ declare namespace LocalJSX {
     }
     interface RuxPopUpMenu {
         /**
-          * emits the value of the selected rux-menu-item inside of rux-pop-up-menu
+          * Element to anchor the menu to. If none is given the menu will anchor to the trigger element where aria-controls === menu id
          */
-        "onRuxpopupmenuselected"?: (event: CustomEvent<any>) => void;
+        "anchorEl"?: HTMLElement;
         /**
-          * determines if the pop up is open or closed
+          * Emitted when the menu is closed.
+         */
+        "onRuxmenudidclose"?: (event: CustomEvent<void>) => void;
+        /**
+          * Emitted when the menu is open.
+         */
+        "onRuxmenudidopen"?: (event: CustomEvent<void>) => void;
+        /**
+          * Emitted when the menu is about to close
+         */
+        "onRuxmenuwillclose"?: (event: CustomEvent<void>) => void;
+        /**
+          * Emitted when the menu is about to open.
+         */
+        "onRuxmenuwillopen"?: (event: CustomEvent<void>) => void;
+        /**
+          * Boolean which controls when to show the menu
          */
         "open"?: boolean;
         /**
-          * the placement of the pop up relative to it's slotted trigger element.
+          * Optional element to trigger opening and closing of the menu. If none is supplied the element where aria-controls === menu id will be assigned
          */
-        "placement"?: Placement;
-        /**
-          * The position strategy of the popup, either absolute or fixed.
-         */
-        "strategy"?: 'absolute' | 'fixed';
+        "triggerEl"?: HTMLElement;
     }
     interface RuxProgress {
         /**
@@ -32760,6 +32814,10 @@ declare namespace LocalJSX {
           * If present, overrides which tab is selected on load / mount. By default, the first <rux-tab> item is selected.
          */
         "selected"?: boolean;
+        /**
+          * If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses.
+         */
+        "small"?: boolean;
     }
     interface RuxTabPanel {
     }
@@ -32953,12 +33011,10 @@ declare namespace LocalJSX {
     interface IntrinsicElements {
         "rux-button": RuxButton;
         "rux-button-group": RuxButtonGroup;
-        "rux-card": RuxCard;
         "rux-checkbox": RuxCheckbox;
         "rux-checkbox-group": RuxCheckboxGroup;
         "rux-classification-marking": RuxClassificationMarking;
         "rux-clock": RuxClock;
-        "rux-container": RuxContainer;
         "rux-datetime": RuxDatetime;
         "rux-dialog": RuxDialog;
         "rux-global-status-bar": RuxGlobalStatusBar;
@@ -34018,12 +34074,11 @@ declare namespace LocalJSX {
         "rux-icon-zoom-in-map": RuxIconZoomInMap;
         "rux-icon-zoom-out": RuxIconZoomOut;
         "rux-icon-zoom-out-map": RuxIconZoomOutMap;
-        "rux-indeterminate-progress": RuxIndeterminateProgress;
         "rux-input": RuxInput;
         "rux-log": RuxLog;
-        "rux-menu": RuxMenu;
         "rux-menu-item": RuxMenuItem;
         "rux-menu-item-divider": RuxMenuItemDivider;
+        "rux-modal": RuxModal;
         "rux-monitoring-icon": RuxMonitoringIcon;
         "rux-monitoring-progress-icon": RuxMonitoringProgressIcon;
         "rux-notification": RuxNotification;
@@ -34066,12 +34121,10 @@ declare module "@stencil/core" {
         interface IntrinsicElements {
             "rux-button": LocalJSX.RuxButton & JSXBase.HTMLAttributes<HTMLRuxButtonElement>;
             "rux-button-group": LocalJSX.RuxButtonGroup & JSXBase.HTMLAttributes<HTMLRuxButtonGroupElement>;
-            "rux-card": LocalJSX.RuxCard & JSXBase.HTMLAttributes<HTMLRuxCardElement>;
             "rux-checkbox": LocalJSX.RuxCheckbox & JSXBase.HTMLAttributes<HTMLRuxCheckboxElement>;
             "rux-checkbox-group": LocalJSX.RuxCheckboxGroup & JSXBase.HTMLAttributes<HTMLRuxCheckboxGroupElement>;
             "rux-classification-marking": LocalJSX.RuxClassificationMarking & JSXBase.HTMLAttributes<HTMLRuxClassificationMarkingElement>;
             "rux-clock": LocalJSX.RuxClock & JSXBase.HTMLAttributes<HTMLRuxClockElement>;
-            "rux-container": LocalJSX.RuxContainer & JSXBase.HTMLAttributes<HTMLRuxContainerElement>;
             "rux-datetime": LocalJSX.RuxDatetime & JSXBase.HTMLAttributes<HTMLRuxDatetimeElement>;
             "rux-dialog": LocalJSX.RuxDialog & JSXBase.HTMLAttributes<HTMLRuxDialogElement>;
             "rux-global-status-bar": LocalJSX.RuxGlobalStatusBar & JSXBase.HTMLAttributes<HTMLRuxGlobalStatusBarElement>;
@@ -35131,12 +35184,11 @@ declare module "@stencil/core" {
             "rux-icon-zoom-in-map": LocalJSX.RuxIconZoomInMap & JSXBase.HTMLAttributes<HTMLRuxIconZoomInMapElement>;
             "rux-icon-zoom-out": LocalJSX.RuxIconZoomOut & JSXBase.HTMLAttributes<HTMLRuxIconZoomOutElement>;
             "rux-icon-zoom-out-map": LocalJSX.RuxIconZoomOutMap & JSXBase.HTMLAttributes<HTMLRuxIconZoomOutMapElement>;
-            "rux-indeterminate-progress": LocalJSX.RuxIndeterminateProgress & JSXBase.HTMLAttributes<HTMLRuxIndeterminateProgressElement>;
             "rux-input": LocalJSX.RuxInput & JSXBase.HTMLAttributes<HTMLRuxInputElement>;
             "rux-log": LocalJSX.RuxLog & JSXBase.HTMLAttributes<HTMLRuxLogElement>;
-            "rux-menu": LocalJSX.RuxMenu & JSXBase.HTMLAttributes<HTMLRuxMenuElement>;
             "rux-menu-item": LocalJSX.RuxMenuItem & JSXBase.HTMLAttributes<HTMLRuxMenuItemElement>;
             "rux-menu-item-divider": LocalJSX.RuxMenuItemDivider & JSXBase.HTMLAttributes<HTMLRuxMenuItemDividerElement>;
+            "rux-modal": LocalJSX.RuxModal & JSXBase.HTMLAttributes<HTMLRuxModalElement>;
             "rux-monitoring-icon": LocalJSX.RuxMonitoringIcon & JSXBase.HTMLAttributes<HTMLRuxMonitoringIconElement>;
             "rux-monitoring-progress-icon": LocalJSX.RuxMonitoringProgressIcon & JSXBase.HTMLAttributes<HTMLRuxMonitoringProgressIconElement>;
             "rux-notification": LocalJSX.RuxNotification & JSXBase.HTMLAttributes<HTMLRuxNotificationElement>;

--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
@@ -25,18 +25,32 @@
     white-space: nowrap;
     text-overflow: ellipsis;
 }
-:host([small]) {
-    .rux-tab--selected {
-        border-bottom: solid 3px var(--color-border-interactive-default);
-    }
-    min-width: 2rem;
-    padding: 1.25rem 1rem; //20 16
-    border-bottom: 3px solid transparent;
+
+.rux-tab--large {
+    font-family: var(--font-heading-2-font-family);
+    font-size: var(--font-heading-2-font-size);
+    letter-spacing: var(--font-heading-2-letter-spacing);
+    font-weight: var(--font-heading-2-font-weight);
+}
+
+.rux-tab--small {
+    font-family: var(--font-heading-5-font-family);
+    font-size: var(--font-heading-5-font-size);
+    letter-spacing: var(--font-heading-5-letter-spacing);
+    font-weight: var(--font-heading-5-font-weight);
+    min-width: 5rem;
+}
+
+.rux-tab--large.rux-tab--selected {
+    border-color: var(--color-border-interactive-default);
+}
+
+.rux-tab--small.rux-tab--selected {
+    border-bottom: 3px solid var(--color-border-interactive-default);
 }
 
 .rux-tab--selected {
     color: var(--color-text-primary);
-    border-bottom: 5px solid var(--color-border-interactive-default);
 }
 
 .rux-tab--disabled {

--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.tsx
@@ -15,6 +15,11 @@ export class RuxTab {
      */
     @Prop({ reflect: true }) disabled: boolean = false
 
+    /**
+     * If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses.
+     */
+    @Prop() small: boolean = false
+
     @Element() el!: HTMLRuxTabElement
 
     connectedCallback() {
@@ -40,6 +45,8 @@ export class RuxTab {
                     class={{
                         'rux-tab': true,
                         'rux-tab--selected': this.selected,
+                        'rux-tab--small': this.small,
+                        'rux-tab--large': !this.small,
                         'rux-tab--disabled': this.disabled,
                     }}
                 >

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.scss
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.scss
@@ -2,10 +2,6 @@
     box-sizing: border-box;
     display: flex;
     justify-content: flex-start;
-    font-family: var(--font-heading-2-font-family);
-    font-size: var(--font-heading-2-font-size);
-    letter-spacing: var(--font-heading-2-letter-spacing);
-    font-weight: var(--font-heading-2-font-weight);
     min-height: 5.625rem;
     height: 100%;
     width: auto;
@@ -23,9 +19,5 @@
 }
 
 :host([small]) {
-    font-family: var(--font-heading-5-font-family);
-    font-size: var(--font-heading-5-font-size);
-    letter-spacing: var(--font-heading-5-letter-spacing);
-    font-weight: var(--font-heading-5-font-weight);
     min-height: 4.125rem; //66px
 }


### PR DESCRIPTION
## Brief Description

Part of https://github.com/RocketCommunicationsInc/astro/pull/589. Breaking into it's own PR because its pretty chonky and required some API changes. 

Tabs relied entirely on host styles so I needed to create an internal class and an explicit `small` prop/attr. 

There is one major breaking change in that rux-tab by itself is now large by default. It was previously small for some reason, which didn't make sense because rux-tabs is large by default. 

## Issues and Limitations

Our dev implementation of design is actually way off after looking at Figma closer. This should hopefully get smoothed out in the spacing effort, I was only concerned with getting our VRT to pass here. 

## Types of changes

- [x] Bug fix
- [x] New feature
- [x] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
