### PR TITLE
Updated downloads page with correct Figma link

### DIFF
--- a/packages/astro-uxds/_content/downloads.md
+++ b/packages/astro-uxds/_content/downloads.md
@@ -11,7 +11,7 @@ title: Downloads
 ## Astro Design System
 
 - Astro Component Source Code ([Git Repository](https://github.com/RocketCommunicationsInc/astro-components))
-- Astro UXDS Figma Page ([Figma](https://www.figma.com/community/file/1014254163928270411))
+- Astro UXDS Figma Page ([Figma](https://www.figma.com/@astrouxds))
 - Astro Icons ([SVG](https://github.com/RocketCommunicationsInc/astro/tree/main/packages/web-components/src/icons) | [Figma](https://www.figma.com/community/file/1022883566772542677))
 - Astro React Wrapper ([Git Repository](https://github.com/RocketCommunicationsInc/astro/tree/main/packages/react))
 - Astro React Starter Kit ([Git Repository](https://github.com/RocketCommunicationsInc/astro/blob/main/packages/starter-kits/react-starter/README.md))


### PR DESCRIPTION
## Brief Description

Changed the Figma link to our profile page with all of our files instead of just the dark 6.0 theme file.

## JIRA Link

None. Quick fix for a KM user.

## Related Issue

## General Notes

## Motivation and Context

Link is incorrect for showing all Figma work.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
