### PR TITLE
Km 3856 popup component spacing

### DIFF
--- a/.changeset/good-emus-confess.md
+++ b/.changeset/good-emus-confess.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+rux-pop-up-menu add design spacing tokens

--- a/packages/web-components/src/components/rux-menu-item/rux-menu-item.scss
+++ b/packages/web-components/src/components/rux-menu-item/rux-menu-item.scss
@@ -29,10 +29,15 @@
 .rux-menu-item {
     position: relative;
     padding: var(--spacing-2); //8
-    color: var(--color-interactive-default);
+    color: var(--color-text-interactive-default);
+    font-family: var(--font-control-body-1-font-family);
+    font-size: var(--font-control-body-1-font-size);
+    font-weight: var(--font-control-body-1-font-weight);
+    line-height: var(--font-control-body-1-line-height);
+    letter-spacing: var(--font-control-body-1-letter-spacing);
     cursor: pointer;
     &:hover {
-        color: var(--color-interactive-hover);
+        color: var(--color-text-interactive-hover);
         background: var(--color-background-base-hover);
     }
     &--selected {

--- a/packages/web-components/src/components/rux-menu-item/rux-menu-item.scss
+++ b/packages/web-components/src/components/rux-menu-item/rux-menu-item.scss
@@ -28,7 +28,7 @@
 
 .rux-menu-item {
     position: relative;
-    padding: 6px 8px;
+    padding: var(--spacing-2); //8
     color: var(--color-interactive-default);
     cursor: pointer;
     &:hover {

--- a/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.scss
+++ b/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.scss
@@ -17,7 +17,7 @@
 
 .rux-popup__content {
     position: absolute;
-    padding: var(--spacing-1); //8
+    padding: var(--spacing-0); //no spacing, slotted content handles padding
     border-radius: var(--radius-base);
     background: var(--color-background-base-default);
     border: 1px solid var(--color-border-interactive-muted);

--- a/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.scss
+++ b/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.scss
@@ -11,10 +11,14 @@
     display: none !important;
 }
 
+::slotted(*[slot='trigger']) {
+    cursor: pointer;
+}
+
 .rux-popup__content {
     position: absolute;
-    color: white;
-    padding: 12px;
+    color: var(--color-text-white);
+    padding: var(--spacing-3);
     border-radius: var(--radius-base);
     background: var(--color-background-base-default);
     border: 1px solid var(--color-border-interactive-muted);
@@ -44,8 +48,8 @@
 
 .rux-popup-arrow {
     position: absolute;
-    background: #2b659b;
-    width: 17px;
-    height: 17px;
+    background: var(--color-border-interactive-muted);
+    width: var(--spacing-4); //16
+    height: var(--spacing-4); //16
     transform: translateZ(-1px) rotate(45deg);
 }

--- a/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.scss
+++ b/packages/web-components/src/components/rux-pop-up-menu/rux-pop-up-menu.scss
@@ -17,8 +17,7 @@
 
 .rux-popup__content {
     position: absolute;
-    color: var(--color-text-white);
-    padding: var(--spacing-3);
+    padding: var(--spacing-1); //8
     border-radius: var(--radius-base);
     background: var(--color-background-base-default);
     border: 1px solid var(--color-border-interactive-muted);

--- a/packages/web-components/src/components/rux-pop-up-menu/test/index.html
+++ b/packages/web-components/src/components/rux-pop-up-menu/test/index.html
@@ -217,7 +217,7 @@
                             icon="menu"
                             slot="trigger"
                         ></rux-icon>
-                        <rux-switch label="Aliquam in lorem"></rux-switch>
+                        <rux-switch label="Aliquam in lorem" style="padding:8px 4px;"></rux-switch>
                     </rux-pop-up-menu>
                 </div>
             </ftl-holster>

--- a/packages/web-components/src/components/rux-pop-up-menu/test/index.html
+++ b/packages/web-components/src/components/rux-pop-up-menu/test/index.html
@@ -17,6 +17,7 @@
         <script nomodule src="/build/astro-web-components.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
+        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
     </head>
 
     <body>
@@ -186,246 +187,41 @@
                 testDiv.innerText = input1.value + ' ' + input2.value
             })
         </script>
-
+        <!-- <ftl-belt access-token="" file-id="">
         <section>
             <h2>Figma Testing</h2>
-
-            <div style="padding: 5%; display: flex; justify-content: center">
-                <rux-pop-up-menu placement="top-end" id="bottom">
-                    <rux-icon
-                        size="normal"
-                        icon="menu"
-                        slot="trigger"
-                    ></rux-icon>
-                    <rux-menu>
-                        <rux-menu-item value="1" selected
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="2"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="3"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                    </rux-menu>
-                </rux-pop-up-menu>
-            </div>
-
-            <div style="padding: 5%; display: flex; justify-content: center">
-                <rux-pop-up-menu placement="top" id="bottom">
-                    <rux-icon
-                        size="normal"
-                        icon="menu"
-                        slot="trigger"
-                    ></rux-icon>
-                    <rux-menu>
-                        <rux-menu-item value="1" selected
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="2"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="3"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                    </rux-menu>
-                </rux-pop-up-menu>
-            </div>
-
-            <div style="padding: 5%; display: flex; justify-content: center">
-                <rux-pop-up-menu placement="top-start" id="bottom">
-                    <rux-icon
-                        size="normal"
-                        icon="menu"
-                        slot="trigger"
-                    ></rux-icon>
-                    <rux-menu>
-                        <rux-menu-item value="1" selected
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="2"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="3"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                    </rux-menu>
-                </rux-pop-up-menu>
-            </div>
-
-            <div style="padding: 5%; display: flex; justify-content: center">
-                <rux-pop-up-menu placement="bottom-end" id="bottom">
-                    <rux-icon
-                        size="normal"
-                        icon="menu"
-                        slot="trigger"
-                    ></rux-icon>
-                    <rux-menu>
-                        <rux-menu-item value="1" selected
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="2"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="3"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                    </rux-menu>
-                </rux-pop-up-menu>
-            </div>
-
-            <div style="padding: 5%; display: flex; justify-content: center">
-                <rux-pop-up-menu placement="bottom" id="bottom">
-                    <rux-icon
-                        size="normal"
-                        icon="menu"
-                        slot="trigger"
-                    ></rux-icon>
-                    <p style="width: 300px; max-width: 100%; display: block">
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                        Sed at mi elementum, scelerisque tortor vitae, suscipit
-                        odio. Sed finibus dui nunc, eget posuere ipsum volutpat
-                        ac. Curabitur sit amet nibh mi. Sed sit amet eleifend
-                        dolor. Cras vitae orci neque. Ut mollis ante est, id
-                        hendrerit elit lacinia in. Quisque scelerisque ex at
-                        neque dignissim finibus. Pellentesque augue erat,
-                        ullamcorper sed laoreet ut, fringilla a metus. Ut tempor
-                        porttitor diam a bibendum. Pellentesque nulla nibh,
-                        vehicula fringilla tortor eget, consequat blandit ante.
-                        Integer ac sagittis risus. Sed vestibulum nisl sit amet
-                        tellus tempus lobortis. In convallis orci a magna
-                        posuere, at rutrum ipsum mattis. Etiam tempus aliquet
-                        felis, ac pulvinar urna elementum sit amet. Curabitur et
-                        ex lectus.
-                    </p>
-                </rux-pop-up-menu>
-            </div>
-
-            <div style="padding: 5%; display: flex; justify-content: center">
-                <rux-pop-up-menu placement="bottom-start" id="bottom">
-                    <rux-icon
-                        size="normal"
-                        icon="menu"
-                        slot="trigger"
-                    ></rux-icon>
-                    <rux-menu>
-                        <rux-menu-item value="1" selected
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="2"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="3"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                    </rux-menu>
-                </rux-pop-up-menu>
-            </div>
-
-            <div style="padding: 5%; display: flex; justify-content: center">
-                <rux-pop-up-menu placement="right-end" id="bottom">
-                    <rux-icon
-                        size="normal"
-                        icon="menu"
-                        slot="trigger"
-                    ></rux-icon>
-                    <rux-menu>
-                        <rux-menu-item value="1" selected
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="2"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="3"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                    </rux-menu>
-                </rux-pop-up-menu>
-            </div>
-
-            <div style="padding: 5%; display: flex; justify-content: center">
-                <rux-pop-up-menu placement="right" id="bottom">
-                    <rux-icon
-                        size="normal"
-                        icon="menu"
-                        slot="trigger"
-                    ></rux-icon>
-                    <rux-switch label="switching it up!"></rux-switch>
-                </rux-pop-up-menu>
-            </div>
-
-            <div style="padding: 5%; display: flex; justify-content: center">
-                <rux-pop-up-menu placement="right-start" id="bottom">
-                    <rux-icon
-                        size="normal"
-                        icon="menu"
-                        slot="trigger"
-                    ></rux-icon>
-                    <rux-slider min="0" max="100" value="50"></rux-slider>
-                </rux-pop-up-menu>
-            </div>
-            <div style="padding: 5%; display: flex; justify-content: center">
-                <rux-pop-up-menu placement="left-end" id="bottom">
-                    <rux-icon
-                        size="normal"
-                        icon="menu"
-                        slot="trigger"
-                    ></rux-icon>
-                    <rux-menu>
-                        <rux-menu-item value="1" selected
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="2"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="3"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                    </rux-menu>
-                </rux-pop-up-menu>
-            </div>
-
-            <div style="padding: 5%; display: flex; justify-content: center">
-                <rux-pop-up-menu placement="left" id="bottom">
-                    <rux-icon
-                        size="normal"
-                        icon="menu"
-                        slot="trigger"
-                    ></rux-icon>
-                    <rux-menu>
-                        <rux-menu-item value="1" selected
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="2"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="3"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                    </rux-menu>
-                </rux-pop-up-menu>
-            </div>
-
-            <div style="padding: 5%; display: flex; justify-content: center">
-                <rux-pop-up-menu placement="left-start" id="bottom">
-                    <rux-icon
-                        size="normal"
-                        icon="menu"
-                        slot="trigger"
-                    ></rux-icon>
-                    <rux-menu>
-                        <rux-menu-item value="1" selected
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="2"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                        <rux-menu-item value="3"
-                            >Pop up menu option test</rux-menu-item
-                        >
-                    </rux-menu>
-                </rux-pop-up-menu>
-            </div>
+            <ftl-holster name="Bottom Center Menu test" node="42751:130506">
+                <div style="margin-top: -52px; display: flex; justify-content: center">
+                    <rux-pop-up-menu placement="bottom" open>
+                        <rux-icon
+                            size="normal"
+                            icon="menu"
+                            slot="trigger"
+                        ></rux-icon>
+                        <rux-menu style="width:175px;">
+                            <rux-menu-item value="1"
+                                >Menu option</rux-menu-item
+                            >
+                            <rux-menu-item value="2"
+                                >Menu option</rux-menu-item
+                            >
+                        </rux-menu>
+                    </rux-pop-up-menu>
+                </div>
+            </ftl-holster>
+            <ftl-holster name="Top start custom content" node="27047:115928">
+                <div style="margin-top:60px;">
+                    <rux-pop-up-menu placement="top-start" open>
+                        <rux-icon
+                            size="small"
+                            icon="menu"
+                            slot="trigger"
+                        ></rux-icon>
+                        <rux-switch label="Aliquam in lorem"></rux-switch>
+                    </rux-pop-up-menu>
+                </div>
+            </ftl-holster>
         </section>
+    </ftl-belt> -->
     </body>
 </html>

--- a/packages/web-components/src/components/rux-pop-up-menu/test/index.html
+++ b/packages/web-components/src/components/rux-pop-up-menu/test/index.html
@@ -186,5 +186,246 @@
                 testDiv.innerText = input1.value + ' ' + input2.value
             })
         </script>
+
+        <section>
+            <h2>Figma Testing</h2>
+
+            <div style="padding: 5%; display: flex; justify-content: center">
+                <rux-pop-up-menu placement="top-end" id="bottom">
+                    <rux-icon
+                        size="normal"
+                        icon="menu"
+                        slot="trigger"
+                    ></rux-icon>
+                    <rux-menu>
+                        <rux-menu-item value="1" selected
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="2"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="3"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                    </rux-menu>
+                </rux-pop-up-menu>
+            </div>
+
+            <div style="padding: 5%; display: flex; justify-content: center">
+                <rux-pop-up-menu placement="top" id="bottom">
+                    <rux-icon
+                        size="normal"
+                        icon="menu"
+                        slot="trigger"
+                    ></rux-icon>
+                    <rux-menu>
+                        <rux-menu-item value="1" selected
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="2"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="3"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                    </rux-menu>
+                </rux-pop-up-menu>
+            </div>
+
+            <div style="padding: 5%; display: flex; justify-content: center">
+                <rux-pop-up-menu placement="top-start" id="bottom">
+                    <rux-icon
+                        size="normal"
+                        icon="menu"
+                        slot="trigger"
+                    ></rux-icon>
+                    <rux-menu>
+                        <rux-menu-item value="1" selected
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="2"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="3"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                    </rux-menu>
+                </rux-pop-up-menu>
+            </div>
+
+            <div style="padding: 5%; display: flex; justify-content: center">
+                <rux-pop-up-menu placement="bottom-end" id="bottom">
+                    <rux-icon
+                        size="normal"
+                        icon="menu"
+                        slot="trigger"
+                    ></rux-icon>
+                    <rux-menu>
+                        <rux-menu-item value="1" selected
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="2"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="3"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                    </rux-menu>
+                </rux-pop-up-menu>
+            </div>
+
+            <div style="padding: 5%; display: flex; justify-content: center">
+                <rux-pop-up-menu placement="bottom" id="bottom">
+                    <rux-icon
+                        size="normal"
+                        icon="menu"
+                        slot="trigger"
+                    ></rux-icon>
+                    <p style="width: 300px; max-width: 100%; display: block">
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        Sed at mi elementum, scelerisque tortor vitae, suscipit
+                        odio. Sed finibus dui nunc, eget posuere ipsum volutpat
+                        ac. Curabitur sit amet nibh mi. Sed sit amet eleifend
+                        dolor. Cras vitae orci neque. Ut mollis ante est, id
+                        hendrerit elit lacinia in. Quisque scelerisque ex at
+                        neque dignissim finibus. Pellentesque augue erat,
+                        ullamcorper sed laoreet ut, fringilla a metus. Ut tempor
+                        porttitor diam a bibendum. Pellentesque nulla nibh,
+                        vehicula fringilla tortor eget, consequat blandit ante.
+                        Integer ac sagittis risus. Sed vestibulum nisl sit amet
+                        tellus tempus lobortis. In convallis orci a magna
+                        posuere, at rutrum ipsum mattis. Etiam tempus aliquet
+                        felis, ac pulvinar urna elementum sit amet. Curabitur et
+                        ex lectus.
+                    </p>
+                </rux-pop-up-menu>
+            </div>
+
+            <div style="padding: 5%; display: flex; justify-content: center">
+                <rux-pop-up-menu placement="bottom-start" id="bottom">
+                    <rux-icon
+                        size="normal"
+                        icon="menu"
+                        slot="trigger"
+                    ></rux-icon>
+                    <rux-menu>
+                        <rux-menu-item value="1" selected
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="2"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="3"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                    </rux-menu>
+                </rux-pop-up-menu>
+            </div>
+
+            <div style="padding: 5%; display: flex; justify-content: center">
+                <rux-pop-up-menu placement="right-end" id="bottom">
+                    <rux-icon
+                        size="normal"
+                        icon="menu"
+                        slot="trigger"
+                    ></rux-icon>
+                    <rux-menu>
+                        <rux-menu-item value="1" selected
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="2"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="3"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                    </rux-menu>
+                </rux-pop-up-menu>
+            </div>
+
+            <div style="padding: 5%; display: flex; justify-content: center">
+                <rux-pop-up-menu placement="right" id="bottom">
+                    <rux-icon
+                        size="normal"
+                        icon="menu"
+                        slot="trigger"
+                    ></rux-icon>
+                    <rux-switch label="switching it up!"></rux-switch>
+                </rux-pop-up-menu>
+            </div>
+
+            <div style="padding: 5%; display: flex; justify-content: center">
+                <rux-pop-up-menu placement="right-start" id="bottom">
+                    <rux-icon
+                        size="normal"
+                        icon="menu"
+                        slot="trigger"
+                    ></rux-icon>
+                    <rux-slider min="0" max="100" value="50"></rux-slider>
+                </rux-pop-up-menu>
+            </div>
+            <div style="padding: 5%; display: flex; justify-content: center">
+                <rux-pop-up-menu placement="left-end" id="bottom">
+                    <rux-icon
+                        size="normal"
+                        icon="menu"
+                        slot="trigger"
+                    ></rux-icon>
+                    <rux-menu>
+                        <rux-menu-item value="1" selected
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="2"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="3"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                    </rux-menu>
+                </rux-pop-up-menu>
+            </div>
+
+            <div style="padding: 5%; display: flex; justify-content: center">
+                <rux-pop-up-menu placement="left" id="bottom">
+                    <rux-icon
+                        size="normal"
+                        icon="menu"
+                        slot="trigger"
+                    ></rux-icon>
+                    <rux-menu>
+                        <rux-menu-item value="1" selected
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="2"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="3"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                    </rux-menu>
+                </rux-pop-up-menu>
+            </div>
+
+            <div style="padding: 5%; display: flex; justify-content: center">
+                <rux-pop-up-menu placement="left-start" id="bottom">
+                    <rux-icon
+                        size="normal"
+                        icon="menu"
+                        slot="trigger"
+                    ></rux-icon>
+                    <rux-menu>
+                        <rux-menu-item value="1" selected
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="2"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                        <rux-menu-item value="3"
+                            >Pop up menu option test</rux-menu-item
+                        >
+                    </rux-menu>
+                </rux-pop-up-menu>
+            </div>
+        </section>
     </body>
 </html>


### PR DESCRIPTION
## Brief Description

Add design spacing tokens to rux-pop-up-menu and rux-menu-item and align to Astro design specs.

## JIRA Link

[ASTRO-3856](https://rocketcom.atlassian.net/browse/ASTRO-3856)

## Related Issue

## General Notes

## Motivation and Context

Astro spacing initiative!

## Issues and Limitations

No issues, but this was difficult to test in the ftl-holster because of all the moving parts involved. Still, I believe that spacing is aligned to design intentions.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
