### PR TITLE
Km 3857 progress bar spacing

### DIFF
--- a/.changeset/khaki-kings-impress.md
+++ b/.changeset/khaki-kings-impress.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+rux-progress / rux-indeterminate-progress spacing and design token updates

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -271,10 +271,6 @@ export namespace Components {
          */
         "icon": string;
         /**
-          * The icon SVG's title attribute. Used for accessibility. If none is provided, the icon name will be used.
-         */
-        "label"?: string;
-        /**
           * The size of the icon. Can be 'extra-small', 'small', 'normal', 'large', 'auto' or any custom value ('30px', '1rem', '3.321em')
          */
         "size": | 'extra-small'
@@ -20585,10 +20581,6 @@ declare namespace LocalJSX {
           * The icon name
          */
         "icon": string;
-        /**
-          * The icon SVG's title attribute. Used for accessibility. If none is provided, the icon name will be used.
-         */
-        "label"?: string;
         /**
           * The size of the icon. Can be 'extra-small', 'small', 'normal', 'large', 'auto' or any custom value ('30px', '1rem', '3.321em')
          */

--- a/packages/web-components/src/components/rux-indeterminate-progress/rux-indeterminate-progress.scss
+++ b/packages/web-components/src/components/rux-indeterminate-progress/rux-indeterminate-progress.scss
@@ -2,24 +2,26 @@
     /**
     * @prop --size: Used to determine the overall size of rux-indeterminate-progress, and used in multiple CSS calculations. 
     */
-    --size: 3.75rem;
+    --size: calc(
+        var(--spacing-14) + (var(--spacing-1) / 2)
+    ); //need to account for border
 
     // These are used to determine nub-size
-    --container-height: calc(var(--size) + 4px);
-    --second-div-height: calc(var(--size) * 0.9 - 6px);
+    --container-height: calc(var(--size) + var(--spacing-1));
+    --second-div-height: calc(var(--size) * 0.9 - var(--spacing-1));
 
     --nub-size: calc(
-        ((var(--container-height) - var(--second-div-height)) / 2) - 4px
+        ((var(--container-height) - var(--second-div-height)) / 2) - 0.187rem
     );
 
-    // .5's here to pervent hard stops in mask
+    // .5 here to prevent hard stops in mask in color
     --mask: radial-gradient(
         farthest-side,
-        transparent calc((((100% - 4px) * 0.9) - 5.5px)),
+        transparent calc((((100% - 1px) * 0.9) - 4px)),
         var(--color-background-interactive-default)
-            calc((((100% - 4px) * 0.9) - 4.5px))
+            calc((((100% - 1px) * 0.9) - 3.5px))
     );
-    --border-width: 2px;
+    --border-width: 1px;
     display: inline-block;
 }
 
@@ -62,8 +64,8 @@
 }
 
 .rux-indeterminate-inner-spinner-gap {
-    height: calc(90% - 6px);
-    width: calc(90% - 6px);
+    height: calc(90% - var(--spacing-1));
+    width: calc(90% - var(--spacing-1));
     background: transparent;
     border-radius: 100%;
     border: var(--border-width) solid var(--color-background-base-default);

--- a/packages/web-components/src/components/rux-indeterminate-progress/test/index.html
+++ b/packages/web-components/src/components/rux-indeterminate-progress/test/index.html
@@ -88,5 +88,11 @@
                 spinner.style.background = 'inherit'
             })
         </script>
+        <h2>Figma Spacing Test</h2>
+        <ftl-belt access-token="" file-id="">
+            <ftl-holster name="Progress Spinner" node="24112:114293">
+                <rux-indeterminate-progress></rux-indeterminate-progress>
+            </ftl-holster>
+        </ftl-belt>
     </body>
 </html>

--- a/packages/web-components/src/components/rux-progress/rux-progress.scss
+++ b/packages/web-components/src/components/rux-progress/rux-progress.scss
@@ -1,7 +1,7 @@
 :host {
     position: relative;
     display: inline-block;
-    padding: 1.25rem; //20px
+    height: calc(var(--spacing-4) + var(--spacing-1)); //20px;
 }
 :host([value]) {
     display: flex;
@@ -10,27 +10,28 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0.125rem; //2px
+    padding: var(--spacing-0);
 }
 
 :host([hidden]) {
     display: none;
 }
 .rux-progress[value] {
+    box-sizing: border-box;
     appearance: none;
     background-color: var(--color-background-surface-default);
     border: 1px solid var(--color-background-interactive-default);
     border-radius: var(--progress-radius-outer);
-    height: 1.25rem;
+    height: calc(var(--spacing-4) + var(--spacing-1)); //20px;
     width: 100%;
     &::-webkit-progress-bar {
         background-color: transparent;
     }
     &::-webkit-progress-value {
         border-radius: var(--progress-radius-outer);
-        height: 0.875rem;
-        margin: 0.125rem 0 0 0.125rem;
-        max-width: calc(100% - 4px);
+        height: var(--spacing-4); //16
+        margin: calc(var(--spacing-1) / 4) 0 0 calc(var(--spacing-1) / 4);
+        max-width: calc(100% - (var(--spacing-1) / 2)); //respect margin spacing
         background: var(--color-background-interactive-default);
         transition: width 0.3s ease;
         -moz-transition: width 0.3s ease;
@@ -40,16 +41,15 @@
     &::-ms-fill {
         border-radius: var(--progress-radius-outer);
         border: none;
-        height: 0.875rem;
-        margin: 0.125rem;
-        max-width: calc(100% - 0.375rem);
+        height: var(--spacing-4); //16
+        margin: calc(var(--spacing-1) / 4);
+        max-width: calc(100% - calc(var(--spacing-1) / 2));
         background-color: var(--color-background-interactive-default);
     }
     &::-moz-progress-bar {
         border-radius: var(--progress-radius-outer);
-        margin: 0.125rem 0.125rem 0 0.125rem;
-        height: 0.875rem;
-        max-width: calc(100% - 4px);
+        margin: calc(var(--spacing-1) / 4); //1
+        height: var(--spacing-4); //16
         background: var(--color-background-interactive-default);
     }
 }
@@ -59,7 +59,7 @@
     font-size: var(--font-body-1-font-size);
     letter-spacing: var(--font-body-1-letter-spacing);
     line-height: var(--font-body-1-line-height);
-    margin-left: 0.5rem;
+    margin-left: var(--spacing-2);
     text-align: right;
     color: var(--color-text-primary);
 }

--- a/packages/web-components/src/components/rux-progress/test/index.html
+++ b/packages/web-components/src/components/rux-progress/test/index.html
@@ -21,5 +21,22 @@
 
     <body>
         <rux-progress max="100" min="0" value="50"></rux-progress>
+        <ftl-belt access-token="" file-id="">
+            <ftl-holster name="Progress Empty" node="24958:114399">
+                <div style="width: 381px">
+                    <rux-progress max="100" min="0" value="0"></rux-progress>
+                </div>
+            </ftl-holster>
+            <ftl-holster name="Progress Half" node="25864:114700">
+                <div style="width: 390px">
+                    <rux-progress max="100" min="0" value="50"></rux-progress>
+                </div>
+            </ftl-holster>
+            <ftl-holster name="Progress Full" node="25864:114706">
+                <div style="width: 399px">
+                    <rux-progress max="100" min="0" value="100"></rux-progress>
+                </div>
+            </ftl-holster>
+        </ftl-belt>
     </body>
 </html>


### PR DESCRIPTION
## Brief Description

Added spacing tokens to <rux-progress> and <rux-indeterminate-progress> and aligned them to Astro design in Figma.

## JIRA Link

[ASTRO-3857](https://rocketcom.atlassian.net/browse/ASTRO-3857)

## Related Issue

## General Notes

## Motivation and Context

Part of the Astro Spacing token initiative!

## Issues and Limitations

Indeterminate Progress could only take some spacing tokens in order to create a pixel perfect render in all browsers and still resize properly.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
