### PR TITLE
Fm 4361 checkbox group spacing

### DIFF
--- a/.changeset/spotty-tips-jam.md
+++ b/.changeset/spotty-tips-jam.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+Modifying checkbox group to match Figma, Fixing border hover in checkbox

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -271,10 +271,6 @@ export namespace Components {
          */
         "icon": string;
         /**
-          * The icon SVG's title attribute. Used for accessibility. If none is provided, the icon name will be used.
-         */
-        "label"?: string;
-        /**
           * The size of the icon. Can be 'extra-small', 'small', 'normal', 'large', 'auto' or any custom value ('30px', '1rem', '3.321em')
          */
         "size": | 'extra-small'
@@ -20585,10 +20581,6 @@ declare namespace LocalJSX {
           * The icon name
          */
         "icon": string;
-        /**
-          * The icon SVG's title attribute. Used for accessibility. If none is provided, the icon name will be used.
-         */
-        "label"?: string;
         /**
           * The size of the icon. Can be 'extra-small', 'small', 'normal', 'large', 'auto' or any custom value ('30px', '1rem', '3.321em')
          */

--- a/packages/web-components/src/components/rux-checkbox-group/rux-checkbox-group.scss
+++ b/packages/web-components/src/components/rux-checkbox-group/rux-checkbox-group.scss
@@ -11,7 +11,8 @@
 
 ::slotted(rux-checkbox) {
     display: block;
-    margin-bottom: 0.625rem; //10px
+    //margin-bottom: 0.625rem; //10px
+    margin-bottom: var(--spacing-2);
 }
 
 ::slotted(rux-checkbox:last-of-type) {
@@ -35,9 +36,10 @@
     display: flex;
     flex-direction: column;
     padding: 1rem;
-    border: 1px solid var(--color-border-interactive-muted);
+    width: fit-content;
+    box-shadow: var(--color-border-interactive-muted) 0 0 0 1px inset;
     border-radius: var(--radius-base);
     &--invalid {
-        border: 1px solid var(--color-text-error);
+        box-shadow: var(--color-text-error) 0 0 0 1px inset;
     }
 }

--- a/packages/web-components/src/components/rux-checkbox-group/test/index.html
+++ b/packages/web-components/src/components/rux-checkbox-group/test/index.html
@@ -24,7 +24,7 @@
     </head>
     <body>
         <!-- <ftl-belt
-            access-token="figd_9S33KsQIz3Kpi6WvFmR0XmeDhfxbCzwm5RYLt4mv"
+            access-token="ACCESS_TOKEN"
             file-id="7a5JMdh1FoXwhg64Tqv9F1"
         >
             <ftl-holster name="Checkbox Group with Border" node="25916:114892">

--- a/packages/web-components/src/components/rux-checkbox-group/test/index.html
+++ b/packages/web-components/src/components/rux-checkbox-group/test/index.html
@@ -17,13 +17,13 @@
         <script nomodule src="/build/astro-web-components.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
-        <script
+        <!-- <script
             type="module"
             src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script>
+        ></script> -->
     </head>
     <body>
-        <ftl-belt
+        <!-- <ftl-belt
             access-token="figd_9S33KsQIz3Kpi6WvFmR0XmeDhfxbCzwm5RYLt4mv"
             file-id="7a5JMdh1FoXwhg64Tqv9F1"
         >
@@ -35,7 +35,7 @@
                     <rux-checkbox>Checkbox</rux-checkbox>
                 </rux-checkbox-group>
             </ftl-holster>
-        </ftl-belt>
+        </ftl-belt> -->
         <rux-checkbox-group>
             <rux-checkbox>one</rux-checkbox>
             <rux-checkbox>two</rux-checkbox>

--- a/packages/web-components/src/components/rux-checkbox-group/test/index.html
+++ b/packages/web-components/src/components/rux-checkbox-group/test/index.html
@@ -17,8 +17,25 @@
         <script nomodule src="/build/astro-web-components.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
+        <script
+            type="module"
+            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
+        ></script>
     </head>
     <body>
+        <ftl-belt
+            access-token="figd_9S33KsQIz3Kpi6WvFmR0XmeDhfxbCzwm5RYLt4mv"
+            file-id="7a5JMdh1FoXwhg64Tqv9F1"
+        >
+            <ftl-holster name="Checkbox Group with Border" node="25916:114892">
+                <rux-checkbox-group>
+                    <rux-checkbox>Checkbox</rux-checkbox>
+                    <rux-checkbox>Checkbox</rux-checkbox>
+                    <rux-checkbox>Checkbox</rux-checkbox>
+                    <rux-checkbox>Checkbox</rux-checkbox>
+                </rux-checkbox-group>
+            </ftl-holster>
+        </ftl-belt>
         <rux-checkbox-group>
             <rux-checkbox>one</rux-checkbox>
             <rux-checkbox>two</rux-checkbox>

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
@@ -46,6 +46,7 @@
     input[type='checkbox'] {
         -webkit-appearance: none;
         appearance: none;
+        margin: 0;
 
         + label {
             position: relative;
@@ -55,7 +56,6 @@
             color: var(--color-text-primary);
             line-height: var(--font-body-1-bold-line-height);
             cursor: pointer;
-            margin-left: -7px;
 
             // Box
             &::before {
@@ -113,7 +113,8 @@
     input[type='checkbox']:not(:disabled):hover {
         + label {
             &::before {
-                border-color: var(--color-background-interactive-hover);
+                box-shadow: var(--color-background-interactive-hover) 0 0 0 1px
+                    inset;
             }
         }
     }

--- a/packages/web-components/src/components/rux-checkbox/test/index.html
+++ b/packages/web-components/src/components/rux-checkbox/test/index.html
@@ -24,7 +24,7 @@
     </head>
 
     <body class="dark-theme">
-        <!-- <ftl-belt access-token="figd_9S33KsQIz3Kpi6WvFmR0XmeDhfxbCzwm5RYLt4mv" file-id="oj8NRemkyC8dBRHHpo95f3">
+        <!-- <ftl-belt access-token="ACCESS_TOKEN">
             <ftl-holster name="Test 1 Name" node="25916:114906">
                 <form id="form" style="width: 100%">
                     <rux-checkbox


### PR DESCRIPTION
## Brief Description

This commit includes changes to both checkbox and checkbox group. For checkbox, an error was corrected where the hover state of the input box was no longer working due to a border vs box-shadow discrepancy. Margin of zero was also applied to the base checkbox input in order to solve a bug appearing on Safari that was actually a bug on all browsers where the input was obeying the user-agent stylesheet, which did not necessarily have a margin of 0. This fix allowed the arbitrary value of -7px on margin-left that was set on the label to be removed.

For checkbox group, the css was modified so that the group matched design which included adding a width specification for the group and modifying the margin with a design token.

## JIRA Link

[Checkbox Group Spacing](https://rocketcom.atlassian.net/browse/ASTRO-4361)

## Related Issue

## General Notes

## Motivation and Context

This change fixes existing bugs and updates the CSS to use design tokens.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
