### PR TITLE
test(ga): added wait on timeout

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -62,3 +62,4 @@ jobs:
           install: false
           start: npm run start.stencil
           wait-on: "http://localhost:3333"
+          wait-on-timeout: "90"


### PR DESCRIPTION
## Brief Description

Adds a `wait-on-timeout` option and sets it to 90 sec in order to ensure that the stencil start command has finished before the cypress tests start.
Since it's a `wait-on`, it will keep pinging the local server until it responds and is ready to test, so it won't take 90 sec to start tests, that's just how long it _can_ wait to start tests. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4094

## Related Issue

## General Notes

## Motivation and Context

Should fix the issue of the Cypress e2e tests running before the stencil start command has finished. 

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
