### PR TITLE
Icon title

### DIFF
--- a/.changeset/good-ears-flow.md
+++ b/.changeset/good-ears-flow.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": major
+"@astrouxds/angular": major
+"astro-website": major
+"@astrouxds/react": major
+"@astrouxds/astro-web-components": major
+---
+
+What: Removed the title attribute from rux-icon. Why: The global HTML title attribute is not recommended for use, and was an oversight when added to rux-icon.

--- a/packages/web-components/src/components/rux-icon/rux-icon.tsx
+++ b/packages/web-components/src/components/rux-icon/rux-icon.tsx
@@ -27,30 +27,12 @@ export class RuxIcon {
      */
     @Prop() icon!: string
 
-    /**
-     * The icon SVG's title attribute. Used for accessibility. If none is provided, the icon name will be used.
-     */
-    @Prop() label?: string
-
-    get iconLabel() {
-        if (this.label) {
-            return this.label
-        } else {
-            return this.icon
-        }
-    }
-
     render() {
         const SVG = `rux-icon-${this.icon}`
 
         return (
             <Host>
-                <SVG
-                    class="icon"
-                    part="icon"
-                    size={this.size}
-                    title={this.iconLabel}
-                ></SVG>
+                <SVG class="icon" part="icon" size={this.size}></SVG>
             </Host>
         )
     }

--- a/packages/web-components/src/components/rux-icon/test/__snapshots__/rux-icon.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-icon/test/__snapshots__/rux-icon.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`rux-icon renders 1`] = `
 <rux-icon icon="360" size="normal">
   <mock:shadow-root>
-    <rux-icon-360 class="icon" part="icon" size="normal" title="360"></rux-icon-360>
+    <rux-icon-360 class="icon" part="icon" size="normal"></rux-icon-360>
   </mock:shadow-root>
 </rux-icon>
 `;

--- a/packages/web-components/src/components/rux-notification/rux-notification.tsx
+++ b/packages/web-components/src/components/rux-notification/rux-notification.tsx
@@ -182,7 +182,6 @@ export class RuxNotification {
                                 <slot name="actions">
                                     <rux-icon
                                         role="button"
-                                        label="Close notification"
                                         onClick={() => this._onClick()}
                                         icon="clear"
                                         size={this.small ? '24px' : '32px'}

--- a/packages/web-components/src/components/rux-notification/test/__snapshots__/rux-notification.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-notification/test/__snapshots__/rux-notification.spec.tsx.snap
@@ -15,7 +15,7 @@ exports[`rux-notification renders 1`] = `
         </div>
         <div class="rux-notification-banner__actions">
           <slot name="actions">
-            <rux-icon exportparts="icon" icon="clear" label="Close notification" role="button" size="32px"></rux-icon>
+            <rux-icon exportparts="icon" icon="clear" role="button" size="32px"></rux-icon>
           </slot>
         </div>
       </div>


### PR DESCRIPTION
## Brief Description

This is a clone of https://github.com/RocketCommunicationsInc/astro/pull/627.


## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4317

## Related Issue

https://github.com/RocketCommunicationsInc/astro/issues/625

## General Notes

## Motivation and Context

Removes the title attr from rux-icon. The title attr is warned against use by web standards. 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
