### PR TITLE
add spacing tokens adjust/test

### DIFF
--- a/.changeset/mean-wasps-fold.md
+++ b/.changeset/mean-wasps-fold.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+functional-components add spacing tokens to FormFieldMessages and align to astro design

--- a/packages/web-components/src/common/functional-components/FormFieldMessage/FormFieldMessage.tsx
+++ b/packages/web-components/src/common/functional-components/FormFieldMessage/FormFieldMessage.tsx
@@ -31,6 +31,18 @@ const FormFieldMessage = (props: FormFieldMessageInterface, children: any) => {
         (shouldShowErrorText() ? (
             <div class="rux-error-text" part="error-text">
                 {children}
+                <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <path
+                        fill-rule="evenodd"
+                        clip-rule="evenodd"
+                        d="M19.53 21.0001C21.07 21.0001 22.03 19.3301 21.26 18.0001L13.73 4.99005C12.96 3.66005 11.04 3.66005 10.27 4.99005L2.74 18.0001C1.97 19.3301 2.93 21.0001 4.47 21.0001H19.53ZM12 14.0001C11.45 14.0001 11 13.5501 11 13.0001V11.0001C11 10.4501 11.45 10.0001 12 10.0001C12.55 10.0001 13 10.4501 13 11.0001V13.0001C13 13.5501 12.55 14.0001 12 14.0001ZM11 16.0001V18.0001H13V16.0001H11Z"
+                        fill="currentColor"
+                    ></path>
+                </svg>
                 {errorText}
             </div>
         ) : null)

--- a/packages/web-components/src/common/functional-components/FormFieldMessage/form-field-message.scss
+++ b/packages/web-components/src/common/functional-components/FormFieldMessage/form-field-message.scss
@@ -1,26 +1,30 @@
 .rux-help-text {
-    margin-top: 0.625rem;
+    margin-top: var(--spacing-2);
     color: var(--color-text-secondary);
     font-size: var(--font-body-2-font-size);
     font-family: var(--font-body-2-font-family);
     font-weight: var(--font-body-2-font-weight);
     letter-spacing: var(--font-body-2-letter-spacing);
+    line-height: var(--font-body-2-line-height);
 }
 
 .rux-error-text {
-    padding-left: 1.625rem;
-    background-image: url(data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20128%20128%22%3E%0A%20%20%3Cpath%20fill%3D%22%23FF3030%22%20fill-rule%3D%22evenodd%22%20d%3D%22M64.031%205c8.461%200%2068.88%20107.243%2063.648%20114.184-5.232%206.942-120.805%205.477-127.212%200C-5.941%20113.708%2055.57%205%2064.03%205zm3.45%2075.894l1.822-34.893H56.946l1.82%2034.893h8.715zM56.803%2093.108c0%201.929.547%203.423%201.643%204.483%201.095%201.06%202.642%201.589%204.642%201.589%201.953%200%203.477-.542%204.572-1.625%201.095-1.084%201.643-2.566%201.643-4.447%200-1.952-.542-3.452-1.625-4.5-1.084-1.047-2.613-1.571-4.59-1.571-2.047%200-3.607.512-4.678%201.536-1.072%201.023-1.607%202.535-1.607%204.535z%22%2F%3E%0A%3C%2Fsvg%3E);
-    background-repeat: no-repeat;
-    background-size: 1rem;
-    background-position: center left 0rem;
-    text-align: left;
-    width: fit-content;
     -webkit-order: 3;
     order: 3;
-    margin-top: 0.625rem;
+    display: flex;
+    margin-top: var(--spacing-2);
     color: var(--color-text-error);
     font-size: var(--font-body-2-bold-font-size);
     font-family: var(--font-body-2-bold-font-family);
     font-weight: var(--font-body-2-bold-font-weight);
     letter-spacing: var(--font-body-2-bold-letter-spacing);
+    line-height: var(--font-body-2-bold-line-height);
+}
+
+.rux-error-text svg {
+    width: calc(var(--spacing-4) + var(--spacing-1)); //20
+    height: calc(var(--spacing-4) + var(--spacing-1)); //20;
+    color: var(--color-text-error);
+    margin-right: var(--spacing-2); //8
+    cursor: default;
 }

--- a/packages/web-components/src/components/rux-input/rux-input.scss
+++ b/packages/web-components/src/components/rux-input/rux-input.scss
@@ -139,11 +139,11 @@
         }
     }
     .rux-input-label {
-        font-family: var(--font-body-1-font-family);
-        font-size: var(--font-body-1-font-size);
-        font-weight: var(--font-body-1-font-weight);
-        letter-spacing: var(--font-body-1-letter-spacing);
-        margin-bottom: var(--spacing-input-label-top);
+        font-family: var(--font-control-body-1-font-family);
+        font-size: var(--font-control-body-1-font-size);
+        font-weight: var(--font-control-body-1-font-weight);
+        letter-spacing: var(--font-control-body-1-letter-spacing);
+        margin-bottom: var(--spacing-2);
         &__asterisk {
             margin-left: var(--spacing-1);
         }

--- a/packages/web-components/src/components/rux-input/test/index.html
+++ b/packages/web-components/src/components/rux-input/test/index.html
@@ -21,11 +21,64 @@
             }
         </style>
         <link rel="stylesheet" href="/build/astro-web-components.css" />
+        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
     </head>
 
     <body class="dark-theme">
-        <h2>Figma spacing test</h2>
+        <!-- <h2>Figma spacing test</h2>
         <ftl-belt access-token="" file-id="">
+            <style>
+                #ruxInputSizingLEFT::part(help-text), #ruxInputSizingLEFT::part(error-text){
+                    display:flex;
+                    justify-content: right;
+                }
+            </style>
+            
+
+        <ftl-holster name="help and error text" node="995:2547" style="position:relative;">
+            <div style="position: absolute; top: 182px; left: 302px;">
+                <rux-input
+                    id="ruxInputSizing"
+                    name="ruxInput"
+                    value="Input test"
+                    size="medium"
+                    label="medium"
+                    error-text="Error text"
+                    invalid
+                ></rux-input>
+            </div>
+            <div style="position: absolute; top: 182px; left: 30px;">
+                <rux-input
+                    id="ruxInputSizing"
+                    name="ruxInput"
+                    value="Input test"
+                    label="medium"
+                    help-text="Help test"
+                ></rux-input>
+            </div>
+            <div style="position: absolute;top: 272px;left: 30px;width: 212px;">
+                <rux-input
+                    id="ruxInputSizingLEFT"
+                    name="ruxInput"
+                    value="Input test"
+                    label="medium"
+                    help-text="Help test"
+                ></rux-input>
+            </div>
+            <div style="position: absolute;top: 272px;left: 302px;width: 212px;">
+                <rux-input
+                    id="ruxInputSizingLEFT"
+                    name="ruxInput"
+                    value="Input test"
+                    label="medium"
+                    error-text="Error text"
+                    invalid
+                ></rux-input>
+            </div>
+        </ftl-holster>
+
+
+            
             <h3>Password</h3>
             <ftl-holster name="Small" node="26010:126009">
                 <div style="width: 170px">
@@ -204,7 +257,7 @@
 
         <div style="width: 200px">
             <rux-input type="time"></rux-input>
-        </div>
+        </div> -->
 
         <h1>Previous Tests</h1>
         <!--

--- a/packages/web-components/src/components/rux-radio-group/rux-radio-group.scss
+++ b/packages/web-components/src/components/rux-radio-group/rux-radio-group.scss
@@ -30,12 +30,12 @@
 
 .rux-label {
     color: var(--color-text-primary);
-    font-family: var(--font-body-1-font-family);
-    font-size: var(--font-body-1-font-size);
-    font-weight: var(--font-body-1-font-weight);
-    letter-spacing: var(--font-body-1-letter-spacing);
-    line-height: var(--font-body-1-line-height);
-    margin-bottom: var(--spacing-input-label-top);
+    font-family: var(--font-control-body-1-font-family);
+    font-size: var(--font-control-body-1-font-size);
+    font-weight: var(--font-control-body-1-font-weight);
+    letter-spacing: var(--font-control-body-1-letter-spacing);
+    line-height: var(--font-control-body-1-line-height);
+    margin-bottom: var(--spacing-2);
     &__asterisk {
         margin-left: var(--spacing-1);
     }

--- a/packages/web-components/src/components/rux-select/rux-select.scss
+++ b/packages/web-components/src/components/rux-select/rux-select.scss
@@ -65,10 +65,10 @@ label {
     display: inline-block;
     margin-bottom: 10px;
     color: var(--color-text-primary);
-    font-family: var(--font-body-1-font-family);
-    font-size: var(--font-body-1-font-size);
-    font-weight: var(--font-body-1-font-weight);
-    letter-spacing: var(--font-body-1-letter-spacing);
+    font-family: var(--font-control-body-1-font-family);
+    font-size: var(--font-control-body-1-font-size);
+    font-weight: var(--font-control-body-1-font-weight);
+    letter-spacing: var(--font-control-body-1-letter-spacing);
     .rux-label__asterisk {
         margin-left: 4px;
     }
@@ -107,10 +107,10 @@ label {
     border: 1px solid var(--color-border-interactive-muted);
     border-radius: var(--radius-base);
     color: var(--color-background-interactive-default);
-    font-family: var(--font-body-1-font-family);
-    font-size: var(--font-body-1-font-size);
-    font-weight: var(--font-body-1-font-weight);
-    letter-spacing: var(--font-body-1-letter-spacing);
+    font-family: var(--font-control-body-1-font-family);
+    font-size: var(--font-control-body-1-font-size);
+    font-weight: var(--font-control-body-1-font-weight);
+    letter-spacing: var(--font-control-body-1-letter-spacing);
     user-select: none;
 
     &--small {

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -86,10 +86,10 @@
 }
 
 .rux-textarea-label {
-    font-family: var(--font-body-1-font-family);
-    font-size: var(--font-body-1-font-size);
-    font-weight: var(--font-body-1-font-weight);
-    letter-spacing: var(--font-body-1-letter-spacing);
+    font-family: var(--font-control-body-1-font-family);
+    font-size: var(--font-control-body-1-font-size);
+    font-weight: var(--font-control-body-1-font-weight);
+    letter-spacing: var(--font-control-body-1-letter-spacing);
     margin-bottom: var(--spacing-input-label-top);
     &__asterisk {
         margin-left: var(--spacing-1);


### PR DESCRIPTION
## Brief Description

Add spacing tokens to FormFieldMessage and adjust error icon to be up to date with figma icon.

## JIRA Link

[ASTRO-3831](https://rocketcom.atlassian.net/browse/ASTRO-3831)

## Related Issue

## General Notes

I noticed that[ figma](https://www.figma.com/file/3tYLyBkvKYOdUysPk6Fu60/Astro-UXDS-7.0-BETA---Dark-Theme?node-id=261%3A1570) shows the ability for a developer to change the error icon. Right now I don't believe that is possible. Might need to address this.

## Motivation and Context

Part of the astro spacing initiative!

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
