### PR TITLE
fix(timeline): editing time events

### DIFF
--- a/.changeset/sweet-chefs-end.md
+++ b/.changeset/sweet-chefs-end.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+timeline - fixed an issue where time regions were not updating when their ranges were edited

--- a/packages/web-components/src/components/rux-timeline/rux-time-region/rux-time-region.tsx
+++ b/packages/web-components/src/components/rux-timeline/rux-time-region/rux-time-region.tsx
@@ -1,4 +1,13 @@
-import { Element, Prop, Component, Host, h } from '@stencil/core'
+import {
+    Watch,
+    Event,
+    EventEmitter,
+    Element,
+    Prop,
+    Component,
+    Host,
+    h,
+} from '@stencil/core'
 import { formatInTimeZone } from 'date-fns-tz'
 
 /**
@@ -40,6 +49,23 @@ export class RuxTimeRegion {
      * @internal - The Time Regions's time zone. Set automatically from the parent Track component.
      */
     @Prop() timezone = 'UTC'
+
+    /**
+     * @internal - Emitted when the start or end date changes so that it's parent Track can update the Time Region's position.
+     */
+    @Event({
+        eventName: 'ruxtimeregionchange',
+    })
+    ruxTimeRegionChange!: EventEmitter
+
+    @Watch('start')
+    @Watch('end')
+    handleTimeUpdate() {
+        this.ruxTimeRegionChange.emit({
+            start: this.start,
+            end: this.end,
+        })
+    }
 
     get formattedTime() {
         if (!this.start || !this.end) {

--- a/packages/web-components/src/components/rux-timeline/rux-track/rux-track.tsx
+++ b/packages/web-components/src/components/rux-timeline/rux-track/rux-track.tsx
@@ -1,4 +1,4 @@
-import { Element, Component, Prop, Host, h, Watch } from '@stencil/core'
+import { Element, Listen, Component, Prop, Host, h, Watch } from '@stencil/core'
 import { differenceInMinutes, differenceInHours } from 'date-fns'
 
 interface DateValidation {
@@ -59,11 +59,21 @@ export class RuxTrack {
         this.initializeRows()
     }
 
+    @Listen('ruxtimeregionchange')
+    handleTimeRegionChange(e: CustomEvent) {
+        this.initializeRows()
+        e.stopPropagation()
+    }
+
     connectedCallback() {
         this._handleSlotChange = this._handleSlotChange.bind(this)
     }
 
-    calculateGridColumnFromTime(time: any) {
+    /**
+     * Tracks are displayed as a (CSS) grid of cells.
+     * Each cell can represent a minute or hour depending on the interval.
+     */
+    private _calculateGridColumnFromTime(time: any) {
         if (this.start) {
             const timelineStart = new Date(this.start)
 
@@ -141,7 +151,11 @@ export class RuxTrack {
         }
     }
 
-    initializeRows() {
+    /**
+     * Time Regions are dumb and don't know anything about the grid.
+     * The Track is responsible for lining up the Time Regions with the grid.
+     */
+    private initializeRows() {
         const children = [...this.el.children].filter(
             (el) => el.tagName.toLowerCase() === 'rux-time-region'
         ) as HTMLRuxTimeRegionElement[]
@@ -154,9 +168,9 @@ export class RuxTrack {
                 el.timezone = this.timezone
                 el.style.gridRow = '1'
                 el.style.visibility = 'inherit'
-                const gridColumn = `${this.calculateGridColumnFromTime(
+                const gridColumn = `${this._calculateGridColumnFromTime(
                     el.start
-                )} / ${this.calculateGridColumnFromTime(el.end)}`
+                )} / ${this._calculateGridColumnFromTime(el.end)}`
                 el.style.gridColumn = gridColumn
             } else {
                 if (!isHidden) {
@@ -171,24 +185,25 @@ export class RuxTrack {
         this.initializeRows()
     }
 
-    renderDebug() {
-        return (
-            <div style={{ display: 'contents' }}>
-                {[...Array(this.columns)].map((_: any, i: any) => (
-                    <div
-                        style={{
-                            gridRow: '1',
-                            gridColumn: `${i + 2} / ${++i + 2}`,
-                        }}
-                        class={{
-                            cell: true,
-                            marker: i % 60 === 0,
-                        }}
-                    ></div>
-                ))}
-            </div>
-        )
-    }
+    // @TODO
+    // renderDebug() {
+    //     return (
+    //         <div style={{ display: 'contents' }}>
+    //             {[...Array(this.columns)].map((_: any, i: any) => (
+    //                 <div
+    //                     style={{
+    //                         gridRow: '1',
+    //                         gridColumn: `${i + 2} / ${++i + 2}`,
+    //                     }}
+    //                     class={{
+    //                         cell: true,
+    //                         marker: i % 60 === 0,
+    //                     }}
+    //                 ></div>
+    //             ))}
+    //         </div>
+    //     )
+    // }
 
     render() {
         return (


### PR DESCRIPTION
## Brief Description

Steps to reproduce:

Change a Time Region's start or end attribute after it's already been rendered. It should update accordingly.

## JIRA Link

ASTRO-4314

## Issues and Limitations

The time region position is calculated from it's parent Track. The problem is that Track doesn't know when a Time Region's start or end date changes. 

Went with an event,  but maybe a mutation observer would've been the better choice? 

Also, tried to write a test for this and gave up.
```
    it('updates the position of an event when its start or end date is changed', () => {
		cy.get('rux-time-region')
		.invoke('prop', 'start', '2022-08-08T01:00')
		.should('have.css', 'grid-area', '1 / 62 / auto / 2882')
    })
```

Passes without any code changes. 

Same test in Playwright:
```
test('homepage has Playwright in title and get started link linking to the intro page', async ({ page }) => {
  await page.goto('http://localhost:3333/components/rux-timeline/test');
  const timeline = await page.locator('rux-time-region')
  await timeline.evaluate(node => node.setAttribute('start', '2022-08-08T01:00'))
  await expect(timeline).toHaveCSS('grid-area', '1 / 62 / auto / 2882')
});
```
Works like a normal person


## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
