### PR TITLE
Typography Utility Classes

### DIFF
--- a/.changeset/lazy-pumas-trade.md
+++ b/.changeset/lazy-pumas-trade.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": minor
+"@astrouxds/angular": minor
+"astro-website": minor
+"@astrouxds/react": minor
+"@astrouxds/astro-web-components": minor
+---
+
+Adds typography utility classes

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -66,7 +66,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           working-directory: ./packages/web-components
-          install: ${{ (true && 'steps.cache-node-modules.outputs.cache-hit != 'true') || 'steps.cache-node-modules.outputs.cache-hit == 'true' }}
+          install: true
           start: npm run start.stencil
           wait-on: "http://localhost:3333"
           wait-on-timeout: "110"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -69,4 +69,4 @@ jobs:
           install: true
           start: npm run start.stencil
           wait-on: "http://localhost:3333"
-          wait-on-timeout: "130"
+          wait-on-timeout: "110"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -69,4 +69,4 @@ jobs:
           install: false
           start: npm run start.stencil
           wait-on: "http://localhost:3333"
-          wait-on-timeout: "110"
+          wait-on-timeout: "130"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,6 +17,11 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16
+      - uses: tj-actions/changed-files@v11
+        id: changed-files
+        with:
+          files: |
+            **/package.json
       - uses: actions/cache@v2
         id: cache-node-modules
         with:
@@ -25,9 +30,9 @@ jobs:
             ~/.cache/Cypress
           key: node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm run web-comps.install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        if: steps.cache-node-modules.outputs.cache-hit != 'true' && steps.changed-files.outputs.only_changed == 'true'
       - run: npm run build.web-comps
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        if: steps.cache-node-modules.outputs.cache-hit != 'true' && steps.changed-files.outputs.only_changed == 'true'
   unit-tests:
     needs: setup
     runs-on: ubuntu-latest
@@ -64,4 +69,4 @@ jobs:
           install: false
           start: npm run start.stencil
           wait-on: "http://localhost:3333"
-          wait-on-timeout: "90"
+          wait-on-timeout: "110"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -69,4 +69,4 @@ jobs:
           install: false
           start: npm run start.stencil
           wait-on: "http://localhost:3333"
-          wait-on-timeout: "130"
+          wait-on-timeout: "110"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -69,4 +69,4 @@ jobs:
           install: true
           start: npm run start.stencil
           wait-on: "http://localhost:3333"
-          wait-on-timeout: "110"
+          wait-on-timeout: "130"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -66,7 +66,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           working-directory: ./packages/web-components
-          install: true
+          install: false
           start: npm run start.stencil
           wait-on: "http://localhost:3333"
           wait-on-timeout: "110"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -66,7 +66,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           working-directory: ./packages/web-components
-          install: false
+          install: ${{ (true && 'steps.cache-node-modules.outputs.cache-hit != 'true') || 'steps.cache-node-modules.outputs.cache-hit == 'true' }}
           start: npm run start.stencil
           wait-on: "http://localhost:3333"
           wait-on-timeout: "110"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,9 +30,9 @@ jobs:
             ~/.cache/Cypress
           key: node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm run web-comps.install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true' && steps.changed-files.outputs.any_changed == 'true'
+        if: steps.cache-node-modules.outputs.cache-hit != 'true' || steps.changed-files.outputs.any_changed == 'true'
       - run: npm run build.web-comps
-        if: steps.cache-node-modules.outputs.cache-hit != 'true' && steps.changed-files.outputs.any_changed == 'true'
+        if: steps.cache-node-modules.outputs.cache-hit != 'true' || steps.changed-files.outputs.any_changed == 'true'
   unit-tests:
     needs: setup
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,9 +30,9 @@ jobs:
             ~/.cache/Cypress
           key: node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm run web-comps.install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true' && steps.changed-files.outputs.only_changed == 'true'
+        if: steps.cache-node-modules.outputs.cache-hit != 'true' && steps.changed-files.outputs.any_changed == 'true'
       - run: npm run build.web-comps
-        if: steps.cache-node-modules.outputs.cache-hit != 'true' && steps.changed-files.outputs.only_changed == 'true'
+        if: steps.cache-node-modules.outputs.cache-hit != 'true' && steps.changed-files.outputs.any_changed == 'true'
   unit-tests:
     needs: setup
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -66,7 +66,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           working-directory: ./packages/web-components
-          install: false
+          install: true
           start: npm run start.stencil
           wait-on: "http://localhost:3333"
           wait-on-timeout: "110"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "lerna run --ignore @astrouxds/angular test",
     "release": "node ./.scripts/release.js && changeset publish",
     "test.web-comps.unit": "lerna run --scope '@astrouxds/astro-web-components' test.unit",
-    "web-comps.install": "cd ./packages/web-components && npm ci",
+    "web-comps.install": "cd ./packages/web-components && npm i",
     "react.install": "cd ./packages/react && npm ci",
     "test.react": "lerna run --scope '@astrouxds/react' test"
   },

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -16,7 +16,7 @@
             },
             "devDependencies": {
                 "@astrouxds/astro-figma-export": "~1.0.1",
-                "@astrouxds/design-tokens": "2.0.0-beta.11",
+                "@astrouxds/design-tokens": "2.0.0-beta.12",
                 "@astrouxds/storybook-addon-docs-stencil": "~1.0.10",
                 "@babel/core": "~7.13.16",
                 "@stencil/angular-output-target": "~0.4.0",
@@ -79,13 +79,12 @@
             }
         },
         "node_modules/@astrouxds/design-tokens": {
-            "version": "2.0.0-beta.11",
-            "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.11.tgz",
-            "integrity": "sha512-fm9kQ+PEdUU35VF1Rrjj1+RiOQw716c9RCsyObtHOIOaMeT2pW4qM77MQH/SfXlwvYDPQKhJFBm63ckx8vncrQ==",
+            "version": "2.0.0-beta.12",
+            "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.12.tgz",
+            "integrity": "sha512-LuoLBz8cvt1wrhjjrGWstUKX85MDbM/WK6mXdgIuPyIU/iR6WMkgVXX+GPIZJy3hAZc690XJh+PX8P+Uu90Fbg==",
             "dev": true,
             "dependencies": {
-                "@changesets/cli": "^2.22.0",
-                "style-dictionary": "^3"
+                "@changesets/cli": "^2.22.0"
             }
         },
         "node_modules/@astrouxds/storybook-addon-docs-stencil": {
@@ -9398,17 +9397,6 @@
                 }
             ]
         },
-        "node_modules/capital-case": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
-            "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-            "dev": true,
-            "dependencies": {
-                "no-case": "^3.0.4",
-                "tslib": "^2.0.3",
-                "upper-case-first": "^2.0.2"
-            }
-        },
         "node_modules/capture-exit": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -9458,26 +9446,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/change-case": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-            "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-            "dev": true,
-            "dependencies": {
-                "camel-case": "^4.1.2",
-                "capital-case": "^1.0.4",
-                "constant-case": "^3.0.4",
-                "dot-case": "^3.0.4",
-                "header-case": "^2.0.4",
-                "no-case": "^3.0.4",
-                "param-case": "^3.0.4",
-                "pascal-case": "^3.1.2",
-                "path-case": "^3.0.4",
-                "sentence-case": "^3.0.4",
-                "snake-case": "^3.0.4",
-                "tslib": "^2.0.3"
             }
         },
         "node_modules/char-regex": {
@@ -10238,17 +10206,6 @@
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
             "dev": true
-        },
-        "node_modules/constant-case": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-            "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-            "dev": true,
-            "dependencies": {
-                "no-case": "^3.0.4",
-                "tslib": "^2.0.3",
-                "upper-case": "^2.0.2"
-            }
         },
         "node_modules/constants-browserify": {
             "version": "1.0.0",
@@ -14656,16 +14613,6 @@
                 "he": "bin/he"
             }
         },
-        "node_modules/header-case": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-            "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-            "dev": true,
-            "dependencies": {
-                "capital-case": "^1.0.4",
-                "tslib": "^2.0.3"
-            }
-        },
         "node_modules/highlight.js": {
             "version": "10.7.3",
             "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
@@ -17633,12 +17580,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/jsonc-parser": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
-            "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
-            "dev": true
         },
         "node_modules/jsonfile": {
             "version": "4.0.0",
@@ -41894,16 +41835,6 @@
             "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
             "dev": true
         },
-        "node_modules/path-case": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-            "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-            "dev": true,
-            "dependencies": {
-                "dot-case": "^3.0.4",
-                "tslib": "^2.0.3"
-            }
-        },
         "node_modules/path-dirname": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
@@ -44452,17 +44383,6 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
         },
-        "node_modules/sentence-case": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-            "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-            "dev": true,
-            "dependencies": {
-                "no-case": "^3.0.4",
-                "tslib": "^2.0.3",
-                "upper-case-first": "^2.0.2"
-            }
-        },
         "node_modules/serialize-javascript": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
@@ -44790,16 +44710,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/snake-case": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-            "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-            "dev": true,
-            "dependencies": {
-                "dot-case": "^3.0.4",
-                "tslib": "^2.0.3"
             }
         },
         "node_modules/snapdragon": {
@@ -45895,125 +45805,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/style-dictionary": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-3.7.1.tgz",
-            "integrity": "sha512-yYU9Z/J8Znj9T9oJVjo8VOYamrOxv0UbBKPjhSt+PharxrhyQCM4RWb71fgEfv2pK9KO8G83/0ChDNQZ1mn0wQ==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "change-case": "^4.1.2",
-                "commander": "^8.3.0",
-                "fs-extra": "^10.0.0",
-                "glob": "^7.2.0",
-                "json5": "^2.2.0",
-                "jsonc-parser": "^3.0.0",
-                "lodash": "^4.17.15",
-                "tinycolor2": "^1.4.1"
-            },
-            "bin": {
-                "style-dictionary": "bin/style-dictionary"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/style-dictionary/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/style-dictionary/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/style-dictionary/node_modules/commander": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-            "dev": true,
-            "engines": {
-                "node": ">= 12"
-            }
-        },
-        "node_modules/style-dictionary/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/style-dictionary/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/style-dictionary/node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/style-dictionary/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/style-dictionary/node_modules/universalify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
         "node_modules/style-loader": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
@@ -47027,15 +46818,6 @@
                 "node": ">=0.6.0"
             }
         },
-        "node_modules/tinycolor2": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-            "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
-            "dev": true,
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/tmp": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -47901,24 +47683,6 @@
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
             "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
             "dev": true
-        },
-        "node_modules/upper-case": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-            "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^2.0.3"
-            }
-        },
-        "node_modules/upper-case-first": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-            "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^2.0.3"
-            }
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
@@ -49554,13 +49318,12 @@
             }
         },
         "@astrouxds/design-tokens": {
-            "version": "2.0.0-beta.11",
-            "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.11.tgz",
-            "integrity": "sha512-fm9kQ+PEdUU35VF1Rrjj1+RiOQw716c9RCsyObtHOIOaMeT2pW4qM77MQH/SfXlwvYDPQKhJFBm63ckx8vncrQ==",
+            "version": "2.0.0-beta.12",
+            "resolved": "https://registry.npmjs.org/@astrouxds/design-tokens/-/design-tokens-2.0.0-beta.12.tgz",
+            "integrity": "sha512-LuoLBz8cvt1wrhjjrGWstUKX85MDbM/WK6mXdgIuPyIU/iR6WMkgVXX+GPIZJy3hAZc690XJh+PX8P+Uu90Fbg==",
             "dev": true,
             "requires": {
-                "@changesets/cli": "^2.22.0",
-                "style-dictionary": "^3"
+                "@changesets/cli": "^2.22.0"
             }
         },
         "@astrouxds/storybook-addon-docs-stencil": {
@@ -56604,17 +56367,6 @@
             "integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==",
             "dev": true
         },
-        "capital-case": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
-            "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-            "dev": true,
-            "requires": {
-                "no-case": "^3.0.4",
-                "tslib": "^2.0.3",
-                "upper-case-first": "^2.0.2"
-            }
-        },
         "capture-exit": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -56651,26 +56403,6 @@
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
-            }
-        },
-        "change-case": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-            "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-            "dev": true,
-            "requires": {
-                "camel-case": "^4.1.2",
-                "capital-case": "^1.0.4",
-                "constant-case": "^3.0.4",
-                "dot-case": "^3.0.4",
-                "header-case": "^2.0.4",
-                "no-case": "^3.0.4",
-                "param-case": "^3.0.4",
-                "pascal-case": "^3.1.2",
-                "path-case": "^3.0.4",
-                "sentence-case": "^3.0.4",
-                "snake-case": "^3.0.4",
-                "tslib": "^2.0.3"
             }
         },
         "char-regex": {
@@ -57265,17 +56997,6 @@
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
             "dev": true
-        },
-        "constant-case": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-            "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-            "dev": true,
-            "requires": {
-                "no-case": "^3.0.4",
-                "tslib": "^2.0.3",
-                "upper-case": "^2.0.2"
-            }
         },
         "constants-browserify": {
             "version": "1.0.0",
@@ -60787,16 +60508,6 @@
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true
         },
-        "header-case": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-            "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-            "dev": true,
-            "requires": {
-                "capital-case": "^1.0.4",
-                "tslib": "^2.0.3"
-            }
-        },
         "highlight.js": {
             "version": "10.7.3",
             "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
@@ -62981,12 +62692,6 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
             "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-            "dev": true
-        },
-        "jsonc-parser": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
-            "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
             "dev": true
         },
         "jsonfile": {
@@ -81758,16 +81463,6 @@
             "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
             "dev": true
         },
-        "path-case": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-            "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-            "dev": true,
-            "requires": {
-                "dot-case": "^3.0.4",
-                "tslib": "^2.0.3"
-            }
-        },
         "path-dirname": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
@@ -83746,17 +83441,6 @@
                 }
             }
         },
-        "sentence-case": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-            "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-            "dev": true,
-            "requires": {
-                "no-case": "^3.0.4",
-                "tslib": "^2.0.3",
-                "upper-case-first": "^2.0.2"
-            }
-        },
         "serialize-javascript": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
@@ -84029,16 +83713,6 @@
                         "yargs-parser": "^18.1.2"
                     }
                 }
-            }
-        },
-        "snake-case": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-            "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-            "dev": true,
-            "requires": {
-                "dot-case": "^3.0.4",
-                "tslib": "^2.0.3"
             }
         },
         "snapdragon": {
@@ -84930,92 +84604,6 @@
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
         },
-        "style-dictionary": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-3.7.1.tgz",
-            "integrity": "sha512-yYU9Z/J8Znj9T9oJVjo8VOYamrOxv0UbBKPjhSt+PharxrhyQCM4RWb71fgEfv2pK9KO8G83/0ChDNQZ1mn0wQ==",
-            "dev": true,
-            "requires": {
-                "chalk": "^4.0.0",
-                "change-case": "^4.1.2",
-                "commander": "^8.3.0",
-                "fs-extra": "^10.0.0",
-                "glob": "^7.2.0",
-                "json5": "^2.2.0",
-                "jsonc-parser": "^3.0.0",
-                "lodash": "^4.17.15",
-                "tinycolor2": "^1.4.1"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "commander": {
-                    "version": "8.3.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-                    "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-                    "dev": true
-                },
-                "fs-extra": {
-                    "version": "10.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-                    "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^6.0.1",
-                        "universalify": "^2.0.0"
-                    }
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
-                "jsonfile": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.6",
-                        "universalify": "^2.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                },
-                "universalify": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-                    "dev": true
-                }
-            }
-        },
         "style-loader": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
@@ -85762,12 +85350,6 @@
                 "setimmediate": "^1.0.4"
             }
         },
-        "tinycolor2": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-            "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
-            "dev": true
-        },
         "tmp": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -86411,24 +85993,6 @@
                     "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
                     "dev": true
                 }
-            }
-        },
-        "upper-case": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-            "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-            "dev": true,
-            "requires": {
-                "tslib": "^2.0.3"
-            }
-        },
-        "upper-case-first": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-            "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-            "dev": true,
-            "requires": {
-                "tslib": "^2.0.3"
             }
         },
         "uri-js": {

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -48,7 +48,7 @@
     "license": "MIT",
     "devDependencies": {
         "@astrouxds/astro-figma-export": "~1.0.1",
-        "@astrouxds/design-tokens": "2.0.0-beta.11",
+        "@astrouxds/design-tokens": "2.0.0-beta.12",
         "@astrouxds/storybook-addon-docs-stencil": "~1.0.10",
         "@babel/core": "~7.13.16",
         "@stencil/angular-output-target": "~0.4.0",

--- a/packages/web-components/src/global/global.scss
+++ b/packages/web-components/src/global/global.scss
@@ -6,4 +6,5 @@
 @use 'mixins';
 @use 'fouc';
 @use 'reset';
-@import '../../node_modules/@astrouxds/design-tokens/dist/css/classes/typography.css';
+// @import '../../node_modules/@astrouxds/design-tokens/dist/css/classes/typography.css';
+@import '~@astrouxds/design-tokens/dist/css/classes/typography.css';

--- a/packages/web-components/src/global/global.scss
+++ b/packages/web-components/src/global/global.scss
@@ -6,3 +6,4 @@
 @use 'mixins';
 @use 'fouc';
 @use 'reset';
+@import '../../node_modules/@astrouxds/design-tokens/dist/css/classes/typography.css';

--- a/packages/web-components/src/global/global.scss
+++ b/packages/web-components/src/global/global.scss
@@ -6,5 +6,4 @@
 @use 'mixins';
 @use 'fouc';
 @use 'reset';
-// @import '../../node_modules/@astrouxds/design-tokens/dist/css/classes/typography.css';
 @import '~@astrouxds/design-tokens/dist/css/classes/typography.css';


### PR DESCRIPTION
## Brief Description

Publishes our new typography utility classes from our design tokens to the global css so peeps can use it.
* .rux-body-1
* .rux-body-1-bold
* .rux-body-2
* .rux-body-2-bold
* .rux-body-3
* .rux-body-3-bold
* .rux-control-body-1
* .rux-control-body-1-bold
* .rux-heading-1
* .rux-heading-1-bold
* .rux-heading-2
* .rux-heading-3
* .rux-heading-4
* .rux-heading-5
* .rux-heading-6
* .rux-display-1
* .rux-display-2
* .rux-monospace-1


## JIRA Link

ASTRO-4339

## Motivation and Context

Using raw design tokens for typography sucks

## Issues and Limitations

* Additional tickets will be created to clean up the import process a bit (ie not importing from /dist)
* These are imported by default without any way to opt out and will add to the bundle size. Because theres so few, it should be negligible, but providing a way to opt in/out is a high priority for me. Unfortunately, this has turned out to be very complicated.
* Documentation coming in separate ticket

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
