### PR TITLE
Mj 3849 gsb spacing

### DIFF
--- a/.changeset/rude-buckets-fail.md
+++ b/.changeset/rude-buckets-fail.md
@@ -1,0 +1,11 @@
+---
+"angular-workspace": major
+"@astrouxds/angular": major
+"astro-website": major
+"@astrouxds/react": major
+"@astrouxds/astro-web-components": major
+---
+
+WHAT: Global status bar no longer automaticall uppercases the app domain and name.
+WHY: This was changed in order to match design.
+HOW TO MIGRATE: If you are reliant on the app state and domain being in all caps, simply pass the `app-domain` and `app-state` an all uppercase version.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -64,4 +64,4 @@ jobs:
           install: false
           start: npm run start.stencil
           wait-on: "http://localhost:3333"
-          wait-on-timeout: "110"
+          wait-on-timeout: "130"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -64,4 +64,4 @@ jobs:
           install: false
           start: npm run start.stencil
           wait-on: "http://localhost:3333"
-          wait-on-timeout: "130"
+          wait-on-timeout: "190"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -55,8 +55,6 @@ jobs:
             ./packages/web-components/node_modules
             ~/.cache/Cypress
           key: node-modules-${{ hashFiles('package-lock.json') }}
-      - run: npm i cypress@8.0.0
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
       - name: Cypress tests 🧪
         uses: cypress-io/github-action@v4
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,6 +17,11 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16
+      - uses: tj-actions/changed-files@v11
+        id: changed-files
+        with:
+          files: |
+            **/package.json
       - uses: actions/cache@v2
         id: cache-node-modules
         with:
@@ -25,9 +30,9 @@ jobs:
             ~/.cache/Cypress
           key: node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm run web-comps.install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        if: steps.cache-node-modules.outputs.cache-hit != 'true' || steps.changed-files.outputs.any_changed == 'true'
       - run: npm run build.web-comps
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        if: steps.cache-node-modules.outputs.cache-hit != 'true' || steps.changed-files.outputs.any_changed == 'true'
   unit-tests:
     needs: setup
     runs-on: ubuntu-latest
@@ -55,11 +60,13 @@ jobs:
             ./packages/web-components/node_modules
             ~/.cache/Cypress
           key: node-modules-${{ hashFiles('package-lock.json') }}
+      - run: npm i cypress@8.0.0
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
       - name: Cypress tests 🧪
         uses: cypress-io/github-action@v4
         with:
           working-directory: ./packages/web-components
-          install: false
+          install: true
           start: npm run start.stencil
           wait-on: "http://localhost:3333"
-          wait-on-timeout: "190"
+          wait-on-timeout: "110"

--- a/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.scss
+++ b/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.scss
@@ -6,11 +6,12 @@
     z-index: 50;
     top: 0;
     left: 0;
-    height: 100px;
+    height: var(--spacing-20); //80 px
     width: -webkit-fill-available;
     width: -moz-available;
     width: stretch;
-    padding: 0 1.875rem;
+    // padding: 0 1.875rem;
+    padding: var(--spacing-2) var(--spacing-6);
     box-sizing: border-box;
     background-color: var(--gsb-color-background);
     -webkit-user-select: none;
@@ -36,25 +37,25 @@ header {
 
 slot[name='left-side'] > *,
 ::slotted(*[slot='left-side']) {
-    margin-right: 10px;
+    margin-right: var(--spacing-2);
 }
 
 slot[name='left-side'] > rux-icon,
 ::slotted(rux-icon[slot='left-side']) {
-    height: 34px;
+    height: calc(var(--spacing-8) + var(--spacing-050)); //38px
 }
 
 slot[name='left-side'] > .shifted-up,
 ::slotted(.shifted-up[slot='left-side']) {
-    height: 54px;
+    height: calc(var(--spacing-14) + var(--spacing-050)); //58px
 }
 
 .app-meta,
 ::slotted(*[slot='app-meta']) {
     display: inline-flex;
     flex-wrap: wrap;
-    padding: 0;
-    margin: 0 auto 0 0;
+    padding: var(--spacing-0);
+    margin: var(--spacing-0) auto var(--spacing-0) var(--spacing-0);
     color: var(--color-palette-neutral-000);
     white-space: nowrap;
 }
@@ -63,30 +64,33 @@ slot[name='left-side'] > .shifted-up,
     flex-basis: 100%;
     display: flex;
     align-items: baseline;
-    margin-bottom: 6px;
+    min-height: var(--spacing-10); //40px
+    padding-bottom: var(--spacing-1);
     min-width: 170px;
 }
 
 .app-meta h1 {
-    margin-bottom: 0;
-    margin-top: 0;
+    margin-bottom: var(--spacing-0);
+    margin-top: var(--spacing-0);
     height: 32px;
     font-family: var(--font-heading-1-font-family);
     font-size: var(--font-heading-1-font-size);
     font-weight: var(--font-heading-1-font-weight);
     letter-spacing: var(--font-heading-1-letter-spacing);
+    line-height: var(--line-height-2xl);
 }
 
 .app-meta h1.app-domain {
-    margin-right: 13px;
+    margin-right: var(--spacing-2);
     font-family: var(--font-heading-1-bold-font-family);
     font-size: var(--font-heading-1-bold-font-size);
     font-weight: var(--font-heading-1-bold-font-weight);
     letter-spacing: var(--font-heading-1-bold-letter-spacing);
+    line-height: var(--line-height-2xl);
 }
 
 .app-name {
-    margin-right: 0.3em;
+    margin-right: var(--spacing-2); //8px
 }
 
 .app-version {
@@ -112,10 +116,10 @@ slot[name='left-side'] > .shifted-up,
     font-size: var(--font-body-2-font-size);
     font-weight: var(--font-body-2-font-weight);
     letter-spacing: var(--font-body-2-letter-spacing);
-    padding: 2px 6px;
+    padding: var(--spacing-050) calc(var(--spacing-1) + var(--spacing-050)); //2px 6px
     text-align: center;
     height: 22px;
-    margin-right: 6px;
+    margin-right: var(--spacing-2); //6px
     white-space: nowrap;
 }
 
@@ -126,8 +130,8 @@ slot[name='left-side'] > .shifted-up,
     font-size: var(--font-body-2-font-size);
     font-weight: var(--font-body-2-font-weight);
     letter-spacing: var(--font-body-2-letter-spacing);
-    padding: 2px 0;
-    height: 22px;
+    padding: var(--spacing-050) var(--spacing-0); //2px 0
+    height: calc(var(--spacing-6) - var(--spacing-050)); //22px
 }
 
 .slotted-content {

--- a/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.scss
+++ b/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.scss
@@ -73,7 +73,7 @@ slot[name='right-side'] > rux-monitoring-icon,
     align-items: baseline;
     min-height: var(--spacing-10); //40px
     padding-bottom: var(--spacing-1);
-    min-width: 170px;
+    min-width: 10.625rem;
 }
 
 .app-meta h1 {
@@ -122,11 +122,8 @@ slot[name='right-side'] > rux-monitoring-icon,
     font-size: var(--font-body-2-font-size);
     font-weight: var(--font-body-2-font-weight);
     letter-spacing: var(--font-body-2-letter-spacing);
-    // padding: var(--spacing-050) calc(var(--spacing-1) + var(--spacing-050)); //2px 6px
-    // padding: 3px 8px;
     padding: calc(var(--spacing-050) + var(--spacing-025)) var(--spacing-2); //3px 8px
     text-align: center;
-    // height: 22px;
     margin-right: var(--spacing-2); //6px
     white-space: nowrap;
 }

--- a/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.scss
+++ b/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.scss
@@ -6,12 +6,11 @@
     z-index: 50;
     top: 0;
     left: 0;
-    height: var(--spacing-20); //80 px
+    height: var(--spacing-24);
     width: -webkit-fill-available;
     width: -moz-available;
     width: stretch;
-    // padding: 0 1.875rem;
-    padding: var(--spacing-2) var(--spacing-6);
+    padding: 0 var(--spacing-6);
     box-sizing: border-box;
     background-color: var(--gsb-color-background);
     -webkit-user-select: none;
@@ -50,6 +49,14 @@ slot[name='left-side'] > .shifted-up,
     height: calc(var(--spacing-14) + var(--spacing-050)); //58px
 }
 
+slot[name='right-side'] > rux-monitoring-icon,
+::slotted(rux-monitoring-icon[slot='right-side']) {
+    display: flex;
+    align-items: center;
+    padding-right: calc(var(--spacing-4) + var(--spacing-2)); //24px
+    padding-top: var(--spacing-2);
+}
+
 .app-meta,
 ::slotted(*[slot='app-meta']) {
     display: inline-flex;
@@ -72,7 +79,6 @@ slot[name='left-side'] > .shifted-up,
 .app-meta h1 {
     margin-bottom: var(--spacing-0);
     margin-top: var(--spacing-0);
-    height: 32px;
     font-family: var(--font-heading-1-font-family);
     font-size: var(--font-heading-1-font-size);
     font-weight: var(--font-heading-1-font-weight);
@@ -116,9 +122,11 @@ slot[name='left-side'] > .shifted-up,
     font-size: var(--font-body-2-font-size);
     font-weight: var(--font-body-2-font-weight);
     letter-spacing: var(--font-body-2-letter-spacing);
-    padding: var(--spacing-050) calc(var(--spacing-1) + var(--spacing-050)); //2px 6px
+    // padding: var(--spacing-050) calc(var(--spacing-1) + var(--spacing-050)); //2px 6px
+    // padding: 3px 8px;
+    padding: calc(var(--spacing-050) + var(--spacing-025)) var(--spacing-2); //3px 8px
     text-align: center;
-    height: 22px;
+    // height: 22px;
     margin-right: var(--spacing-2); //6px
     white-space: nowrap;
 }
@@ -130,7 +138,7 @@ slot[name='left-side'] > .shifted-up,
     font-size: var(--font-body-2-font-size);
     font-weight: var(--font-body-2-font-weight);
     letter-spacing: var(--font-body-2-letter-spacing);
-    padding: var(--spacing-050) var(--spacing-0); //2px 0
+    padding: calc(var(--spacing-050) + var(--spacing-025)) var(--spacing-0); //3px 0
     height: calc(var(--spacing-6) - var(--spacing-050)); //22px
 }
 

--- a/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.scss
+++ b/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.scss
@@ -83,7 +83,7 @@ slot[name='right-side'] > rux-monitoring-icon,
     font-size: var(--font-heading-1-font-size);
     font-weight: var(--font-heading-1-font-weight);
     letter-spacing: var(--font-heading-1-letter-spacing);
-    line-height: var(--line-height-2xl);
+    line-height: var(--font-heading-1-line-height);
 }
 
 .app-meta h1.app-domain {
@@ -92,7 +92,7 @@ slot[name='right-side'] > rux-monitoring-icon,
     font-size: var(--font-heading-1-bold-font-size);
     font-weight: var(--font-heading-1-bold-font-weight);
     letter-spacing: var(--font-heading-1-bold-letter-spacing);
-    line-height: var(--line-height-2xl);
+    line-height: var(--font-heading-1-line-height);
 }
 
 .app-name {

--- a/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.tsx
+++ b/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.tsx
@@ -103,8 +103,8 @@ export class RuxGlobalStatusBar {
                             this.appName ||
                             this.appVersion) && (
                             <AppMeta
-                                domain={this.appDomain?.toUpperCase()}
-                                name={this.appName?.toUpperCase()}
+                                domain={this.appDomain}
+                                name={this.appName}
                                 version={this.appVersion}
                             >
                                 <div class="app-state-wrapper">

--- a/packages/web-components/src/components/rux-global-status-bar/test/__snapshots__/rux-global-status-bar.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-global-status-bar/test/__snapshots__/rux-global-status-bar.spec.tsx.snap
@@ -29,7 +29,7 @@ exports[`rux-global-status-bar renders with icon and app meta 1`] = `
               ASTRO
             </h1>
             <h1 class="app-name">
-              TEST APP NAME
+              Test App Name
             </h1>
             <span class="app-version">
               test v1.0
@@ -68,7 +68,7 @@ exports[`rux-global-status-bar renders with icon, app meta and slotted content 1
               ASTRO
             </h1>
             <h1 class="app-name">
-              TEST APP NAME
+              Test App Name
             </h1>
             <span class="app-version">
               test v1.0

--- a/packages/web-components/src/components/rux-global-status-bar/test/index.html
+++ b/packages/web-components/src/components/rux-global-status-bar/test/index.html
@@ -26,10 +26,10 @@
     <body>
         <rux-global-status-bar
             include-icon
-            app-domain="A"
-            app-state="A"
-            app-name="A"
-            username="U"
+            app-domain="App Domain"
+            app-state="App State"
+            app-name="App Name"
+            username="Username"
         >
             <div
                 slot="right-side"

--- a/packages/web-components/src/components/rux-global-status-bar/test/index.html
+++ b/packages/web-components/src/components/rux-global-status-bar/test/index.html
@@ -31,10 +31,10 @@
             <ftl-belt access-token="" file-id="J77M8jPxzOBoxQeevckKwb">
                 <ftl-holster node="1626:8219">
                     <rux-global-status-bar
-                        app-domain="Global"
-                        app-name="status bar"
+                        app-domain="GLOBAL"
+                        app-name="STATUS BAR"
                         app-state="App state"
-                        username="User name"
+                        username="User Name"
                         include-icon="true"
                     >
                     </rux-global-status-bar>
@@ -44,12 +44,13 @@
                         app-domain="Testing Text"
                         app-name="Testing Text"
                         app-state="App state"
-                        username="User name"
+                        username="User Name"
                         include-icon="true"
                     >
                     </rux-global-status-bar>
                 </ftl-holster>
                 <ftl-holster node="1628:8698">
+                    <!-- This one is differnet from figma on the left and right due to our padding. -->
                     <rux-global-status-bar
                         style="width: 329px"
                         app-domain="Testing Text"
@@ -63,7 +64,7 @@
                     <rux-global-status-bar
                         app-domain="Testing Text"
                         app-name="Testing Text"
-                        app-state="App state text"
+                        app-state="App state test"
                         username="Jane Doe test"
                         include-icon="true"
                     >
@@ -73,17 +74,30 @@
                     <rux-global-status-bar
                         app-domain="Testing Text"
                         app-name="Testing Text"
-                        app-state="App state text"
+                        app-state="App state test"
+                        username="Jane Doe test"
                         include-icon="true"
                     >
                     </rux-global-status-bar>
                 </ftl-holster>
-                <ftl-holster node="1628:8789">
+                <ftl-holster node="39040:129519">
                     <rux-global-status-bar
-                        app-domain="Testing Text"
-                        app-name="Testing Text"
-                        app-state="App state text"
+                        app-domain="GLOBAL"
+                        app-name="STATUS BAR"
+                        app-state="App state"
+                        username="User Name"
+                        include-icon="true"
                     >
+                        <rux-clock></rux-clock>
+                        <rux-monitoring-icon
+                            slot="right-side"
+                            icon="antenna-transmit"
+                            status="critical"
+                            notifications="99"
+                            label="Label"
+                            sublabel="Sub"
+                        >
+                        </rux-monitoring-icon>
                     </rux-global-status-bar>
                 </ftl-holster>
             </ftl-belt>

--- a/packages/web-components/src/components/rux-global-status-bar/test/index.html
+++ b/packages/web-components/src/components/rux-global-status-bar/test/index.html
@@ -17,8 +17,76 @@
         <script nomodule src="/build/astro-web-components.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
+        <script
+            type="module"
+            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
+        ></script>
     </head>
+
     <body>
         <rux-global-status-bar></rux-global-status-bar>
+
+        <section>
+            <h3>Basic</h3>
+            <ftl-belt access-token="" file-id="J77M8jPxzOBoxQeevckKwb">
+                <ftl-holster node="1626:8219">
+                    <rux-global-status-bar
+                        app-domain="Global"
+                        app-name="status bar"
+                        app-state="App state"
+                        username="User name"
+                        include-icon="true"
+                    >
+                    </rux-global-status-bar>
+                </ftl-holster>
+                <ftl-holster node="1628:8594">
+                    <rux-global-status-bar
+                        app-domain="Testing Text"
+                        app-name="Testing Text"
+                        app-state="App state"
+                        username="User name"
+                        include-icon="true"
+                    >
+                    </rux-global-status-bar>
+                </ftl-holster>
+                <ftl-holster node="1628:8698">
+                    <rux-global-status-bar
+                        style="width: 329px"
+                        app-domain="Testing Text"
+                        app-name="Testing Text"
+                        username="Jane Doe test"
+                        include-icon="true"
+                    >
+                    </rux-global-status-bar>
+                </ftl-holster>
+                <ftl-holster node="1628:8722">
+                    <rux-global-status-bar
+                        app-domain="Testing Text"
+                        app-name="Testing Text"
+                        app-state="App state text"
+                        username="Jane Doe test"
+                        include-icon="true"
+                    >
+                    </rux-global-status-bar>
+                </ftl-holster>
+                <ftl-holster node="1628:8749">
+                    <rux-global-status-bar
+                        app-domain="Testing Text"
+                        app-name="Testing Text"
+                        app-state="App state text"
+                        include-icon="true"
+                    >
+                    </rux-global-status-bar>
+                </ftl-holster>
+                <ftl-holster node="1628:8789">
+                    <rux-global-status-bar
+                        app-domain="Testing Text"
+                        app-name="Testing Text"
+                        app-state="App state text"
+                    >
+                    </rux-global-status-bar>
+                </ftl-holster>
+            </ftl-belt>
+        </section>
     </body>
 </html>

--- a/packages/web-components/src/components/rux-global-status-bar/test/index.html
+++ b/packages/web-components/src/components/rux-global-status-bar/test/index.html
@@ -17,10 +17,10 @@
         <script nomodule src="/build/astro-web-components.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
-        <script
+        <!-- <script
             type="module"
             src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script>
+        ></script> -->
     </head>
 
     <body>

--- a/packages/web-components/src/components/rux-global-status-bar/test/index.html
+++ b/packages/web-components/src/components/rux-global-status-bar/test/index.html
@@ -24,83 +24,73 @@
     </head>
 
     <body>
-        <rux-global-status-bar></rux-global-status-bar>
+        <rux-global-status-bar
+            include-icon
+            app-domain="A"
+            app-state="A"
+            app-name="A"
+            username="U"
+        >
+            <div
+                slot="right-side"
+                style="
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                "
+            >
+                <rux-monitoring-icon
+                    label="Label"
+                    sublabel="Sub"
+                    icon="antenna-transmit"
+                    notifications="999"
+                    status="critical"
+                ></rux-monitoring-icon>
+                <rux-monitoring-icon
+                    icon="antenna-receive"
+                    label="Label"
+                    sublabel="Sub"
+                    notifications="1"
+                    status="standby"
+                >
+                </rux-monitoring-icon>
+            </div>
+        </rux-global-status-bar>
 
-        <section>
-            <h3>Basic</h3>
-            <ftl-belt access-token="" file-id="J77M8jPxzOBoxQeevckKwb">
-                <ftl-holster node="1626:8219">
-                    <rux-global-status-bar
-                        app-domain="GLOBAL"
-                        app-name="STATUS BAR"
-                        app-state="App state"
-                        username="User Name"
-                        include-icon="true"
-                    >
-                    </rux-global-status-bar>
-                </ftl-holster>
-                <ftl-holster node="1628:8594">
-                    <rux-global-status-bar
-                        app-domain="Testing Text"
-                        app-name="Testing Text"
-                        app-state="App state"
-                        username="User Name"
-                        include-icon="true"
-                    >
-                    </rux-global-status-bar>
-                </ftl-holster>
-                <ftl-holster node="1628:8698">
-                    <!-- This one is differnet from figma on the left and right due to our padding. -->
-                    <rux-global-status-bar
-                        style="width: 329px"
-                        app-domain="Testing Text"
-                        app-name="Testing Text"
-                        username="Jane Doe test"
-                        include-icon="true"
-                    >
-                    </rux-global-status-bar>
-                </ftl-holster>
-                <ftl-holster node="1628:8722">
-                    <rux-global-status-bar
-                        app-domain="Testing Text"
-                        app-name="Testing Text"
-                        app-state="App state test"
-                        username="Jane Doe test"
-                        include-icon="true"
-                    >
-                    </rux-global-status-bar>
-                </ftl-holster>
-                <ftl-holster node="1628:8749">
-                    <rux-global-status-bar
-                        app-domain="Testing Text"
-                        app-name="Testing Text"
-                        app-state="App state test"
-                        username="Jane Doe test"
-                        include-icon="true"
-                    >
-                    </rux-global-status-bar>
-                </ftl-holster>
-                <ftl-holster node="39040:129519">
-                    <rux-global-status-bar
-                        app-domain="GLOBAL"
-                        app-name="STATUS BAR"
-                        app-state="App state"
-                        username="User Name"
-                        include-icon="true"
-                    >
-                        <rux-clock></rux-clock>
-                        <rux-monitoring-icon
-                            slot="right-side"
-                            icon="antenna-transmit"
-                            status="critical"
-                            notifications="99"
-                            label="Label"
-                            sublabel="Sub"
-                        >
-                        </rux-monitoring-icon>
-                    </rux-global-status-bar>
-                </ftl-holster>
-            </ftl-belt>
-        </section>
+        <!-- <section>
+        <h3>Basic</h3>
+        <ftl-belt access-token="" file-id="J77M8jPxzOBoxQeevckKwb">
+            <ftl-holster node="1626:8219">
+                <rux-global-status-bar app-domain="GLOBAL" app-name="STATUS BAR" app-state="App state"
+                    username="User Name" include-icon="true">
+                </rux-global-status-bar>
+            </ftl-holster>
+            <ftl-holster node="1628:8594">
+                <rux-global-status-bar app-domain="Testing Text" app-name="Testing Text" app-state="App state"
+                    username="User Name" include-icon="true">
+                </rux-global-status-bar>
+            </ftl-holster>
+            <ftl-holster node="1628:8698"> -->
+        <!-- This one is differnet from figma on the left and right due to our padding. -->
+        <!-- <rux-global-status-bar style="width: 329px" app-domain="Testing Text" app-name="Testing Text"
+                    username="Jane Doe test" include-icon="true">
+                </rux-global-status-bar>
+            </ftl-holster>
+            <ftl-holster node="1628:8722">
+                <rux-global-status-bar app-domain="Testing Text" app-name="Testing Text" app-state="App state test"
+                    username="Jane Doe test" include-icon="true">
+                </rux-global-status-bar>
+            </ftl-holster>
+            <ftl-holster node="39040:129519">
+                <rux-global-status-bar app-domain="GLOBAL" app-name="STATUS BAR" app-state="App state"
+                    username="User Name" include-icon="true">
+                    <rux-clock></rux-clock>
+                    <rux-monitoring-icon slot="right-side" icon="antenna-transmit" status="critical" notifications="99"
+                        label="Label" sublabel="Sub">
+                    </rux-monitoring-icon>
+                </rux-global-status-bar>
+            </ftl-holster>
+        </ftl-belt>
+    </section> -->
     </body>
 </html>

--- a/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
+++ b/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
@@ -20,7 +20,7 @@
     flex-direction: column;
     justify-content: flex-start;
     position: relative;
-    margin: 0;
+    margin: var(--spacing-0);
     line-height: 0;
     -webkit-user-select: none;
     -moz-user-select: none;
@@ -31,8 +31,8 @@
 .rux-advanced-status__icon-group {
     display: flex;
     position: relative;
-    margin: 0 auto;
-    width: 4.5rem;
+    margin: var(--spacing-0) auto;
+    width: calc(var(--spacing-16) + var(--spacing-2)); //4.5rem
 }
 
 rux-icon {
@@ -42,8 +42,8 @@ rux-icon {
 
 .rux-advanced-status__status {
     position: absolute;
-    top: -0.4rem;
-    left: -0.4rem;
+    // top: -0.4rem;
+    // left: -0.4rem;
     margin: 0;
 }
 
@@ -52,11 +52,12 @@ rux-icon {
     z-index: 2;
     order: 3;
     position: absolute;
-    left: 3.438rem;
-    top: -0.625rem;
-    border: 1px solid var(--color-background-interactive-default);
-    border-radius: 2px;
-    padding: 0.5rem 0.25rem;
+    left: calc(var(--spacing-14) - var(--spacing-025));
+    top: calc(var(--spacing-1) * -1);
+    border: 1px solid var(--color-text-secondary);
+    border-radius: var(--radius-base);
+    padding: calc(var(--spacing-2) - var(--spacing-025))
+        calc(var(--spacing-025) * 3); //7px 3px
     color: var(--color-palette-neutral-000);
     font-family: var(--font-body-3-font-family);
     font-size: var(--font-body-3-font-size);
@@ -78,11 +79,10 @@ rux-icon {
     text-align: center;
     text-overflow: ellipsis;
     white-space: nowrap;
-    line-height: 1.2;
+    line-height: var(--line-height-sm);
     overflow: hidden;
-    margin-top: 1rem;
     width: 100%;
-    max-width: 6.25rem;
+    max-width: calc(var(--spacing-24) + var(--spacing-2)); //6.5rem
 }
 
 .rux-advanced-status__sublabel {

--- a/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
+++ b/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
@@ -42,8 +42,6 @@ rux-icon {
 
 .rux-advanced-status__status {
     position: absolute;
-    // top: -0.4rem;
-    // left: -0.4rem;
     margin: 0;
 }
 
@@ -54,7 +52,7 @@ rux-icon {
     position: absolute;
     left: calc(var(--spacing-14) - var(--spacing-025));
     top: calc(var(--spacing-1) * -1);
-    border: 1px solid var(--color-text-secondary);
+    box-shadow: 0 0 0 1px var(--color-text-secondary);
     border-radius: var(--radius-base);
     padding: calc(var(--spacing-2) - var(--spacing-025))
         calc(var(--spacing-025) * 3); //7px 3px

--- a/packages/web-components/src/components/rux-monitoring-icon/test/index.html
+++ b/packages/web-components/src/components/rux-monitoring-icon/test/index.html
@@ -17,8 +17,28 @@
         <script nomodule src="/build/astro-web-components.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
+        <script
+            type="module"
+            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
+        ></script>
     </head>
+
     <body>
         <rux-monitoring-icon></rux-monitoring-icon>
+        <h1>Figma VRT</h1>
+        <section>
+            <ftl-belt access-token="" file-id="J77M8jPxzOBoxQeevckKwb">
+                <ftl-holster node="40983:130550">
+                    <rux-monitoring-icon
+                        icon="antenna-transmit"
+                        status="critical"
+                        notifications="99"
+                        label="Label"
+                        sublabel="Sub"
+                    >
+                    </rux-monitoring-icon>
+                </ftl-holster>
+            </ftl-belt>
+        </section>
     </body>
 </html>

--- a/packages/web-components/src/components/rux-monitoring-icon/test/index.html
+++ b/packages/web-components/src/components/rux-monitoring-icon/test/index.html
@@ -25,20 +25,15 @@
 
     <body>
         <rux-monitoring-icon></rux-monitoring-icon>
-        <h1>Figma VRT</h1>
-        <section>
-            <ftl-belt access-token="" file-id="J77M8jPxzOBoxQeevckKwb">
-                <ftl-holster node="40983:130550">
-                    <rux-monitoring-icon
-                        icon="antenna-transmit"
-                        status="critical"
-                        notifications="99"
-                        label="Label"
-                        sublabel="Sub"
-                    >
-                    </rux-monitoring-icon>
-                </ftl-holster>
-            </ftl-belt>
-        </section>
+        <!-- <h1>Figma VRT</h1>
+    <section>
+        <ftl-belt access-token="" file-id="J77M8jPxzOBoxQeevckKwb">
+            <ftl-holster node="40983:130550">
+                <rux-monitoring-icon icon="antenna-transmit" status="critical" notifications="99" label="Label"
+                    sublabel="Sub">
+                </rux-monitoring-icon>
+            </ftl-holster>
+        </ftl-belt>
+    </section> -->
     </body>
 </html>

--- a/packages/web-components/src/components/rux-monitoring-icon/test/index.html
+++ b/packages/web-components/src/components/rux-monitoring-icon/test/index.html
@@ -17,10 +17,10 @@
         <script nomodule src="/build/astro-web-components.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
-        <script
+        <!-- <script
             type="module"
             src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script>
+        ></script> -->
     </head>
 
     <body>


### PR DESCRIPTION
## Brief Description

Spacing updates for GSB and it's close counterparts, monitoring icon and app-state.


## JIRA Link

GSB -> https://rocketcom.atlassian.net/browse/ASTRO-3849
App state -> https://rocketcom.atlassian.net/browse/ASTRO-3843
Monitoring icon -> https://rocketcom.atlassian.net/browse/ASTRO-3850

## Related Issue

## General Notes
I tackled monitoring icon with GSB since it's a very common use case, and needed it for Figma VRT's anyway.
App state is a separate component in Figma, but it part of GSB in code - hence why it's here too. 

## Motivation and Context

Spacing effort 👾 

## Issues and Limitations

Monitoring icon is a bit off still due to the status symbol mismatches in size - this will be addressed at a later stage when we swap in SVG's for the status symbols. 
The only thing not lining up in GSB is the text due to a font difference. It's like half a px off. 
Clock does not look the same inside GSB as it does in Figma, due to a couple things:
- Clocks own spacing 
- It's a default slot in code, which means not a ton of specific styling since anything could go there. External devs can style it however they see fit. 

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
