### PR TITLE
Fix spelling error

### DIFF
--- a/packages/web-components/src/stories/astro-uxds/welcome/react.stories.mdx
+++ b/packages/web-components/src/stories/astro-uxds/welcome/react.stories.mdx
@@ -142,7 +142,7 @@ const SegmentedButton = () => {
 
 ```
 
-This will take the input from RuxInput and add to the dataArr, thus adding to RuxSegmentedButton and trigerring a re-render.
+This will take the input from RuxInput and add to the dataArr, thus adding to RuxSegmentedButton and triggering a re-render.
 
 ## Using Slots
 


### PR DESCRIPTION
## Brief Description

Correct misspelled word 'trigerring' to be correctly spelled as 'triggering'.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
