### PR TITLE
chore: extend cypress tiemout

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -64,4 +64,4 @@ jobs:
           install: false
           start: npm run start.stencil
           wait-on: "http://localhost:3333"
-          wait-on-timeout: "90"
+          wait-on-timeout: "110"


### PR DESCRIPTION
## Brief Description

This was implemented in main, but not next. This will allow our tests to pass first try without rux-button-group failing. 

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
