### PR TITLE
(documentation): updated status-symbol page with new table, removed c…

### DIFF
--- a/packages/astro-uxds/_content/_data/compliance.json
+++ b/packages/astro-uxds/_content/_data/compliance.json
@@ -814,12 +814,6 @@
               "rule": "Status Symbols shall be displayed with the [specified colors](/components/status-symbol/#status-colors).",
               "status": "current",
               "tier": 1
-            },
-            {
-              "numeral": 3,
-              "rule": "Switch labels shall use sentence case capitalization.",
-              "status": "under-review",
-              "tier": 3
             }
           ]
         },

--- a/packages/astro-uxds/_content/components/status-symbol.md
+++ b/packages/astro-uxds/_content/components/status-symbol.md
@@ -28,12 +28,6 @@ To ensure compliance with [WCAG 2.0 contrast specifications for non-text content
 - Only use the provided colors for status.
 - Use the highest color possible if multiple statuses are consolidated. For example, if the statuses of underlying components are green, yellow, and red, the consolidated indicator is red.
 
-::: note
-Adding a title attribute to status elements can improve accessibility by offering additional information about the status when the user hovers over the element or when used in conjunction with a screen reader.
-
-Place your cursor over any Status Symbol above to see an example.
-:::
-
 ## Related Pages
 
 - For a detailed description of how Status Symbols are used within Monitoring Icons, see [Icons and Symbols](/components/icons-and-symbols).
@@ -45,25 +39,38 @@ Status colors are provided for both light and dark theme versions of Astro in He
 
 ### Dark Theme Status Colors
 
-|                                                              | Hex     | RGB         | CSS             | Synonyms                                 |
-| ------------------------------------------------------------ | ------- | ----------- | --------------- | ---------------------------------------- |
-| ![Status Color: Critical ](/img/swatches/critical__dark.svg) | #ff3838 | 255,56,56   | --colorCritical | Critical, alert, emergency, urgent       |
-| ![Status Color: Serious ](/img/swatches/serious__dark.svg)   | #ffb302 | 255,179,2   | --colorSerious  | Serious, error, warning, needs attention |
-| ![Status Color: Caution ](/img/swatches/caution__dark.svg)   | #fce83a | 252,232,58  | --colorCaution  | Caution, unstable, unsatisfactory        |
-| ![Status Color: Normal ](/img/swatches/normal__dark.svg)     | #56f000 | 86,240,0    | --colorNormal   | Normal, on, ok, fine, go, satisfactory   |
-| ![Status Color: Standby ](/img/swatches/standby__dark.svg)   | #2dccff | 45,204,255  | --colorStandby  | Standby, available, enabled              |
-| ![Status Color: Off ](/img/swatches/off__dark.svg)           | #9ea7ad | 158,167,173 | --colorOff      | Off, unavailable, disabled               |
+|                                                              | Hex     | RGB         | Synonyms                                       |     |
+| ------------------------------------------------------------ | ------- | ----------- | ---------------------------------------------- | --- |
+| ![Status Color: Critical ](/img/swatches/critical__dark.svg) | #ff3838 | 255,56,56   | Critical, form error, alert, emergency, urgent |
+| ![Status Color: Serious ](/img/swatches/serious__dark.svg)   | #ffb302 | 255,179,2   | Serious, error, warning, needs attention       |
+| ![Status Color: Caution ](/img/swatches/caution__dark.svg)   | #fce83a | 252,232,58  | Caution, unstable, unsatisfactory              |
+| ![Status Color: Normal ](/img/swatches/normal__dark.svg)     | #56f000 | 86,240,0    | Normal, on, ok, fine, go, satisfactory         |
+| ![Status Color: Standby ](/img/swatches/standby__dark.svg)   | #2dccff | 45,204,255  | Standby, available, enabled                    |
+| ![Status Color: Off ](/img/swatches/off__dark.svg)           | #a4abb6 | 158,167,173 | Off, unavailable, disabled                     |
 
 ### Light Theme Status Colors
 
-|                                                               | Hex     | RGB         | CSS             | Synonyms                                 |
-| ------------------------------------------------------------- | ------- | ----------- | --------------- | ---------------------------------------- |
-| ![Status Color: Critical ](/img/swatches/critical__light.svg) | #ff3838 | 255,56,56   | --colorCritical | Critical, alert, emergency, urgent       |
-| ![Status Color: Serious ](/img/swatches/serious__light.svg)   | #ffb302 | 255,179,2   | --colorSerious  | Serious, error, warning, needs attention |
-| ![Status Color: Caution ](/img/swatches/caution__light.svg)   | #fce83a | 252,232,58  | --colorCaution  | Caution, unstable, unsatisfactory        |
-| ![Status Color: Normal ](/img/swatches/normal__light.svg)     | #56f000 | 86,240,0    | --colorNormal   | Normal, on, ok, fine, go, satisfactory   |
-| ![Status Color: Standby ](/img/swatches/standby__light.svg)   | #2dccff | 45,204,255  | --colorStandby  | Standby, available, enabled              |
-| ![Status Color: Off ](/img/swatches/off__light.svg)           | #9ea7ad | 158,167,173 | --colorOff      | Off, unavailable, disabled               |
+|                                                               | Hex     | RGB         | Synonyms                                       |     |
+| ------------------------------------------------------------- | ------- | ----------- | ---------------------------------------------- | --- |
+| ![Status Color: Critical ](/img/swatches/critical__light.svg) | #ff3838 | 255,56,56   | Critical, form error, alert, emergency, urgent |
+| ![Status Color: Serious ](/img/swatches/serious__light.svg)   | #ffb302 | 255,179,2   | Serious, error, warning, needs attention       |
+| ![Status Color: Caution ](/img/swatches/caution__light.svg)   | #fce83a | 252,232,58  | Caution, unstable, unsatisfactory              |
+| ![Status Color: Normal ](/img/swatches/normal__light.svg)     | #56f000 | 86,240,0    | Normal, on, ok, fine, go, satisfactory         |
+| ![Status Color: Standby ](/img/swatches/standby__light.svg)   | #64d9ff | 45,204,255  | Standby, available, enabled                    |
+| ![Status Color: Off ](/img/swatches/off__light.svg)           | #9ea7ad | 158,167,173 | Off, unavailable, disabled                     |
+
+### Light Theme Status Symbol Borders
+
+- In light theme Status Symbols should have a 1px border set to the inside of the symbol.
+
+|                                                               | Hex     | RGB       | Synonyms                                       |     |
+| ------------------------------------------------------------- | ------- | --------- | ---------------------------------------------- | --- |
+| ![Status Color: Critical ](/img/swatches/critical__light.svg) | #661102 | 102,17,2  | Critical, form error, alert, emergency, urgent |
+| ![Status Color: Serious ](/img/swatches/serious__light.svg)   | #664618 | 102,70,24 | Serious, error, warning, needs attention       |
+| ![Status Color: Caution ](/img/swatches/caution__light.svg)   | #645600 | 100,86,0  | Caution, unstable, unsatisfactory              |
+| ![Status Color: Normal ](/img/swatches/normal__light.svg)     | #005a00 | 0,90,0    | Normal, on, ok, fine, go, satisfactory         |
+| ![Status Color: Standby ](/img/swatches/standby__light.svg)   | #285766 | 40,87,102 | Standby, available, enabled                    |
+| ![Status Color: Off ](/img/swatches/off__light.svg)           | #3c3e42 | 60,62,66  | Off, unavailable, disabled                     |
 
 ::: note
 In light theme user interfaces all symbols indicating status must include a 1 pixel border set to black with an opacity of 50% to meet WCAG 2.0 Contrast Compliance.


### PR DESCRIPTION
## Brief Description

Added new table for light theme status symbol borders, removed CSS columns in all status color tables, removed switch label statement from compliance, updated hex code values on light and dark tables

## JIRA Link
https://rocketcom.atlassian.net/browse/ASTRO-4047

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
