### PR TITLE
ASTRO-3867 tabs spacing

### DIFF
--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
@@ -5,12 +5,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 1.875rem 1rem; //30 16
     margin: 0;
     min-width: 5rem;
     text-decoration: none;
     color: var(--color-background-interactive-default);
-    border-bottom: 5px solid transparent;
+    border-bottom: var(--border-width-lg) solid transparent;
     &:hover {
         color: var(--color-background-interactive-hover);
     }
@@ -31,6 +30,8 @@
     font-size: var(--font-heading-2-font-size);
     letter-spacing: var(--font-heading-2-letter-spacing);
     font-weight: var(--font-heading-2-font-weight);
+    line-height: var(--font-heading-2-line-height);
+    padding: var(--spacing-6) var(--spacing-3); //24 12
 }
 
 .rux-tab--small {
@@ -38,6 +39,8 @@
     font-size: var(--font-heading-5-font-size);
     letter-spacing: var(--font-heading-5-letter-spacing);
     font-weight: var(--font-heading-5-font-weight);
+    line-height: var(--font-heading-5-line-height);
+    padding: var(--spacing-4) var(--spacing-3); //16 12
     min-width: 5rem;
 }
 
@@ -46,7 +49,8 @@
 }
 
 .rux-tab--small.rux-tab--selected {
-    border-bottom: 3px solid var(--color-border-interactive-default);
+    border-bottom: var(--border-width-lg) solid
+        var(--color-border-interactive-default);
 }
 
 .rux-tab--selected {

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.scss
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.scss
@@ -2,7 +2,6 @@
     box-sizing: border-box;
     display: flex;
     justify-content: flex-start;
-    min-height: 5.625rem;
     height: 100%;
     width: auto;
     margin: 0;
@@ -16,8 +15,4 @@
 }
 :host([hidden]) {
     display: none;
-}
-
-:host([small]) {
-    min-height: 4.125rem; //66px
 }

--- a/packages/web-components/src/components/rux-tabs/test/index.html
+++ b/packages/web-components/src/components/rux-tabs/test/index.html
@@ -19,6 +19,7 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
     <body>
+        <!--Previous Tests-->
         <div style="display: flex; flex-flow: column">
             <rux-tabs id="tab-set-id-1">
                 <rux-tab id="tab-id-1">Tab 1</rux-tab>
@@ -49,6 +50,109 @@
                     </div>
                 </rux-tab-panel>
                 <rux-tab-panel aria-labelledby="tab-id-3">
+                    <div
+                        style="
+                            padding: 1vw;
+                            border: rgba(255, 255, 255, 0.15) dashed 1px;
+                            font-family: monospace;
+                        "
+                    >
+                        <pre><<span>!-- Tab 3 HTML content --</span>></pre>
+                    </div>
+                </rux-tab-panel>
+            </rux-tab-panels>
+        </div>
+
+        <!--Figma Spacing Tests-->
+        <h2>Large Tabs</h2>
+        <div
+            style="
+                display: flex;
+                flex-flow: column;
+                padding-top: 20px;
+                padding-left: 20px;
+            "
+        >
+            <rux-tabs id="tabs-spacing-large">
+                <rux-tab id="spacing-large-id-1">Tab large</rux-tab>
+                <rux-tab id="spacing-large-id-2">Tab large</rux-tab>
+                <rux-tab id="spacing-large-id-3">Tab large</rux-tab>
+            </rux-tabs>
+            <rux-tab-panels aria-labelledby="tabs-spacing-large">
+                <rux-tab-panel aria-labelledby="spacing-large-id-1">
+                    <div
+                        style="
+                            padding: 1vw;
+                            border: rgba(255, 255, 255, 0.15) dashed 1px;
+                            font-family: monospace;
+                        "
+                    >
+                        <pre><<span>!-- Tab 1 HTML content --</span>></pre>
+                    </div>
+                </rux-tab-panel>
+                <rux-tab-panel aria-labelledby="spacing-large-id-2">
+                    <div
+                        style="
+                            padding: 1vw;
+                            border: rgba(255, 255, 255, 0.15) dashed 1px;
+                            font-family: monospace;
+                        "
+                    >
+                        <pre><<span>!-- Tab 2 HTML content --</span>></pre>
+                    </div>
+                </rux-tab-panel>
+                <rux-tab-panel aria-labelledby="spacing-large-id-3">
+                    <div
+                        style="
+                            padding: 1vw;
+                            border: rgba(255, 255, 255, 0.15) dashed 1px;
+                            font-family: monospace;
+                        "
+                    >
+                        <pre><<span>!-- Tab 3 HTML content --</span>></pre>
+                    </div>
+                </rux-tab-panel>
+            </rux-tab-panels>
+        </div>
+
+        <h2>Small Tabs</h2>
+        <div
+            style="
+                display: flex;
+                flex-flow: column;
+                padding-top: 20px;
+                padding-left: 20px;
+            "
+        >
+            <rux-tabs id="tabs-spacing-small" small>
+                <rux-tab id="spacing-small-id-1">Tab small</rux-tab>
+                <rux-tab id="spacing-small-id-2">Tab small</rux-tab>
+                <rux-tab id="spacing-small-id-3">Tab small</rux-tab>
+            </rux-tabs>
+            <rux-tab-panels aria-labelledby="tabs-spacing-small">
+                <rux-tab-panel aria-labelledby="spacing-small-id-1">
+                    <div
+                        style="
+                            padding: 1vw;
+                            border: rgba(255, 255, 255, 0.15) dashed 1px;
+                            font-family: monospace;
+                        "
+                    >
+                        <pre><<span>!-- Tab 1 HTML content --</span>></pre>
+                    </div>
+                </rux-tab-panel>
+                <rux-tab-panel aria-labelledby="spacing-small-id-2">
+                    <div
+                        style="
+                            padding: 1vw;
+                            border: rgba(255, 255, 255, 0.15) dashed 1px;
+                            font-family: monospace;
+                        "
+                    >
+                        <pre><<span>!-- Tab 2 HTML content --</span>></pre>
+                    </div>
+                </rux-tab-panel>
+                <rux-tab-panel aria-labelledby="spacing-small-id-3">
                     <div
                         style="
                             padding: 1vw;


### PR DESCRIPTION
## Brief Description

Change tabs spacing to follow Figma guidelines using Figma design tokens where applicable. I also removed min-height from the tabs and I believe it is no longer necessary.

## JIRA Link

[ASTRO-3867](https://rocketcom.atlassian.net/browse/ASTRO-3867)

## Related Issue

## General Notes

## Motivation and Context

Part of the Astro spacing and design token initiative

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ]  I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
