### PR TITLE
Fm 3845 checkbox spacing

### DIFF
--- a/.changeset/dull-cobras-wash.md
+++ b/.changeset/dull-cobras-wash.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+Changing border to box-shadow, cleaning up commented out code, changing heights and widths to design tokens.

--- a/.changeset/famous-eels-dress.md
+++ b/.changeset/famous-eels-dress.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+Updating checkbox to match Figma

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -271,10 +271,6 @@ export namespace Components {
          */
         "icon": string;
         /**
-          * The icon SVG's title attribute. Used for accessibility. If none is provided, the icon name will be used.
-         */
-        "label"?: string;
-        /**
           * The size of the icon. Can be 'extra-small', 'small', 'normal', 'large', 'auto' or any custom value ('30px', '1rem', '3.321em')
          */
         "size": | 'extra-small'
@@ -20585,10 +20581,6 @@ declare namespace LocalJSX {
           * The icon name
          */
         "icon": string;
-        /**
-          * The icon SVG's title attribute. Used for accessibility. If none is provided, the icon name will be used.
-         */
-        "label"?: string;
         /**
           * The size of the icon. Can be 'extra-small', 'small', 'normal', 'large', 'auto' or any custom value ('30px', '1rem', '3.321em')
          */

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
@@ -26,7 +26,7 @@
 .rux-checkbox {
     display: flex;
     position: relative;
-    line-height: 1.2;
+    //line-height: 1.2;
 
     &--indeterminate {
         input[type='checkbox'] + label::after {
@@ -54,7 +54,7 @@
             align-items: center;
             justify-content: flex-start;
             color: var(--color-text-primary);
-            letter-spacing: 0.5px;
+            line-height: var(--font-body-1-bold-line-height);
             cursor: pointer;
             margin-left: -7px;
 
@@ -65,11 +65,13 @@
                 align-self: start;
                 height: 1.125rem;
                 width: 1.125rem;
-
-                margin: 0 0.625rem 0 0;
+                margin: calc(var(--spacing-1) / 2) calc(var(--spacing-2) + 2px)
+                    calc(var(--spacing-1) / 2) calc(var(--spacing-1) / 2);
+                //margin: calc(var(--spacing-1) / 2);
                 background-color: var(--color-background-base-default);
-                border: 1px solid var(--color-border-interactive-muted);
-                border-radius: var(--radius-checkbox);
+                border: var(--border-width-xs) solid
+                    var(--color-border-interactive-muted);
+                border-radius: 2px;
             }
         }
         //If no label is passed in we don't want the margin
@@ -86,10 +88,10 @@
                     position: absolute;
                     display: flex;
                     content: '';
-                    top: 5px;
-                    height: 6px;
-                    width: 12px;
-                    left: 3px;
+                    top: 7px;
+                    height: 5px;
+                    width: 10px;
+                    left: 6px;
                     border-right: 2px solid
                         var(--color-background-interactive-default);
                     border-top: 2px solid

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
@@ -26,7 +26,6 @@
 .rux-checkbox {
     display: flex;
     position: relative;
-    //line-height: 1.2;
 
     &--indeterminate {
         input[type='checkbox'] + label::after {
@@ -63,14 +62,13 @@
                 display: flex;
                 content: '';
                 align-self: start;
-                height: 1.125rem;
-                width: 1.125rem;
+                height: calc(var(--spacing-1) + var(--spacing-4)); //20px
+                width: calc(var(--spacing-1) + var(--spacing-4));
                 margin: calc(var(--spacing-1) / 2) calc(var(--spacing-2) + 2px)
                     calc(var(--spacing-1) / 2) calc(var(--spacing-1) / 2);
-                //margin: calc(var(--spacing-1) / 2);
                 background-color: var(--color-background-base-default);
-                border: var(--border-width-xs) solid
-                    var(--color-border-interactive-muted);
+                box-shadow: var(--color-border-interactive-muted) 0 0 0 1px
+                    inset;
                 border-radius: 2px;
             }
         }

--- a/packages/web-components/src/components/rux-checkbox/test/index.html
+++ b/packages/web-components/src/components/rux-checkbox/test/index.html
@@ -17,14 +17,14 @@
         <script nomodule src="/build/astro-web-components.esm.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
-        <script
+        <!-- <script
             type="module"
             src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script>
+        ></script> -->
     </head>
 
     <body class="dark-theme">
-        <!-- <ftl-belt access-token="" file-id="oj8NRemkyC8dBRHHpo95f3">
+        <!-- <ftl-belt access-token="figd_9S33KsQIz3Kpi6WvFmR0XmeDhfxbCzwm5RYLt4mv" file-id="oj8NRemkyC8dBRHHpo95f3">
             <ftl-holster name="Test 1 Name" node="25916:114906">
                 <form id="form" style="width: 100%">
                     <rux-checkbox
@@ -34,15 +34,6 @@
                     >
                         Checkbox
                     </rux-checkbox>
-
-                    <rux-checkbox
-                        id="ruxCheckboxDisabled"
-                        name="ruxCheckboxDisabled"
-                        disabled
-                    >
-                        Disabled
-                    </rux-checkbox>
-                    <button id="submit" type="submit">submit</button>
                 </form>
             </ftl-holster>
           </ftl-belt> -->

--- a/packages/web-components/src/components/rux-checkbox/test/index.html
+++ b/packages/web-components/src/components/rux-checkbox/test/index.html
@@ -17,9 +17,35 @@
         <script nomodule src="/build/astro-web-components.esm.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
+        <script
+            type="module"
+            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
+        ></script>
     </head>
 
     <body class="dark-theme">
+        <!-- <ftl-belt access-token="" file-id="oj8NRemkyC8dBRHHpo95f3">
+            <ftl-holster name="Test 1 Name" node="25916:114906">
+                <form id="form" style="width: 100%">
+                    <rux-checkbox
+                        id="ruxCheckbox"
+                        name="ruxCheckbox"
+                        value="foo"
+                    >
+                        Checkbox
+                    </rux-checkbox>
+
+                    <rux-checkbox
+                        id="ruxCheckboxDisabled"
+                        name="ruxCheckboxDisabled"
+                        disabled
+                    >
+                        Disabled
+                    </rux-checkbox>
+                    <button id="submit" type="submit">submit</button>
+                </form>
+            </ftl-holster>
+          </ftl-belt> -->
         <div style="padding: 10%; display: flex; justify-content: center">
             <div style="width: 60%">
                 <form id="form" style="width: 100%">


### PR DESCRIPTION
## Brief Description

Style changes to make checkbox match Figma. Changes include updated margin, adding in border-radius for the box itself and updating the checkmark itself.

## JIRA Link

[3845](https://rocketcom.atlassian.net/browse/ASTRO-3845)

## Related Issue

## General Notes

## Motivation and Context

Makes the checkbox component better match that in Figma. Adds in ftl belt and holster component for testing.

## Issues and Limitations

## Types of changes

- [ x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ x] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
