### PR TITLE
feat(dialog): add better keyboard support

### DIFF
--- a/.changeset/young-apricots-grin.md
+++ b/.changeset/young-apricots-grin.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/angular": minor
+"astro-website": minor
+"@astrouxds/react": minor
+"@astrouxds/astro-web-components": minor
+---
+
+Added better keyboard support to rux-dialog. Now supports tabbing between confrim and deny buttons, and triggers deny on an escape key press.

--- a/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
+++ b/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
@@ -81,10 +81,27 @@ export class RuxDialog {
     // confirm dialog if Enter key is pressed
     @Listen('keydown', { target: 'window' })
     handleKeyDown(ev: KeyboardEvent) {
-        if (ev.key === 'Enter') {
-            const button = this._getDefaultButton()
-            if (button) {
-                button.click()
+        if (this.open) {
+            const btns: NodeListOf<HTMLRuxButtonElement> = this.element.shadowRoot!.querySelectorAll(
+                'rux-button'
+            )
+            if (ev.key === 'Enter') {
+                //If enter is hit but the cancel/deny button is focused, we want to click that instead.
+                let activeEl: any = this.element.shadowRoot?.activeElement
+                if (activeEl && activeEl === btns[0]) {
+                    this._userInput = false
+                    btns[0].click()
+                } else {
+                    const button = this._getDefaultButton()
+                    if (button) {
+                        this._userInput = true
+                        button.click()
+                    }
+                }
+            }
+            if (ev.key === 'Escape') {
+                this._userInput = false
+                btns[0].click()
             }
         }
     }
@@ -235,8 +252,9 @@ export class RuxDialog {
                                                 onClick={_handleDialogChoice}
                                                 data-value="false"
                                                 hidden={!denyText}
-                                                tabindex="-1"
+                                                tabindex="0"
                                                 exportparts="container:deny-button"
+                                                id="rux-dialog-deny-button"
                                             >
                                                 {denyText}
                                             </rux-button>
@@ -244,7 +262,7 @@ export class RuxDialog {
                                                 onClick={_handleDialogChoice}
                                                 hidden={!confirmText}
                                                 data-value="true"
-                                                tabindex="0"
+                                                tabindex="1"
                                                 exportparts="container:confirm-button"
                                             >
                                                 {confirmText}

--- a/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
+++ b/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
@@ -81,11 +81,13 @@ export class RuxDialog {
     // confirm dialog if Enter key is pressed
     @Listen('keydown', { target: 'window' })
     handleKeyDown(ev: KeyboardEvent) {
-        if (this.open) {
+        // prevent this from running if the slots version is being used
+        if (this.open && !this.hasFooter) {
             const btns: NodeListOf<HTMLRuxButtonElement> = this.element.shadowRoot!.querySelectorAll(
                 'rux-button'
             )
             if (ev.key === 'Enter') {
+                console.log('inside the enter if, this is running')
                 //If enter is hit but the cancel/deny button is focused, we want to click that instead.
                 let activeEl: any = this.element.shadowRoot?.activeElement
                 if (activeEl && activeEl === btns[0]) {

--- a/packages/web-components/src/components/rux-dialog/test/index.html
+++ b/packages/web-components/src/components/rux-dialog/test/index.html
@@ -1,151 +1,134 @@
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
-    <head>
-        <meta charset="utf-8" />
-        <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
-        />
-        <title>Stencil Component Starter</title>
 
-        <link rel="preconnect" href="https://fonts.gstatic.com" />
-        <link
-            href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@100;300;400&family=Roboto:wght@100;300;400;500;700;900&display=swap"
-            rel="stylesheet"
-        />
-        <script type="module" src="/build/astro-web-components.esm.js"></script>
-        <script nomodule src="/build/astro-web-components.js"></script>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Stencil Component Starter</title>
 
-        <link rel="stylesheet" href="/build/astro-web-components.css" />
-    </head>
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+        href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@100;300;400&family=Roboto:wght@100;300;400;500;700;900&display=swap"
+        rel="stylesheet" />
+    <script type="module" src="/build/astro-web-components.esm.js"></script>
+    <script nomodule src="/build/astro-web-components.js"></script>
 
-    <body>
-        <section>
-            <rux-dialog
-                open
-                modal-title="hello"
-                modal-message="world"
-            ></rux-dialog>
-        </section>
-        <section>
-            <rux-dialog
-                id="props"
-                modal-message="Props Message"
-                modal-title="Props Title"
-            ></rux-dialog>
-            <rux-button id="openprops">Open Props Version</rux-button>
-        </section>
-        <section>
-            <rux-dialog id="slots">
-                <span slot="header">Slot Header</span>
-                <div slot="message">
-                    <span>Slot Message</span>
-                    <rux-input placeholder="input time"></rux-input>
-                </div>
-                <div slot="footer">
-                    <rux-button-group h-align="right">
-                        <rux-button secondary>Slot Cancel</rux-button>
-                        <rux-button id="slotconfirm">Slot Confirm</rux-button>
-                    </rux-button-group>
-                </div>
-            </rux-dialog>
-            <rux-button id="openslots" style="padding: 15px 0px"
-                >Open Slots Version</rux-button
-            >
-        </section>
-        <section>
-            <rux-dialog
-                id="mix"
-                modal-title="Mixed"
-                deny-text="Custom Deny Text"
-            >
-                <div slot="message">
-                    <span>Slot Message</span>
-                    <rux-input placeholder="input time"></rux-input>
-                </div>
-                <div slot="footer">
-                    <rux-button-group h-align="right">
-                        <rux-button secondary>Slot Cancel</rux-button>
-                        <rux-button id="confirm">Slot Confirm</rux-button>
-                    </rux-button-group>
-                </div>
-            </rux-dialog>
-            <rux-button id="openmix">Open Mixed Version</rux-button>
-        </section>
-        <section>
-            <rux-button id="dyn" style="padding: 15px 0px"
-                >Open changing slot</rux-button
-            >
-            <rux-dialog id="change" modal-title="Title"> </rux-dialog>
-        </section>
-        <script>
-            const props = document.getElementById('props')
-            const openProps = document.getElementById('openprops')
+    <link rel="stylesheet" href="/build/astro-web-components.css" />
+</head>
 
-            openProps.addEventListener('click', () => {
-                props.open = !props.open
-            })
+<body>
+    <section>
+        <rux-dialog open modal-title="hello" modal-message="world"></rux-dialog>
+    </section>
+    <section>
+        <rux-dialog id="props" modal-message="Props Message" modal-title="Props Title"></rux-dialog>
+        <rux-button id="openprops">Open Props Version</rux-button>
+    </section>
+    <section>
+        <rux-dialog id="slots">
+            <span slot="header">Slot Header</span>
+            <div slot="message">
+                <span>Slot Message</span>
+                <rux-input placeholder="input time"></rux-input>
+            </div>
+            <div slot="footer">
+                <rux-button-group h-align="right">
+                    <rux-button secondary>Slot Cancel</rux-button>
+                    <rux-button id="slotconfirm">Slot Confirm</rux-button>
+                </rux-button-group>
+            </div>
+        </rux-dialog>
+        <rux-button id="openslots" style="padding: 15px 0px">Open Slots Version</rux-button>
+    </section>
+    <section>
+        <rux-dialog id="mix" modal-title="Mixed" deny-text="Custom Deny Text">
+            <div slot="message">
+                <span>Slot Message</span>
+                <rux-input placeholder="input time"></rux-input>
+            </div>
+            <div slot="footer">
+                <rux-button-group h-align="right">
+                    <rux-button secondary>Slot Cancel</rux-button>
+                    <rux-button id="confirm">Slot Confirm</rux-button>
+                </rux-button-group>
+            </div>
+        </rux-dialog>
+        <rux-button id="openmix">Open Mixed Version</rux-button>
+    </section>
+    <section>
+        <rux-button id="dyn" style="padding: 15px 0px">Open changing slot</rux-button>
+        <rux-dialog id="change" modal-title="Title"> </rux-dialog>
+    </section>
+    <script>
+        const props = document.getElementById('props')
+        const openProps = document.getElementById('openprops')
 
-            props.addEventListener('ruxmodalopened', () =>
-                console.log('props ruxmodalopened')
-            )
-            props.addEventListener('ruxmodalclosed', () =>
-                console.log('props ruxmodalclosed')
-            )
+        openProps.addEventListener('click', () => {
+            props.open = !props.open
+        })
 
-            const slots = document.getElementById('slots')
-            const openSlots = document.getElementById('openslots')
-            const slotconfirm = document.getElementById('slotconfirm')
+        props.addEventListener('ruxdialogopened', () =>
+            console.log('props ruxdialogopened')
+        )
+        props.addEventListener('ruxdialogclosed', () =>
+            console.log('props ruxdialogclosed')
+        )
 
-            slotconfirm.addEventListener('click', () => {
-                slots.open = false
-            })
+        const slots = document.getElementById('slots')
+        const openSlots = document.getElementById('openslots')
+        const slotconfirm = document.getElementById('slotconfirm')
 
-            openSlots.addEventListener('click', () => {
-                slots.open = !slots.open
-            })
-            slots.addEventListener('ruxmodalopened', () =>
-                console.log('heard ruxmodalopened')
-            )
-            slots.addEventListener('ruxmodalclosed', () =>
-                console.log('heard ruxmodalclosed')
-            )
+        slotconfirm.addEventListener('click', () => {
+            slots.open = false
+        })
 
-            const mixed = document.getElementById('mix')
-            const openMixed = document.getElementById('openmix')
-            openMixed.addEventListener('click', () => {
-                mixed.open = !mixed.open
-            })
+        openSlots.addEventListener('click', () => {
+            slots.open = !slots.open
+        })
+        slots.addEventListener('ruxdialogopened', () =>
+            console.log('heard ruxdialogopened')
+        )
+        slots.addEventListener('ruxdialogclosed', () =>
+            console.log('heard ruxdialogclosed')
+        )
 
-            //Focus the confirm button on mixed modal
+        const mixed = document.getElementById('mix')
+        const openMixed = document.getElementById('openmix')
+        openMixed.addEventListener('click', () => {
+            mixed.open = !mixed.open
+        })
 
-            const confirmBtn = document.getElementById('confirm')
-            mixed.addEventListener('ruxmodalopened', () => {
-                const shadowBtn = confirmBtn.shadowRoot.querySelector('button')
-                setTimeout(() => shadowBtn.focus())
-            })
+        //Focus the confirm button on mixed modal
 
-            const dyn = document.getElementById('dyn')
-            const changeModal = document.getElementById('change')
+        const confirmBtn = document.getElementById('confirm')
+        mixed.addEventListener('ruxdialogopened', () => {
+            const shadowBtn = confirmBtn.shadowRoot.querySelector('button')
+            setTimeout(() => shadowBtn.focus())
+        })
 
-            const newFooter = document.createElement('span')
-            const newMessage = document.createElement('span')
+        const dyn = document.getElementById('dyn')
+        const changeModal = document.getElementById('change')
 
-            newFooter.innerHTML = 'Slot Footer'
-            newFooter.slot = 'footer'
-            newMessage.innerHTML = 'Slot Message'
-            newMessage.classList.add('test')
+        const newFooter = document.createElement('span')
+        const newMessage = document.createElement('span')
 
-            dyn.addEventListener('click', () => {
-                changeModal.open = true
-            })
-            changeModal.addEventListener('ruxmodalopened', () => {
-                setTimeout(() => {
-                    changeModal.append(newFooter)
-                    changeModal.append(newMessage)
-                    //The assertion in the e2e test will timeout after 4000 ms of not finding the appended stuff
-                }, 500)
-            })
-        </script>
-    </body>
+        newFooter.innerHTML = 'Slot Footer'
+        newFooter.slot = 'footer'
+        newMessage.innerHTML = 'Slot Message'
+        newMessage.classList.add('test')
+
+        dyn.addEventListener('click', () => {
+            changeModal.open = true
+        })
+        changeModal.addEventListener('ruxdialogopened', () => {
+            setTimeout(() => {
+                console.log('heard')
+                changeModal.append(newFooter)
+                changeModal.append(newMessage)
+                //The assertion in the e2e test will timeout after 4000 ms of not finding the appended stuff
+            }, 500)
+        })
+    </script>
+</body>
+
 </html>

--- a/packages/web-components/src/components/rux-dialog/test/rux-dialog.e2e.js
+++ b/packages/web-components/src/components/rux-dialog/test/rux-dialog.e2e.js
@@ -1,46 +1,49 @@
-describe('Modal', () => {
+describe('dialog', () => {
     beforeEach(() => {
-        cy.visitComponent('rux-modal')
+        cy.visitComponent('rux-dialog')
     })
     it('renders', () => {
-        cy.get('rux-modal').should('have.class', 'hydrated')
+        cy.get('rux-dialog').should('have.class', 'hydrated')
     })
 
-    it('should close and open the modal', () => {
-        cy.get('rux-modal').then(($modal) => {
-            $modal[0].setAttribute('open', false)
+    it('should close and open the dialog', () => {
+        cy.get('rux-dialog').then(($dialog) => {
+            $dialog[0].setAttribute('open', false)
         })
-        cy.get('rux-modal').then(($modal) => {
-            $modal[0].setAttribute('open', true)
+        cy.get('rux-dialog').then(($dialog) => {
+            $dialog[0].setAttribute('open', true)
         })
-        cy.get('rux-modal').shadow().find('.rux-modal__wrapper').should('exist')
-    })
-
-    it('should display new modal title in the dialog when changed', () => {
-        cy.get('rux-modal').then(($modal) => {
-            $modal[0].setAttribute('modal-title', 'This is a test title')
-        })
-        cy.get('rux-modal')
+        cy.get('rux-dialog')
             .shadow()
-            .find('.rux-modal__header')
+            .find('.rux-dialog__wrapper')
+            .should('exist')
+    })
+
+    it('should display new dialog title in the dialog when changed', () => {
+        cy.get('rux-dialog').then(($dialog) => {
+            $dialog[0].setAttribute('modal-title', 'This is a test title')
+        })
+        cy.get('rux-dialog')
+            .shadow()
+            .find('.rux-dialog__header')
             .contains('This is a test title')
     })
 
-    it('should display new modal message in the dialog when changed', () => {
-        cy.get('rux-modal').then(($modal) => {
-            $modal[0].setAttribute('modal-message', 'This is a test message')
+    it('should display new dialog message in the dialog when changed', () => {
+        cy.get('rux-dialog').then(($dialog) => {
+            $dialog[0].setAttribute('modal-message', 'This is a test message')
         })
-        cy.get('rux-modal')
+        cy.get('rux-dialog')
             .shadow()
-            .find('.rux-modal__message')
+            .find('.rux-dialog__message')
             .contains('This is a test message')
     })
 
     it('should display new confirmation text in the dialog when changed', () => {
-        cy.get('rux-modal').then(($modal) => {
-            $modal[0].setAttribute('confirm-text', 'Test Confirm Text')
+        cy.get('rux-dialog').then(($dialog) => {
+            $dialog[0].setAttribute('confirm-text', 'Test Confirm Text')
         })
-        cy.get('rux-modal')
+        cy.get('rux-dialog')
             .shadow()
             .find('rux-button-group')
             .find('rux-button')
@@ -49,10 +52,10 @@ describe('Modal', () => {
     })
 
     it('should display new deny text in the dialog when changed', () => {
-        cy.get('rux-modal').then(($modal) => {
-            $modal[0].setAttribute('deny-text', 'Test Deny Text')
+        cy.get('rux-dialog').then(($dialog) => {
+            $dialog[0].setAttribute('deny-text', 'Test Deny Text')
         })
-        cy.get('rux-modal')
+        cy.get('rux-dialog')
             .shadow()
             .find('rux-button-group')
             .find('rux-button')
@@ -60,103 +63,120 @@ describe('Modal', () => {
             .contains('Test Deny Text')
     })
 
-    it('should close the modal when deny clicked', () => {
-        cy.get('rux-modal')
+    it('should close the dialog when deny clicked', () => {
+        cy.get('rux-dialog')
             .shadow()
             .find('rux-button-group')
             .find('rux-button')
             .first()
             .click()
-        cy.get('rux-modal')
+        cy.get('rux-dialog')
             .shadow()
-            .find('.rux-modal__wrapper')
+            .find('.rux-dialog__wrapper')
             .should('not.exist')
     })
 
-    it('should close the modal when confirm clicked', () => {
-        cy.get('rux-modal')
+    it('should close the dialog when confirm clicked', () => {
+        cy.get('rux-dialog')
             .shadow()
             .find('rux-button-group')
             .find('rux-button')
             .next()
             .click()
-        cy.get('rux-modal')
+        cy.get('rux-dialog')
             .shadow()
-            .find('.rux-modal__wrapper')
+            .find('.rux-dialog__wrapper')
             .should('not.exist')
     })
 
     it('should close when enter key pressed', () => {
-        cy.get('rux-modal').shadow().find('dialog').click()
+        cy.get('rux-dialog').shadow().find('dialog').click()
         cy.get('body').type('{enter}')
-        cy.get('rux-modal')
+        cy.get('rux-dialog')
             .shadow()
-            .find('.rux-modal__wrapper')
+            .find('.rux-dialog__wrapper')
             .should('not.exist')
     })
 
-    it('should close the modal when click occurs outside modal', () => {
-        cy.get('rux-modal')
+    it('should close the dialog when click occurs outside dialog', () => {
+        cy.get('rux-dialog')
             .shadow()
-            .find('.rux-modal__wrapper')
+            .find('.rux-dialog__wrapper')
             .click('topLeft')
-        cy.get('rux-modal')
+        cy.get('rux-dialog')
             .shadow()
-            .find('.rux-modal__wrapper')
+            .find('.rux-dialog__wrapper')
             .should('not.exist')
     })
     it('should be able to dynamically add slots', () => {
-        cy.get('rux-modal').then(($modal) => {
-            $modal[0].setAttribute('open', false)
+        cy.get('rux-dialog').then(($dialog) => {
+            $dialog[0].setAttribute('open', false)
         })
         cy.get('#dyn').click()
         cy.get('#change').find('.test')
         cy.get('#change')
             .shadow()
-            .find('.rux-modal__wrapper')
+            .find('.rux-dialog__wrapper')
             .find('dialog')
-            .find('.rux-modal__footer')
+            .find('.rux-dialog__footer')
             .children()
             .should('have.length', '1')
     })
-    it('should emit ruxmodalclosed with a detail of false when default deny button is clicked', () => {
-        cy.get('rux-modal').then(($modal) => {
-            $modal[0].setAttribute('open', true)
+    it('should emit ruxdialogclosed with a detail of false when default deny button is clicked', () => {
+        cy.get('rux-dialog').then(($dialog) => {
+            $dialog[0].setAttribute('open', true)
         })
         cy.document().invoke(
             'addEventListener',
-            'ruxmodalclosed',
-            cy.stub().as('ruxmodalclosed')
+            'ruxdialogclosed',
+            cy.stub().as('ruxdialogclosed')
         )
-        cy.get('rux-modal')
+        cy.get('rux-dialog')
             .shadow()
             .find('rux-button-group')
             .find('rux-button')
             .first()
             .click()
-        cy.get('@ruxmodalclosed')
+        cy.get('@ruxdialogclosed')
             .should('have.been.calledOnce')
             .its('firstCall.args.0.detail')
             .should('deep.equal', false)
     })
-    it('should emit ruxmodalclosed with a detail of true when default confirm button is clicked', () => {
-        cy.get('rux-modal').then(($modal) => {
-            $modal[0].setAttribute('open', true)
+    it('should emit ruxdialogclosed with a detail of true when default confirm button is clicked', () => {
+        cy.get('rux-dialog').then(($dialog) => {
+            $dialog[0].setAttribute('open', true)
         })
         cy.document().invoke(
             'addEventListener',
-            'ruxmodalclosed',
-            cy.stub().as('ruxmodalclosed')
+            'ruxdialogclosed',
+            cy.stub().as('ruxdialogclosed')
         )
-        cy.get('rux-modal')
+        cy.get('rux-dialog')
             .shadow()
             .find('rux-button-group')
             .find('rux-button')
             .next()
             .click()
-        cy.get('@ruxmodalclosed')
+        cy.get('@ruxdialogclosed')
             .should('have.been.calledOnce')
             .its('firstCall.args.0.detail')
             .should('deep.equal', true)
     })
+    // Cypress doesn't support a generic keyboard press. Can only use .type() in inputs and such.
+    // it('should be able to trigger the deny button on escape key press', () => {
+    //     cy.get('rux-dialog').then(($dialog) => {
+    //         $dialog[0].setAttribute('open', true)
+    //     })
+    //     cy.document().invoke(
+    //         'addEventListener',
+    //         'ruxdialogclosed',
+    //         cy.stub().as('ruxdialogclosed')
+    //     )
+    //     cy.get('rux-dialog').first().type('{esc}', { force: true })
+    //     cy.get('@ruxdialogclosed')
+    //         .should('have.been.calledOnce')
+    //         .its('first')
+    //         .its('firstCall.args.0.detail')
+    //         .should('deep.equal', false)
+    // })
 })

--- a/packages/web-components/src/components/rux-modal/rux-modal.tsx
+++ b/packages/web-components/src/components/rux-modal/rux-modal.tsx
@@ -83,10 +83,27 @@ export class RuxModal {
     // confirm dialog if Enter key is pressed
     @Listen('keydown', { target: 'window' })
     handleKeyDown(ev: KeyboardEvent) {
-        if (ev.key === 'Enter') {
-            const button = this._getDefaultButton()
-            if (button) {
-                button.click()
+        if (this.open) {
+            const btns: NodeListOf<HTMLRuxButtonElement> = this.element.shadowRoot!.querySelectorAll(
+                'rux-button'
+            )
+            if (ev.key === 'Enter') {
+                //If enter is hit but the cancel/deny button is focused, we want to click that instead.
+                let activeEl: any = this.element.shadowRoot?.activeElement
+                if (activeEl && activeEl === btns[0]) {
+                    this._userInput = false
+                    btns[0].click()
+                } else {
+                    const button = this._getDefaultButton()
+                    if (button) {
+                        this._userInput = true
+                        button.click()
+                    }
+                }
+            }
+            if (ev.key === 'Escape') {
+                this._userInput = false
+                btns[0].click()
             }
         }
     }
@@ -243,7 +260,7 @@ export class RuxModal {
                                                 onClick={_handleModalChoice}
                                                 data-value="false"
                                                 hidden={!denyText}
-                                                tabindex="-1"
+                                                tabindex="0"
                                                 exportparts="container:deny-button"
                                             >
                                                 {denyText}
@@ -252,7 +269,7 @@ export class RuxModal {
                                                 onClick={_handleModalChoice}
                                                 hidden={!confirmText}
                                                 data-value="true"
-                                                tabindex="0"
+                                                tabindex="1"
                                                 exportparts="container:confirm-button"
                                             >
                                                 {confirmText}

--- a/packages/web-components/src/components/rux-modal/rux-modal.tsx
+++ b/packages/web-components/src/components/rux-modal/rux-modal.tsx
@@ -83,7 +83,8 @@ export class RuxModal {
     // confirm dialog if Enter key is pressed
     @Listen('keydown', { target: 'window' })
     handleKeyDown(ev: KeyboardEvent) {
-        if (this.open) {
+        // prevent this from running if the slots version is being used
+        if (this.open && !this.hasFooter) {
             const btns: NodeListOf<HTMLRuxButtonElement> = this.element.shadowRoot!.querySelectorAll(
                 'rux-button'
             )

--- a/packages/web-components/src/stories/dialog.stories.mdx
+++ b/packages/web-components/src/stories/dialog.stories.mdx
@@ -101,6 +101,11 @@ export const WithSlots = (args) => {
     </Story>
 </Canvas>
 
+## Keyboard Interactions
+
+Using the default (non-slot version) footer of rux-dialog supports tabbing between the deny and confirm buttons, as well as 
+hitting Enter for confrim and Escape for deny.
+
 ## Opening, Closing and Focusing with Slots
 
 Using slots in the Dialog allows for near complete customization of the component, but also requires a bit more


### PR DESCRIPTION
## Brief Description

Adds tabindex's to the default (prop version) of the dialog footer. 
Adds the ability to trigger the deny button on an escape key press.
Added a section to dialog's SB page about keyboard interactions.

Added a commented out test - cypress does not allow for a keyboard press if it's not a form element. We will be switching these to playwright soon anyway.
Dialogs tests were still using modals - I changed that to be dialogs.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4456

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/675
## General Notes

I've thought up a way to provide this keyboard functionality to folks using slots for the footer too, but it will need some more testing and is beyond the scope of this ticket. 
I've also added these changes to rux-modal

## Motivation and Context

GitHub issue - provides better keyboard accessibility to dialog. 

## Issues and Limitations

This does not add keyboard interactions by default to slot versions of dialog - that is on the external dev to add as of right now. A version with that functionality is in the works but is not ready yet.

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
