### PR TITLE
Km 3866 switch toggle spacing

### DIFF
--- a/.changeset/gorgeous-rice-repeat.md
+++ b/.changeset/gorgeous-rice-repeat.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+rux-switch - updated spacing with design tokens to align with design

--- a/packages/astro-uxds/package-lock.json
+++ b/packages/astro-uxds/package-lock.json
@@ -11500,62 +11500,6 @@
         }
       }
     },
-    "@eslint/eslintrc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^9.3.2",
-        "globals": "^13.15.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true,
-          "peer": true
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        }
-      }
-    },
-    "@humanwhocodes/config-array": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
-      }
-    },
-    "@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "dev": true,
-      "peer": true
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -13796,7 +13740,6 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -14725,37 +14668,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
         },
         "string-width": {
           "version": "4.2.3",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -271,6 +271,10 @@ export namespace Components {
          */
         "icon": string;
         /**
+           * The icon SVG's title attribute. Used for accessibility. If none is provided, the icon name will be used.
+         */
+        "label"?: string;
+        /**
           * The size of the icon. Can be 'extra-small', 'small', 'normal', 'large', 'auto' or any custom value ('30px', '1rem', '3.321em')
          */
         "size": | 'extra-small'
@@ -20582,6 +20586,10 @@ declare namespace LocalJSX {
          */
         "icon": string;
         /**
+          * The icon SVG's title attribute. Used for accessibility. If none is provided, the icon name will be used.
+         */
+         "label"?: string;
+         /**
           * The size of the icon. Can be 'extra-small', 'small', 'normal', 'large', 'auto' or any custom value ('30px', '1rem', '3.321em')
          */
         "size"?: | 'extra-small'

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -271,10 +271,6 @@ export namespace Components {
          */
         "icon": string;
         /**
-          * The icon SVG's title attribute. Used for accessibility. If none is provided, the icon name will be used.
-         */
-        "label"?: string;
-        /**
           * The size of the icon. Can be 'extra-small', 'small', 'normal', 'large', 'auto' or any custom value ('30px', '1rem', '3.321em')
          */
         "size": | 'extra-small'
@@ -20585,10 +20581,6 @@ declare namespace LocalJSX {
           * The icon name
          */
         "icon": string;
-        /**
-          * The icon SVG's title attribute. Used for accessibility. If none is provided, the icon name will be used.
-         */
-        "label"?: string;
         /**
           * The size of the icon. Can be 'extra-small', 'small', 'normal', 'large', 'auto' or any custom value ('30px', '1rem', '3.321em')
          */

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -271,10 +271,6 @@ export namespace Components {
          */
         "icon": string;
         /**
-           * The icon SVG's title attribute. Used for accessibility. If none is provided, the icon name will be used.
-         */
-        "label"?: string;
-        /**
           * The size of the icon. Can be 'extra-small', 'small', 'normal', 'large', 'auto' or any custom value ('30px', '1rem', '3.321em')
          */
         "size": | 'extra-small'
@@ -20586,10 +20582,6 @@ declare namespace LocalJSX {
          */
         "icon": string;
         /**
-          * The icon SVG's title attribute. Used for accessibility. If none is provided, the icon name will be used.
-         */
-         "label"?: string;
-         /**
           * The size of the icon. Can be 'extra-small', 'small', 'normal', 'large', 'auto' or any custom value ('30px', '1rem', '3.321em')
          */
         "size"?: | 'extra-small'

--- a/packages/web-components/src/components/rux-switch/rux-switch.scss
+++ b/packages/web-components/src/components/rux-switch/rux-switch.scss
@@ -1,7 +1,6 @@
 @use '../../common/functional-components/FormFieldMessage/form-field-message.scss';
 :host {
     display: block;
-    padding-left: 1%;
 }
 .rux-switch {
     position: relative;
@@ -26,6 +25,7 @@
             background-color: var(--color-background-base-default);
             height: var(--spacing-3); //12
             width: var(--spacing-8); //32
+            margin: var(--spacing-1);
             z-index: 2;
             transition: 0.1s background-color linear;
         }
@@ -34,8 +34,7 @@
         &::after {
             position: absolute;
             content: '';
-            top: 1px;
-            left: -4px;
+            left: 0;
             z-index: 3;
             height: calc(var(--spacing-4) + var(--spacing-1)); //20
             width: calc(var(--spacing-4) + var(--spacing-1)); //20
@@ -63,7 +62,7 @@
                     );
                 }
                 &::after {
-                    left: var(--spacing-4); //16
+                    left: calc(var(--spacing-4) + var(--spacing-1)); //20
                     background-color: var(--color-background-base-default);
                     box-shadow: var(--color-background-interactive-default) 0 0
                         0 1px inset;

--- a/packages/web-components/src/components/rux-switch/rux-switch.scss
+++ b/packages/web-components/src/components/rux-switch/rux-switch.scss
@@ -5,7 +5,7 @@
 .rux-switch {
     position: relative;
     display: flex;
-    height: var(--line-height-sm);
+    height: calc(var(--spacing-4) + var(--spacing-1)); //20
     white-space: nowrap;
 
     // Default Styling

--- a/packages/web-components/src/components/rux-switch/rux-switch.scss
+++ b/packages/web-components/src/components/rux-switch/rux-switch.scss
@@ -6,7 +6,7 @@
 .rux-switch {
     position: relative;
     display: flex;
-    height: 22px;
+    height: var(--line-height-sm);
     white-space: nowrap;
 
     // Default Styling
@@ -21,11 +21,11 @@
             display: flex;
             content: '';
             border-radius: var(--switch-radius-track);
-            border: 1px solid;
-            border-color: var(--color-border-interactive-muted);
+            border: 0;
+            box-shadow: var(--color-border-interactive-muted) 0 0 0 1px inset;
             background-color: var(--color-background-base-default);
-            height: 10px;
-            width: 30px;
+            height: var(--spacing-3); //12
+            width: var(--spacing-8); //32
             z-index: 2;
             transition: 0.1s background-color linear;
         }
@@ -37,10 +37,11 @@
             top: 1px;
             left: -4px;
             z-index: 3;
-            height: 18px;
-            width: 18px;
+            height: calc(var(--spacing-4) + var(--spacing-1)); //20
+            width: calc(var(--spacing-4) + var(--spacing-1)); //20
             border-radius: var(--radius-circle);
-            border: 1px solid var(--color-background-interactive-default);
+            box-shadow: var(--color-background-interactive-default) 0 0 0 1px
+                inset;
             background-color: var(--color-background-base-default);
             transition: 0.1s left linear, 0.1s border-color linear;
         }
@@ -55,15 +56,17 @@
         &:checked {
             + .rux-switch__button {
                 &::before {
-                    border-color: var(--color-background-interactive-default);
+                    box-shadow: var(--color-background-interactive-default) 0 0
+                        0 1px inset;
                     background-color: var(
                         --color-background-interactive-default
                     );
                 }
                 &::after {
-                    left: 16px;
+                    left: var(--spacing-4); //16
                     background-color: var(--color-background-base-default);
-                    border-color: var(--color-background-interactive-default);
+                    box-shadow: var(--color-background-interactive-default) 0 0
+                        0 1px inset;
                 }
             }
         }
@@ -89,7 +92,8 @@
                         );
                     }
                     &::after {
-                        border-color: var(--color-background-interactive-hover);
+                        box-shadow: var(--color-background-interactive-hover) 0
+                            0 0 1px inset;
                     }
                 }
             }

--- a/packages/web-components/src/components/rux-switch/test/index.html
+++ b/packages/web-components/src/components/rux-switch/test/index.html
@@ -17,6 +17,10 @@
         <script nomodule src="/build/astro-web-components.esm.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
+        <script
+            type="module"
+            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
+        ></script>
     </head>
 
     <body class="dark-theme">
@@ -88,5 +92,11 @@
                 }
             </script>
         </div>
+
+        <!--Spacing tests-->
+        <h2>Switch on</h2>
+        <rux-switch id="ruxSwitchOn" name="ruxSwitchOn" checked></rux-switch>
+        <h2>Switch off</h2>
+        <rux-switch id="ruxSwitchOff" name="ruxSwitchOff"></rux-switch>
     </body>
 </html>

--- a/packages/web-components/src/components/rux-switch/test/index.html
+++ b/packages/web-components/src/components/rux-switch/test/index.html
@@ -24,79 +24,90 @@
     </head>
 
     <body class="dark-theme">
-        <div style="padding: 10%; display: flex; justify-content: center">
-            <div style="width: 60%">
-                <form id="form" style="width: 100%">
-                    <rux-switch id="ruxSwitch" name="ruxSwitch" value="foo">
-                        Checkbox
-                    </rux-switch>
+        <ftl-belt access-token="" file-id="">
+            <div style="padding: 10%; display: flex; justify-content: center">
+                <div style="width: 60%">
+                    <form id="form" style="width: 100%">
+                        <rux-switch id="ruxSwitch" name="ruxSwitch" value="foo">
+                            Checkbox
+                        </rux-switch>
 
-                    <rux-switch
-                        id="ruxSwitchDisabled"
-                        name="ruxSwitchDisabled"
-                        disabled
+                        <rux-switch
+                            id="ruxSwitchDisabled"
+                            name="ruxSwitchDisabled"
+                            disabled
+                        >
+                            Disabled
+                        </rux-switch>
+
+                        <input
+                            id="nativeCheckbox"
+                            type="checkbox"
+                            name="nativeCheckbox"
+                            value="foo"
+                        />
+                        <button id="submit" type="submit">submit</button>
+                    </form>
+
+                    <form
+                        id="form-no-value"
+                        style="margin-top: 1rem; width: 100%"
                     >
-                        Disabled
-                    </rux-switch>
+                        <rux-switch id="ruxSwitch2" name="ruxSwitch">
+                            Checkbox
+                        </rux-switch>
 
-                    <input
-                        id="nativeCheckbox"
-                        type="checkbox"
-                        name="nativeCheckbox"
-                        value="foo"
-                    />
-                    <button id="submit" type="submit">submit</button>
-                </form>
+                        <input
+                            id="nativeCheckbox2"
+                            type="checkbox"
+                            name="nativeCheckbox"
+                        />
+                        <button type="submit">submit</button>
+                    </form>
+                </div>
+                <div style="width: 30%">
+                    <ul id="log"></ul>
+                </div>
+                <script>
+                    const log = document.getElementById('log')
+                    const forms = document.querySelectorAll('form')
 
-                <form id="form-no-value" style="margin-top: 1rem; width: 100%">
-                    <rux-switch id="ruxSwitch2" name="ruxSwitch">
-                        Checkbox
-                    </rux-switch>
+                    for (const form of forms) {
+                        form.addEventListener('submit', (e) => {
+                            event.preventDefault()
+                            // trigger formdata event
+                            new FormData(form)
+                        })
 
-                    <input
-                        id="nativeCheckbox2"
-                        type="checkbox"
-                        name="nativeCheckbox"
-                    />
-                    <button type="submit">submit</button>
-                </form>
-            </div>
-            <div style="width: 30%">
-                <ul id="log"></ul>
-            </div>
-            <script>
-                const log = document.getElementById('log')
-                const forms = document.querySelectorAll('form')
-
-                for (const form of forms) {
-                    form.addEventListener('submit', (e) => {
-                        event.preventDefault()
-                        // trigger formdata event
-                        new FormData(form)
-                    })
-
-                    form.addEventListener('formdata', logFormData)
-                }
-
-                function logFormData(e) {
-                    const status = document.getElementById('status')
-                    log.innerHTML = ''
-                    // Get the form data from the event object
-                    let data = e.formData
-                    const values = data.values()
-                    for (var value of data.entries()) {
-                        const item = document.createElement('li')
-                        item.innerHTML = `<strong>${value[0]}:</strong>${value[1]}`
-                        log.appendChild(item)
+                        form.addEventListener('formdata', logFormData)
                     }
-                }
-            </script>
-        </div>
 
-        <!--Spacing tests-->
-        <h2>Switch on</h2>
-        <rux-switch id="ruxSwitchOn" name="ruxSwitchOn" checked></rux-switch>
-        <h2>Switch off</h2>
-        <rux-switch id="ruxSwitchOff" name="ruxSwitchOff"></rux-switch>
+                    function logFormData(e) {
+                        const status = document.getElementById('status')
+                        log.innerHTML = ''
+                        // Get the form data from the event object
+                        let data = e.formData
+                        const values = data.values()
+                        for (var value of data.entries()) {
+                            const item = document.createElement('li')
+                            item.innerHTML = `<strong>${value[0]}:</strong>${value[1]}`
+                            log.appendChild(item)
+                        }
+                    }
+                </script>
+            </div>
+
+            <!--Spacing tests-->
+            <ftl-holster name="Switch On" node="2739:21011">
+                <rux-switch
+                    id="ruxSwitchOn"
+                    name="ruxSwitchOn"
+                    checked
+                ></rux-switch>
+            </ftl-holster>
+            <ftl-holster name="Switch Off" node="2739:21023">
+                <rux-switch id="ruxSwitchOff" name="ruxSwitchOff"></rux-switch>
+            </ftl-holster>
+        </ftl-belt>
     </body>
 </html>

--- a/packages/web-components/src/components/rux-switch/test/index.html
+++ b/packages/web-components/src/components/rux-switch/test/index.html
@@ -17,10 +17,6 @@
         <script nomodule src="/build/astro-web-components.esm.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
-        <script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script>
     </head>
 
     <body class="dark-theme">

--- a/packages/web-components/src/components/rux-switch/test/index.html
+++ b/packages/web-components/src/components/rux-switch/test/index.html
@@ -35,7 +35,6 @@
                         >
                             Disabled
                         </rux-switch>
-
                         <input
                             id="nativeCheckbox"
                             type="checkbox"


### PR DESCRIPTION
## Brief Description

Add design tokens to rux-switch to bring in line with Figma design

**Question**: This is one of the components that requires actual height and width declarations. For those I used the --spacing tokens and some calculation but I'm wondering if that's the best path. Is there a better choice?

**Comment**: If you're wondering why components.d.ts was touched.. My stencil compiler keeps changing it when compiling. I had to bring it back inline with next.

## JIRA Link

[ASTRO-3866](https://rocketcom.atlassian.net/browse/ASTRO-3866)

## Related Issue

## General Notes
I added inset shadows rather than borders to the thumb switch and rail in order to allow easier sizing via tokens.

## Motivation and Context

Part of the astro spacing adjustment initiative!

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
