### PR TITLE
Remove icon title

### DIFF
--- a/packages/web-components/src/components/rux-icon/rux-icon.tsx
+++ b/packages/web-components/src/components/rux-icon/rux-icon.tsx
@@ -45,12 +45,7 @@ export class RuxIcon {
 
         return (
             <Host>
-                <SVG
-                    class="icon"
-                    part="icon"
-                    size={this.size}
-                    title={this.iconLabel}
-                ></SVG>
+                <SVG class="icon" part="icon" size={this.size}></SVG>
             </Host>
         )
     }

--- a/packages/web-components/src/components/rux-icon/rux-icon.tsx
+++ b/packages/web-components/src/components/rux-icon/rux-icon.tsx
@@ -27,19 +27,6 @@ export class RuxIcon {
      */
     @Prop() icon!: string
 
-    /**
-     * The icon SVG's title attribute. Used for accessibility. If none is provided, the icon name will be used.
-     */
-    @Prop() label?: string
-
-    get iconLabel() {
-        if (this.label) {
-            return this.label
-        } else {
-            return this.icon
-        }
-    }
-
     render() {
         const SVG = `rux-icon-${this.icon}`
 

--- a/packages/web-components/src/components/rux-icon/test/__snapshots__/rux-icon.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-icon/test/__snapshots__/rux-icon.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`rux-icon renders 1`] = `
 <rux-icon icon="360" size="normal">
   <mock:shadow-root>
-    <rux-icon-360 class="icon" part="icon" size="normal" title="360"></rux-icon-360>
+    <rux-icon-360 class="icon" part="icon" size="normal"></rux-icon-360>
   </mock:shadow-root>
 </rux-icon>
 `;


### PR DESCRIPTION
## Brief Description

Removes the global title attribute from our rux icon. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4317

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/625

## General Notes

## Motivation and Context

Folks using the attribute title on button are having that title overriden when using an icon inside that button, due to us setting the title in the icon component. 

Title is not a recommended attribute in any standard, and should be avoided anyway. This takes care of that. 
Reference: https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
