### PR TITLE
Fix incorrect step number

### DIFF
--- a/packages/astro-uxds/_content/community/propose-a-change.md
+++ b/packages/astro-uxds/_content/community/propose-a-change.md
@@ -41,7 +41,7 @@ This is a commit message and will be forever included in the Astro changelog.
 
 ![GitHub’s integrated Markdown editor](/img/community/step-3.png)
 
-## Step 4 - Confirm your changes and create a pull request
+## Step 5 - Confirm your changes and create a pull request
 
 Take a moment after submitting your change to confirm there are no errors. GitHub will present the file you are changing, the previous version highlighted in red and your proposed change highlighted in green.
 


### PR DESCRIPTION
## Brief Description

Step 5 was mislabeled as Step 4.  Changed it to the correct number.

## Motivation and Context

Correct step numbering seemed important.

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
