### PR TITLE
Km 3842 rux textarea spacing alignment

### DIFF
--- a/.changeset/old-bottles-poke.md
+++ b/.changeset/old-bottles-poke.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+rux-textarea - add spacing tokens and adjust code to fix firefox issue with resize

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -16,12 +16,14 @@
     min-height: var(--spacing-16); //64
     width: 100%;
     padding: var(--spacing-2); //8px
+    margin: var(--spacing-0);
     border: 1px solid var(--color-border-interactive-muted);
     border-radius: var(--radius-base);
-    font-family: var(--font-body-1-font-family);
-    font-size: var(--font-body-1-font-size);
-    letter-spacing: var(--font-body-1-letter-spacing);
-    font-weight: var(--font-body-1-font-weight);
+    font-family: var(--font-control-body-1-font-family);
+    font-size: var(--font-control-body-1-font-size);
+    letter-spacing: var(--font-control-body-1-letter-spacing);
+    font-weight: var(--font-control-body-1-font-weight);
+    line-height: var(--font-control-body-1-line-height);
     color: var(--color-text-primary);
     background-color: var(--color-background-base-default);
     &--invalid {

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -30,6 +30,7 @@
 
 .rux-textarea-wrapper {
     box-sizing: border-box;
+    position: relative;
     display: flex;
     min-height: var(--spacing-16); //64
     width: 100%;
@@ -96,27 +97,27 @@
 }
 
 //add proper grabber icon - disabled for now
-// .rux-textarea::-webkit-resizer {
+// .rux-textarea-wrapper::-webkit-resizer {
 //     display: none;
 // }
-// .rux-textarea-field::after {
+// .rux-textarea-wrapper::after {
 //     content: '';
 //     background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M5 9H19C19.55 9 20 9.45 20 10C20 10.55 19.55 11 19 11H5C4.45 11 4 10.55 4 10C4 9.45 4.45 9 5 9ZM19 15H5C4.45 15 4 14.55 4 14C4 13.45 4.45 13 5 13H19C19.55 13 20 13.45 20 14C20 14.55 19.55 15 19 15Z' fill='%23a4abb6'/%3E%3C/svg%3E");
 //     background-repeat: none;
 //     background-position: center;
 //     background-size: 10px;
 //     position: absolute;
-//     bottom: 8px;
-//     right: 4px;
-//     width: 8px;
-//     height: 8px;
+//     bottom: var(--spacing-1);
+//     right: var(--spacing-1);
+//     width: var(--spacing-2);
+//     height: var(--spacing-2);
 //     pointer-events: none;
 //     transform: rotate(-45deg);
 // }
 
 //firefox can't style the resize handle
 // @-moz-document url-prefix() {
-//     .rux-textarea-field::after {
+//     .rux-textarea-wrapper::after {
 //         display: none;
 //     }
 // }

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -26,6 +26,7 @@
     line-height: var(--font-control-body-1-line-height);
     color: var(--color-text-primary);
     background-color: var(--color-background-base-default);
+
     &--invalid {
         border: 1px solid var(--color-text-error);
     }
@@ -64,9 +65,10 @@
 }
 
 .rux-textarea-field {
-    display: flex;
-    flex-direction: column;
+    display: inline-block;
+    //flex-direction: column;
     color: var(--color-text-primary);
+    position: relative;
 }
 
 .rux-textarea-label {
@@ -77,6 +79,32 @@
     margin-bottom: var(--spacing-input-label-top);
     &__asterisk {
         margin-left: var(--spacing-1);
+    }
+}
+
+//add proper grabber icon
+.rux-textarea::-webkit-resizer {
+    display: none;
+}
+.rux-textarea-field::after {
+    content: '';
+    background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M5 9H19C19.55 9 20 9.45 20 10C20 10.55 19.55 11 19 11H5C4.45 11 4 10.55 4 10C4 9.45 4.45 9 5 9ZM19 15H5C4.45 15 4 14.55 4 14C4 13.45 4.45 13 5 13H19C19.55 13 20 13.45 20 14C20 14.55 19.55 15 19 15Z' fill='%23a4abb6'/%3E%3C/svg%3E");
+    background-repeat: none;
+    background-position: center;
+    background-size: 10px;
+    position: absolute;
+    bottom: 8px;
+    right: 4px;
+    width: 8px;
+    height: 8px;
+    pointer-events: none;
+    transform: rotate(-45deg);
+}
+
+//firefox can't style the resize handle
+@-moz-document url-prefix() {
+    .rux-textarea-field::after {
+        display: none;
     }
 }
 

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -10,22 +10,36 @@
 }
 
 .rux-textarea {
+    display: inline-block;
     box-sizing: border-box;
-    -webkit-order: 2;
-    order: 2;
-    min-height: var(--spacing-16); //64
-    width: 100%;
-    padding: var(--spacing-2); //8
-    margin: var(--spacing-0);
-    border: 1px solid var(--color-border-interactive-muted);
-    border-radius: var(--radius-base);
     font-family: var(--font-control-body-1-font-family);
     font-size: var(--font-control-body-1-font-size);
     letter-spacing: var(--font-control-body-1-letter-spacing);
     font-weight: var(--font-control-body-1-font-weight);
     line-height: var(--font-control-body-1-line-height);
     color: var(--color-text-primary);
+    background-color: transparent;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    padding: var(--spacing-0);
+    margin: var(--spacing-0);
+    resize: none;
+    outline: none;
+}
+
+.rux-textarea-wrapper {
+    box-sizing: border-box;
+    display: flex;
+    min-height: var(--spacing-16); //64
+    width: 100%;
+    padding: var(--spacing-2);
+    margin: var(--spacing-0);
+    border: 1px solid var(--color-border-interactive-muted);
+    border-radius: var(--radius-base);
     background-color: var(--color-background-base-default);
+    resize: both;
+    overflow-y: auto;
 
     &--invalid {
         border: 1px solid var(--color-text-error);
@@ -65,10 +79,9 @@
 }
 
 .rux-textarea-field {
-    display: inline-block;
-    //flex-direction: column;
+    display: flex;
+    flex-direction: column;
     color: var(--color-text-primary);
-    position: relative;
 }
 
 .rux-textarea-label {

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -15,7 +15,7 @@
     order: 2;
     min-height: var(--spacing-16); //64
     width: 100%;
-    padding: var(--spacing-2); //8px
+    padding: var(--spacing-2); //8
     margin: var(--spacing-0);
     border: 1px solid var(--color-border-interactive-muted);
     border-radius: var(--radius-base);
@@ -82,31 +82,31 @@
     }
 }
 
-//add proper grabber icon
-.rux-textarea::-webkit-resizer {
-    display: none;
-}
-.rux-textarea-field::after {
-    content: '';
-    background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M5 9H19C19.55 9 20 9.45 20 10C20 10.55 19.55 11 19 11H5C4.45 11 4 10.55 4 10C4 9.45 4.45 9 5 9ZM19 15H5C4.45 15 4 14.55 4 14C4 13.45 4.45 13 5 13H19C19.55 13 20 13.45 20 14C20 14.55 19.55 15 19 15Z' fill='%23a4abb6'/%3E%3C/svg%3E");
-    background-repeat: none;
-    background-position: center;
-    background-size: 10px;
-    position: absolute;
-    bottom: 8px;
-    right: 4px;
-    width: 8px;
-    height: 8px;
-    pointer-events: none;
-    transform: rotate(-45deg);
-}
+//add proper grabber icon - disabled for now
+// .rux-textarea::-webkit-resizer {
+//     display: none;
+// }
+// .rux-textarea-field::after {
+//     content: '';
+//     background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M5 9H19C19.55 9 20 9.45 20 10C20 10.55 19.55 11 19 11H5C4.45 11 4 10.55 4 10C4 9.45 4.45 9 5 9ZM19 15H5C4.45 15 4 14.55 4 14C4 13.45 4.45 13 5 13H19C19.55 13 20 13.45 20 14C20 14.55 19.55 15 19 15Z' fill='%23a4abb6'/%3E%3C/svg%3E");
+//     background-repeat: none;
+//     background-position: center;
+//     background-size: 10px;
+//     position: absolute;
+//     bottom: 8px;
+//     right: 4px;
+//     width: 8px;
+//     height: 8px;
+//     pointer-events: none;
+//     transform: rotate(-45deg);
+// }
 
 //firefox can't style the resize handle
-@-moz-document url-prefix() {
-    .rux-textarea-field::after {
-        display: none;
-    }
-}
+// @-moz-document url-prefix() {
+//     .rux-textarea-field::after {
+//         display: none;
+//     }
+// }
 
 ::selection {
     background-color: var(--color-palette-brightblue-400);

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -13,9 +13,9 @@
     box-sizing: border-box;
     -webkit-order: 2;
     order: 2;
-    min-height: 4.25rem;
+    min-height: var(--spacing-16); //64
     width: 100%;
-    padding: 0.469rem 0.5rem; //7.5px 8px
+    padding: var(--spacing-2); //8px
     border: 1px solid var(--color-border-interactive-muted);
     border-radius: var(--radius-base);
     font-family: var(--font-body-1-font-family);
@@ -33,12 +33,12 @@
         cursor: not-allowed;
     }
     &--small {
-        padding: 0.219rem 0.5rem; //3.5px 8px
-        min-height: 3.25rem; //52px
+        padding: var(--spacing-1) var(--spacing-2); //4px 8px
+        min-height: var(--spacing-14); //56px
     }
     &--large {
-        min-height: 5.75rem; //92px
-        padding: 0.844rem 0.5rem; //13.5px 8px
+        min-height: calc(var(--spacing-16) + var(--spacing-2)); //72px
+        padding: var(--spacing-3) var(--spacing-2); //12px 8px
     }
 
     &:focus {
@@ -74,7 +74,7 @@
     letter-spacing: var(--font-body-1-letter-spacing);
     margin-bottom: var(--spacing-input-label-top);
     &__asterisk {
-        margin-left: 4px;
+        margin-left: var(--spacing-1);
     }
 }
 

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -96,32 +96,6 @@
     }
 }
 
-//add proper grabber icon - disabled for now
-// .rux-textarea-wrapper::-webkit-resizer {
-//     display: none;
-// }
-// .rux-textarea-wrapper::after {
-//     content: '';
-//     background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M5 9H19C19.55 9 20 9.45 20 10C20 10.55 19.55 11 19 11H5C4.45 11 4 10.55 4 10C4 9.45 4.45 9 5 9ZM19 15H5C4.45 15 4 14.55 4 14C4 13.45 4.45 13 5 13H19C19.55 13 20 13.45 20 14C20 14.55 19.55 15 19 15Z' fill='%23a4abb6'/%3E%3C/svg%3E");
-//     background-repeat: none;
-//     background-position: center;
-//     background-size: 10px;
-//     position: absolute;
-//     bottom: var(--spacing-1);
-//     right: var(--spacing-1);
-//     width: var(--spacing-2);
-//     height: var(--spacing-2);
-//     pointer-events: none;
-//     transform: rotate(-45deg);
-// }
-
-//firefox can't style the resize handle
-// @-moz-document url-prefix() {
-//     .rux-textarea-wrapper::after {
-//         display: none;
-//     }
-// }
-
 ::selection {
     background-color: var(--color-palette-brightblue-400);
 }

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.tsx
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.tsx
@@ -191,30 +191,37 @@ export class RuxTextarea implements FormFieldInterface {
                             </span>
                         </label>
                     ) : null}
-
-                    <textarea
-                        name={this.name}
-                        disabled={this.disabled}
-                        aria-invalid={this.invalid ? 'true' : 'false'}
-                        placeholder={this.placeholder}
-                        required={this.required}
-                        minlength={this.minLength}
-                        maxlength={this.maxLength}
-                        value={this.value}
+                    <div
                         class={{
-                            'rux-textarea': true,
-                            'rux-textarea--disabled': this.disabled,
-                            'rux-textarea--invalid': this.invalid,
-                            'rux-textarea--small': this.size === 'small',
-                            'rux-textarea--large': this.size === 'large',
+                            'rux-textarea-wrapper': true,
+                            'rux-textarea-wrapper--disabled': this.disabled,
+                            'rux-textarea-wrapper--invalid': this.invalid,
+                            'rux-textarea-wrapper--small':
+                                this.size === 'small',
+                            'rux-textarea-wrapper--large':
+                                this.size === 'large',
                         }}
-                        id={this.inputId}
-                        rows={this.rows}
-                        onChange={this._onChange}
-                        onInput={this._onInput}
-                        onBlur={this._onBlur}
-                        part="textarea"
-                    ></textarea>
+                    >
+                        <textarea
+                            name={this.name}
+                            disabled={this.disabled}
+                            aria-invalid={this.invalid ? 'true' : 'false'}
+                            placeholder={this.placeholder}
+                            required={this.required}
+                            minlength={this.minLength}
+                            maxlength={this.maxLength}
+                            value={this.value}
+                            class={{
+                                'rux-textarea': true,
+                            }}
+                            id={this.inputId}
+                            rows={this.rows}
+                            onChange={this._onChange}
+                            onInput={this._onInput}
+                            onBlur={this._onBlur}
+                            part="textarea"
+                        ></textarea>
+                    </div>
                 </div>
                 <FormFieldMessage
                     helpText={this.helpText}

--- a/packages/web-components/src/components/rux-textarea/test/__snapshots__/rux-textarea.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-textarea/test/__snapshots__/rux-textarea.spec.tsx.snap
@@ -3,7 +3,9 @@
 exports[`rux-textarea renders 1`] = `
 <rux-textarea value="">
   <mock:shadow-root>
-    <div class="rux-textarea-field" part="form-field"><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-1" part="textarea" value=""></textarea>
+    <div class="rux-textarea-field" part="form-field">
+      <div class="rux-textarea-wrapper"><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-1" part="textarea" value=""></textarea>
+      </div>
     </div>
   </mock:shadow-root>
   <input class="aux-input" type="hidden" value="">
@@ -20,7 +22,9 @@ exports[`rux-textarea renders label prop 1`] = `
             hello
           </slot>
         </span>
-      </label><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-2" part="textarea" value=""></textarea>
+      </label>
+      <div class="rux-textarea-wrapper"><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-2" part="textarea" value=""></textarea>
+      </div>
     </div>
   </mock:shadow-root>
   <input class="aux-input" type="hidden" value="">
@@ -35,7 +39,9 @@ exports[`rux-textarea renders label slot 1`] = `
         <span>
           <slot name="label"></slot>
         </span>
-      </label><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-3" part="textarea" value=""></textarea>
+      </label>
+      <div class="rux-textarea-wrapper"><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-3" part="textarea" value=""></textarea>
+      </div>
     </div>
   </mock:shadow-root>
   <div slot="label">

--- a/packages/web-components/src/components/rux-textarea/test/index.html
+++ b/packages/web-components/src/components/rux-textarea/test/index.html
@@ -98,8 +98,7 @@ Native Text Area</textarea
                         id="figmatextarea1"
                         name="figmatest1"
                         placeholder="Small textarea"
-                        size="small"
-                    ></rux-textarea>
+                        size="small"rux
                 </div>
             </ftl-holster>
 
@@ -138,7 +137,7 @@ Native Text Area</textarea
             <ftl-holster name="With Error Text" node="1057:3759">
                 <div style="min-width: 170px">
                     <rux-textarea
-                        error
+                        invalid
                         id="figmatextarea1"
                         name="figmatest1"
                         placeholder="Textarea"
@@ -147,6 +146,6 @@ Native Text Area</textarea
                 </div>
             </ftl-holster>
         </section>
-    </ftl-belt> -->
+        </ftl-belt> -->
     </body>
 </html>

--- a/packages/web-components/src/components/rux-textarea/test/index.html
+++ b/packages/web-components/src/components/rux-textarea/test/index.html
@@ -81,5 +81,35 @@ Native Text Area</textarea
                 })
             </script>
         </div>
+        <section>
+            <h2>Figma Testing</h2>
+            <rux-textarea
+                id="figmatextarea1"
+                name="figmatest1"
+                placeholder="Placeholder text"
+                size="small"
+            ></rux-textarea>
+            <br />
+            <rux-textarea
+                id="figmatextarea1"
+                name="figmatest1"
+                value="Textarea"
+            ></rux-textarea>
+            <br />
+            <rux-textarea
+                id="figmatextarea1"
+                name="figmatest1"
+                placeholder="Placeholder text"
+            ></rux-textarea>
+            <br />
+            <rux-textarea
+                id="figmatextarea1"
+                name="figmatest1"
+                placeholder="Placeholder text"
+                size="large"
+            ></rux-textarea>
+            <br />
+            <br />
+        </section>
     </body>
 </html>

--- a/packages/web-components/src/components/rux-textarea/test/index.html
+++ b/packages/web-components/src/components/rux-textarea/test/index.html
@@ -17,10 +17,10 @@
         <script nomodule src="/build/astro-web-components.esm.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
-        <script
+        <!-- <script
             type="module"
             src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script>
+        ></script> -->
     </head>
 
     <body class="dark-theme">
@@ -89,7 +89,7 @@ Native Text Area</textarea
                 })
             </script>
         </div>
-
+        <!-- <ftl-belt access-token="" file-id="">
         <section>
             <h2>Figma Testing</h2>
             <ftl-holster name="Small text area" node="1043:6671">
@@ -147,17 +147,6 @@ Native Text Area</textarea
                 </div>
             </ftl-holster>
         </section>
-        <!-- </ftl-belt> -->
-
-        <rux-textarea
-            label="Textarea label"
-            error-text=""
-            help-text=""
-            max-length=""
-            min-length=""
-            rows=""
-            value=""
-            type=""
-        ></rux-textarea>
+    </ftl-belt> -->
     </body>
 </html>

--- a/packages/web-components/src/components/rux-textarea/test/index.html
+++ b/packages/web-components/src/components/rux-textarea/test/index.html
@@ -17,6 +17,10 @@
         <script nomodule src="/build/astro-web-components.esm.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
+        <script
+            type="module"
+            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
+        ></script>
     </head>
 
     <body class="dark-theme">
@@ -81,35 +85,63 @@ Native Text Area</textarea
                 })
             </script>
         </div>
+
         <section>
             <h2>Figma Testing</h2>
-            <rux-textarea
-                id="figmatextarea1"
-                name="figmatest1"
-                placeholder="Placeholder text"
-                size="small"
-            ></rux-textarea>
-            <br />
-            <rux-textarea
-                id="figmatextarea1"
-                name="figmatest1"
-                value="Textarea"
-            ></rux-textarea>
-            <br />
-            <rux-textarea
-                id="figmatextarea1"
-                name="figmatest1"
-                placeholder="Placeholder text"
-            ></rux-textarea>
-            <br />
-            <rux-textarea
-                id="figmatextarea1"
-                name="figmatest1"
-                placeholder="Placeholder text"
-                size="large"
-            ></rux-textarea>
-            <br />
-            <br />
+            <ftl-holster name="Small text area" node="1043:6671">
+                <div style="width: 170px">
+                    <rux-textarea
+                        id="figmatextarea1"
+                        name="figmatest1"
+                        placeholder="Small textarea"
+                        size="small"
+                    ></rux-textarea>
+                </div>
+            </ftl-holster>
+
+            <ftl-holster name="Medium text area" node="1043:6665">
+                <div style="width: 170px">
+                    <rux-textarea
+                        id="figmatextarea1"
+                        name="figmatest1"
+                        placeholder="Medium textarea"
+                    ></rux-textarea>
+                </div>
+            </ftl-holster>
+
+            <ftl-holster name="Large text area" node="1043:6689">
+                <div style="width: 170px">
+                    <rux-textarea
+                        id="figmatextarea1"
+                        name="figmatest1"
+                        placeholder="Large textarea"
+                        size="large"
+                    ></rux-textarea>
+                </div>
+            </ftl-holster>
+
+            <ftl-holster name="With Help Text" node="1043:6604">
+                <div style="width: 170px">
+                    <rux-textarea
+                        id="figmatextarea1"
+                        name="figmatest1"
+                        value="Textarea"
+                        help-text="help"
+                    ></rux-textarea>
+                </div>
+            </ftl-holster>
+
+            <ftl-holster name="With Error Text" node="1057:3759">
+                <div style="width: 170px">
+                    <rux-textarea
+                        id="figmatextarea1"
+                        name="figmatest1"
+                        placeholder="Textarea"
+                        error-text="error"
+                    ></rux-textarea>
+                </div>
+            </ftl-holster>
         </section>
+        <!-- </ftl-belt> -->
     </body>
 </html>

--- a/packages/web-components/src/components/rux-textarea/test/index.html
+++ b/packages/web-components/src/components/rux-textarea/test/index.html
@@ -57,7 +57,11 @@
                     error-text="PLZ YES"
                 ></rux-textarea>
                 <br />
-                <textarea id="nativeTextArea" name="native">
+                <textarea
+                    id="nativeTextArea"
+                    name="native"
+                    style="padding: 8px"
+                >
 Native Text Area</textarea
                 >
 
@@ -132,8 +136,9 @@ Native Text Area</textarea
             </ftl-holster>
 
             <ftl-holster name="With Error Text" node="1057:3759">
-                <div style="width: 170px">
+                <div style="min-width: 170px">
                     <rux-textarea
+                        error
                         id="figmatextarea1"
                         name="figmatest1"
                         placeholder="Textarea"
@@ -143,5 +148,16 @@ Native Text Area</textarea
             </ftl-holster>
         </section>
         <!-- </ftl-belt> -->
+
+        <rux-textarea
+            label="Textarea label"
+            error-text=""
+            help-text=""
+            max-length=""
+            min-length=""
+            rows=""
+            value=""
+            type=""
+        ></rux-textarea>
     </body>
 </html>


### PR DESCRIPTION
## Brief Description

Add spacing tokens and align to Astro design specifications. Additionally, in service to fixing an issue caused by padding in Firefox, I added a wrapper around textarea and added padding to that. Explained more thoroughly below.

## JIRA Link

[ASTRO-3842](https://rocketcom.atlassian.net/browse/ASTRO-3842)

## Related Issue

## General Notes

## Motivation and Context

Part of the Astro spacing initiative!

## Issues and Limitations

Adding spacing to text areas adds a range of issues that you wouldn't expect, but it boils down to two issues:

**Issue 1: Padding**
Adding too much padding to a textarea breaks resizing in safari. The user becomes unable to get to the resizing handle for whatever reason.

After an extensive amount of testing, troubleshooting, and research I styled a new resizable wrapper around textarea. Safari doesn't have trouble with resize and padding when it is not attached to textarea. This works across all evergreen browsers but the scrollbar positioning is a little odd when a scrollbar exists, so it's an imperfect solution.

**Issue 2: Styling the resize handle**

Only ::-webkit browsers can target the resize handle, which means that it cannot be restyled in Firefox. I checked with design and they are ok with allowing the handle to be styled by the browser. I left my suggested solution for a styled handle commented out in the css, but this should be removed before merging.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
