### PR TITLE
add border-box sizing to fix visual glitch

### DIFF
--- a/.changeset/thin-flowers-carry.md
+++ b/.changeset/thin-flowers-carry.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+rux-progress - visual fix for firefox, properly align progress indicator

--- a/packages/angular/package-lock.json
+++ b/packages/angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astrouxds/angular",
-  "version": "6.12.0",
+  "version": "6.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@astrouxds/angular",
-      "version": "6.12.0",
+      "version": "6.12.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "^1.9.3"

--- a/packages/astro-uxds/package-lock.json
+++ b/packages/astro-uxds/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-website",
-  "version": "6.12.0",
+  "version": "6.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-website",
-      "version": "6.12.0",
+      "version": "6.12.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@astrouxds/astro-figma-export": "^1.4.0",

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astrouxds/react",
-  "version": "6.12.0",
+  "version": "6.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@astrouxds/react",
-      "version": "6.12.0",
+      "version": "6.12.1",
       "devDependencies": {
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.1.0",

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@astrouxds/astro-web-components",
-    "version": "6.12.0",
+    "version": "6.12.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@astrouxds/astro-web-components",
-            "version": "6.12.0",
+            "version": "6.12.1",
             "license": "MIT",
             "dependencies": {
                 "@stencil/core": "~2.5.2",

--- a/packages/web-components/src/components/rux-progress/rux-progress.scss
+++ b/packages/web-components/src/components/rux-progress/rux-progress.scss
@@ -70,6 +70,7 @@
     border-radius: var(--progress-radius);
     height: 1.25rem;
     width: 100%;
+    box-sizing: border-box;
     &::-webkit-progress-bar {
         background-color: transparent;
     }

--- a/packages/web-components/src/components/rux-progress/test/index.html
+++ b/packages/web-components/src/components/rux-progress/test/index.html
@@ -20,5 +20,8 @@
     </head>
     <body>
         <rux-progress></rux-progress>
+        <div style="margin: 3rem auto; padding: 2rem; text-align: center">
+            <rux-progress value="100" max="100"></rux-progress>
+        </div>
     </body>
 </html>


### PR DESCRIPTION
## Brief Description

Current rux-progress in Firefox was out of alignment with the size and visuals of rux-progress in other browsers. Adding a box-sizing: border-box property to run-progress fixed this issue while not changing the design or size in other evergreen browsers.

## JIRA Link

[ASTRO-4363](https://rocketcom.atlassian.net/browse/ASTRO-4363)

## Related Issue

## General Notes

## Motivation and Context

Noticed a visual defect in the current branch while working on the spacing initiative for next branch.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
