### PR TITLE
Update README browser chart with checkmarks

### DIFF
--- a/packages/astro-uxds/_content/getting-started/_readme.md
+++ b/packages/astro-uxds/_content/getting-started/_readme.md
@@ -45,7 +45,7 @@ Astro is tested & supported in major 'evergreen' web browsers (the latest browse
 
 |       |  Chrome  | Firefox  |   Edge   |  Safari  | Chrome (Android) | Safari (iOS) |
 | :---- | :------: | :------: | :------: | :------: | :--------------: | :----------: |
-| Astro | &#x2715; | &#x2715; | &#x2715; | &#x2715; |   unsupported    | unsupported  |
+| Astro | &check;  | &check;  | &check;  | &check;  |   unsupported    | unsupported  |
 
 ### Versioning
 


### PR DESCRIPTION
## Brief Description

Change the browser chart to use checkmarks (&check;) instead of X's to indicate a supported browser.

## Motivation and Context

The 'X' marks in the supported browser chart might indicate that the browsers were not supported.  A checkmark seems like a more obvious way to indicate support.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
