### PR TITLE
Feat(slider): added onChange event

### DIFF
--- a/.changeset/few-candles-pull.md
+++ b/.changeset/few-candles-pull.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/angular": minor
+"@astrouxds/react": minor
+"@astrouxds/astro-web-components": minor
+"astro-website": minor
+---
+
+Adds a ruxchange event to rux-slider.

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -32745,6 +32745,10 @@ declare namespace LocalJSX {
          */
         "onRuxblur"?: (event: CustomEvent<any>) => void;
         /**
+          * Fired when the element's value is altered by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
+         */
+        "onRuxchange"?: (event: CustomEvent<any>) => void;
+        /**
           * Fired when the value of the input changes - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
          */
         "onRuxinput"?: (event: CustomEvent<any>) => void;

--- a/packages/web-components/src/components/rux-slider/readme.md
+++ b/packages/web-components/src/components/rux-slider/readme.md
@@ -74,10 +74,11 @@ Pass properties via attributes similar to the native [HTML Input Range](https://
 
 ## Events
 
-| Event      | Description                                                                                                                                     | Type               |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| `ruxblur`  | Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)            | `CustomEvent<any>` |
-| `ruxinput` | Fired when the value of the input changes - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) | `CustomEvent<any>` |
+| Event       | Description                                                                                                                                                   | Type               |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `ruxblur`   | Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)                          | `CustomEvent<any>` |
+| `ruxchange` | Fired when the element's value is altered by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) | `CustomEvent<any>` |
+| `ruxinput`  | Fired when the value of the input changes - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)               | `CustomEvent<any>` |
 
 
 ## Slots

--- a/packages/web-components/src/components/rux-slider/rux-slider.tsx
+++ b/packages/web-components/src/components/rux-slider/rux-slider.tsx
@@ -99,6 +99,10 @@ export class RuxSlider implements FormFieldInterface {
      * Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)
      */
     @Event({ eventName: 'ruxblur' }) ruxBlur!: EventEmitter
+    /**
+     * Fired when the element's value is altered by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
+     */
+    @Event({ eventName: 'ruxchange' }) ruxChange!: EventEmitter
 
     componentWillLoad() {
         this._updateValue()
@@ -110,6 +114,7 @@ export class RuxSlider implements FormFieldInterface {
         this._onInput = this._onInput.bind(this)
         this._onBlur = this._onBlur.bind(this)
         this._handleSlotChange = this._handleSlotChange.bind(this)
+        this._onChange = this._onChange.bind(this)
     }
 
     disconnectedCallback() {
@@ -193,6 +198,10 @@ export class RuxSlider implements FormFieldInterface {
         this.ruxInput.emit()
     }
 
+    private _onChange() {
+        this.ruxChange.emit()
+    }
+
     private _onBlur = () => {
         this.ruxBlur.emit()
     }
@@ -235,6 +244,7 @@ export class RuxSlider implements FormFieldInterface {
             name,
             _onInput,
             _onBlur,
+            _onChange,
         } = this
 
         renderHiddenInput(true, el, name, JSON.stringify(this.value), disabled)
@@ -264,6 +274,7 @@ export class RuxSlider implements FormFieldInterface {
                         <input
                             id={sliderId}
                             onInput={_onInput}
+                            onChange={_onChange}
                             type="range"
                             class="rux-range"
                             min={min}

--- a/packages/web-components/src/components/rux-slider/test/index.html
+++ b/packages/web-components/src/components/rux-slider/test/index.html
@@ -27,6 +27,8 @@
 
                 <rux-slider name="ruxSliderTicks" id="ticks"></rux-slider>
 
+                <rux-slider id="change-test" max="100" value="50"></rux-slider>
+
                 <button type="submit">submit</button>
             </form>
             <ul id="log"></ul>

--- a/packages/web-components/src/components/rux-slider/test/rux-slider.e2e.js
+++ b/packages/web-components/src/components/rux-slider/test/rux-slider.e2e.js
@@ -39,4 +39,33 @@ describe('Slider with Form', () => {
     it('should render the datalist when axis-labels is provided', () => {
         cy.get('#ticks').shadow().find('.rux-slider').find('#steplist')
     })
+    it('should hear the ruxChange event', () => {
+        cy.document().invoke(
+            'addEventListener',
+            'ruxchange',
+            cy.stub().as('ruxChange')
+        )
+        // trigger a change event and expect it to fire once
+        cy.get('#change-test').trigger('change')
+        cy.get('@ruxChange').should('be.calledOnce')
+    })
+    it('should hear the ruxInput event', () => {
+        cy.document().invoke(
+            'addEventListener',
+            'ruxinput',
+            cy.stub().as('ruxInput')
+        )
+        cy.get('#change-test').trigger('input')
+        cy.get('@ruxInput').should('be.calledOnce')
+    })
+    it('should hear the ruxBlur event', () => {
+        cy.document().invoke(
+            'addEventListener',
+            'ruxblur',
+            cy.stub().as('ruxBlur')
+        )
+        cy.get('#change-test').click()
+        cy.get('#ticks').click()
+        cy.get('@ruxBlur').should('be.calledOnce')
+    })
 })

--- a/packages/web-components/src/stories/slider.stories.mdx
+++ b/packages/web-components/src/stories/slider.stories.mdx
@@ -8,7 +8,7 @@ import { html, render } from 'lit-html'
     argTypes={extractArgTypes('rux-slider')}
     parameters={{
         actions: {
-            handles: ['ruxinput rux-slider', 'ruxblur rux-slider'],
+            handles: ['ruxinput rux-slider', 'ruxblur rux-slider', 'ruxchange rux-slider'],
         },
     }}
 />


### PR DESCRIPTION
## Brief Description

Added a ruxChange event to rux-slider. 
Adds tests for events on slider.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4214

## Related Issue

https://github.com/RocketCommunicationsInc/astro/issues/609

## General Notes

## Motivation and Context

Adds the missing onchange event to slider.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
