### PR TITLE
Added Figma 6.0 wireframe theme link

### DIFF
--- a/packages/astro-uxds/_content/getting-started/designers.md
+++ b/packages/astro-uxds/_content/getting-started/designers.md
@@ -22,7 +22,8 @@ Before reading any further, we recommend you take a look at a live [Astro Sample
 
 ## Figma
 
-[Astro UXDS Figma Library](https://www.figma.com/community/file/1014254163928270411)
+[Astro UXDS Figma Library 6.0 - Dark Theme](https://www.figma.com/community/file/1014254163928270411)
+[Astro UXDS Figma Library 6.0 - Wireframe Theme](https://www.figma.com/community/file/1101538528179386032)
 [Astro UXDS Icon Library](https://www.figma.com/community/file/1022883566772542677)
 
 ## Sketch


### PR DESCRIPTION
## Brief Description

Added Figma 6.0 wireframe theme link

## JIRA Link

No ticket. Just a quick fix for a request from a KM user.

## Related Issue

## General Notes

## Motivation and Context

Adds in the missing link to the Wireframe 6.0 file.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
