### PR TITLE
feat(icon, button): icon now inherits the buttons title attr

### DIFF
--- a/packages/web-components/src/components/rux-button/rux-button.tsx
+++ b/packages/web-components/src/components/rux-button/rux-button.tsx
@@ -77,6 +77,12 @@ export class RuxButton {
         }
     }
 
+    private get getTitle() {
+        if (this.el.title) {
+            return this.el.title
+        }
+    }
+
     render() {
         const { size, iconOnly, secondary, disabled, icon, borderless } = this
         return (
@@ -96,6 +102,7 @@ export class RuxButton {
                     aria-disabled={disabled ? 'true' : null}
                     disabled={disabled}
                     part="container"
+                    title={this.getTitle}
                 >
                     {icon ? (
                         <rux-icon
@@ -103,6 +110,7 @@ export class RuxButton {
                             icon={icon}
                             exportparts="icon"
                             color={secondary ? 'primary' : 'dark'}
+                            title={this.el.title}
                         ></rux-icon>
                     ) : null}
 

--- a/packages/web-components/src/components/rux-icon/rux-icon.tsx
+++ b/packages/web-components/src/components/rux-icon/rux-icon.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, Prop, h } from '@stencil/core'
+import { Component, Host, Prop, h, Element } from '@stencil/core'
 
 /**
  * @part icon - the icon in rux-icon
@@ -11,6 +11,8 @@ import { Component, Host, Prop, h } from '@stencil/core'
 export class RuxIcon {
     // eslint-disable-next-line
     svg: string = ''
+
+    @Element() el!: HTMLRuxIconElement
 
     /**
      * The size of the icon. Can be 'extra-small', 'small', 'normal', 'large', 'auto' or any custom value ('30px', '1rem', '3.321em')
@@ -40,6 +42,14 @@ export class RuxIcon {
         }
     }
 
+    private get _getTitle() {
+        if (this.el.parentElement && this.el.parentElement.title) {
+            return this.el.parentElement.title
+        } else {
+            return this.iconLabel
+        }
+    }
+
     render() {
         const SVG = `rux-icon-${this.icon}`
 
@@ -49,7 +59,7 @@ export class RuxIcon {
                     class="icon"
                     part="icon"
                     size={this.size}
-                    title={this.iconLabel}
+                    title={this._getTitle}
                 ></SVG>
             </Host>
         )

--- a/packages/web-components/src/components/rux-icon/test/index.html
+++ b/packages/web-components/src/components/rux-icon/test/index.html
@@ -18,7 +18,14 @@
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
+
     <body>
         <rux-icon icon="apps"></rux-icon>
+        <rux-button
+            id="btn"
+            icon="apps"
+            title="Button Title"
+            icon-only
+        ></rux-button>
     </body>
 </html>

--- a/packages/web-components/src/components/rux-icon/test/rux-icon.e2e.js
+++ b/packages/web-components/src/components/rux-icon/test/rux-icon.e2e.js
@@ -5,4 +5,11 @@ describe('Icon', () => {
     it('renders', () => {
         cy.get('rux-icon').should('have.class', 'hydrated')
     })
+    it('inherits title from a button', () => {
+        cy.get('#btn').should('have.attr', 'title', 'Button Title')
+        cy.get('#btn')
+            .shadow()
+            .find('rux-icon')
+            .should('have.attr', 'title', 'Button Title')
+    })
 })


### PR DESCRIPTION
## Brief Description

Adds some getters for the title attr for button and icon, in order to pass the button title to the icon title. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4317

## Related Issue

https://github.com/RocketCommunicationsInc/astro/issues/625
## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
