### PR TITLE
docs(starter kits): removed the spinner from angular starter page

### DIFF
--- a/packages/starter-kits/angular-starter/src/app/app.component.html
+++ b/packages/starter-kits/angular-starter/src/app/app.component.html
@@ -11,7 +11,7 @@
   "
 >
   <div>
-    <rux-progress></rux-progress>
+    <h1>Add your comps!</h1>
   </div>
   <p>
     Welcome to Astro UXDS Web Components in Angular! <br />

--- a/packages/starter-kits/angular-starter/src/app/app.component.html
+++ b/packages/starter-kits/angular-starter/src/app/app.component.html
@@ -10,9 +10,8 @@
     color: white;
   "
 >
-  <div>
-    <h1>Add your comps!</h1>
-  </div>
+  <h1>Astro Components</h1>
+
   <p>
     Welcome to Astro UXDS Web Components in Angular! <br />
     Check out the README.md for more information on getting started.


### PR DESCRIPTION
## Brief Description

Removed the spinner from the angular start-up page

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-3962

## Related Issue

## General Notes

## Motivation and Context

The spinner was confusing people, so we removed it. 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
