### PR TITLE
revert(wc): reverted link change that was supposed to be in next

### DIFF
--- a/.changeset/eight-flowers-exist.md
+++ b/.changeset/eight-flowers-exist.md
@@ -1,8 +1,0 @@
----
-"@astrouxds/astro-web-components": patch
-"@astrouxds/angular": patch
-"astro-website": patch
-"@astrouxds/react": patch
----
-
-Links no longer have color change on hover

--- a/packages/web-components/src/global/_reset.scss
+++ b/packages/web-components/src/global/_reset.scss
@@ -39,6 +39,7 @@ body {
     }
     a:hover {
         text-decoration: underline;
+        color: var(--color-background-interactive-hover);
     }
 }
 


### PR DESCRIPTION
## Brief Description

Maria and I merged in a change to links on hover which was supposed to be into next, not main. Reverting here and will take the change and add it to the next branch.

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
