### PR TITLE
Fix code formatting in Methods section

### DIFF
--- a/packages/web-components/src/stories/astro-uxds/welcome/javascript.stories.mdx
+++ b/packages/web-components/src/stories/astro-uxds/welcome/javascript.stories.mdx
@@ -145,17 +145,17 @@ Astro Components emit their own custom events, prefixed with `rux`.
 Some components offer public methods that can be executed. These methods are async and can be executed by selecting the Node element.
 
 ```js
-  <rux-tree>
-    <rux-tree-node id="firstNode">Hello</rux-tree-node>
-    <rux-tree-node>World</rux-tree-node>
-    </rux-tree>
-  <rux-button @click="selectNode">Select Node</rux-button>
+<rux-tree>
+  <rux-tree-node id="firstNode">Hello</rux-tree-node>
+  <rux-tree-node>World</rux-tree-node>
+</rux-tree>
+<rux-button @click="selectNode">Select Node</rux-button>
 
-  <script>
-    const button = document.querySelector('rux-button')
-    const node = document.querySelector('#firstNode')
-    button.addEventListener('click', () => {
-      node.setSelected(true)
-    })
-  </script>
+<script>
+  const button = document.querySelector('rux-button')
+  const node = document.querySelector('#firstNode')
+  button.addEventListener('click', () => {
+    node.setSelected(true)
+  })
+</script>
 ```


### PR DESCRIPTION
## Brief Description

The code formatting in the Methods section was improper.  Reformatted so it is consistent with the rest of the page.

## Motivation and Context

The code formatting looked odd.  Now it is more consistent with the rest of the page.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
