### PR TITLE
Km 3657 tabs styling parts

### DIFF
--- a/.changeset/weak-spoons-compare.md
+++ b/.changeset/weak-spoons-compare.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+rux-tab add shadow part for styling tab colors to replace deprecated custom properties

--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.tsx
@@ -2,8 +2,7 @@ import { Component, Host, h, Prop, Element } from '@stencil/core'
 
 /**
  *
- * @part tab - individual tabs
- * @part selected - the selected tab
+ * @part container - individual tabs
  *
  */
 
@@ -49,7 +48,7 @@ export class RuxTab {
         return (
             <Host onClick={this._clickHandler}>
                 <div
-                    part={this.selected ? 'tab selected' : 'tab'}
+                    part="container"
                     class={{
                         'rux-tab': true,
                         'rux-tab--selected': this.selected,

--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.tsx
@@ -1,5 +1,12 @@
 import { Component, Host, h, Prop, Element } from '@stencil/core'
 
+/**
+ *
+ * @part tab - individual tabs
+ * @part selected - the selected tab
+ *
+ */
+
 @Component({
     tag: 'rux-tab',
     styleUrl: 'rux-tab.scss',
@@ -42,6 +49,7 @@ export class RuxTab {
         return (
             <Host onClick={this._clickHandler}>
                 <div
+                    part={this.selected ? 'tab selected' : 'tab'}
                     class={{
                         'rux-tab': true,
                         'rux-tab--selected': this.selected,

--- a/packages/web-components/src/components/rux-tabs/test/index.html
+++ b/packages/web-components/src/components/rux-tabs/test/index.html
@@ -117,16 +117,16 @@
 
         <h2>Parts Styling Tabs</h2>
         <style>
-            #tabs-spacing-styling rux-tab::part(tab) {
+            #tabs-spacing-styling rux-tab::part(container) {
                 color: red;
                 border: 1px solid greenyellow;
             }
-            #tabs-spacing-styling rux-tab::part(selected) {
+            #tabs-spacing-styling rux-tab[selected]::part(container) {
                 color: black;
                 background: white;
                 border-color: blueviolet;
             }
-            #tabs-spacing-styling rux-tab::part(tab):hover {
+            #tabs-spacing-styling rux-tab::part(container):hover {
                 background: pink;
                 color: darkblue;
             }

--- a/packages/web-components/src/components/rux-tabs/test/index.html
+++ b/packages/web-components/src/components/rux-tabs/test/index.html
@@ -115,7 +115,22 @@
             </rux-tab-panels>
         </div>
 
-        <h2>Small Tabs</h2>
+        <h2>Parts Styling Tabs</h2>
+        <style>
+            #tabs-spacing-styling rux-tab::part(tab) {
+                color: red;
+                border: 1px solid greenyellow;
+            }
+            #tabs-spacing-styling rux-tab::part(selected) {
+                color: black;
+                background: white;
+                border-color: blueviolet;
+            }
+            #tabs-spacing-styling rux-tab::part(tab):hover {
+                background: pink;
+                color: darkblue;
+            }
+        </style>
         <div
             style="
                 display: flex;
@@ -124,12 +139,12 @@
                 padding-left: 20px;
             "
         >
-            <rux-tabs id="tabs-spacing-small" small>
-                <rux-tab id="spacing-small-id-1">Tab small</rux-tab>
-                <rux-tab id="spacing-small-id-2">Tab small</rux-tab>
-                <rux-tab id="spacing-small-id-3">Tab small</rux-tab>
+            <rux-tabs id="tabs-spacing-styling" small>
+                <rux-tab id="spacing-small-id-1">Tab One</rux-tab>
+                <rux-tab id="spacing-small-id-2">Tab Two</rux-tab>
+                <rux-tab id="spacing-small-id-3">Tab Three</rux-tab>
             </rux-tabs>
-            <rux-tab-panels aria-labelledby="tabs-spacing-small">
+            <rux-tab-panels aria-labelledby="tabs-spacing-styling">
                 <rux-tab-panel aria-labelledby="spacing-small-id-1">
                     <div
                         style="


### PR DESCRIPTION
## Brief Description

Added a shadow part to rux-tab in order to facilitate styling text and border colors
(Redid pull request as I accidentally requested to main the first time, sorry!)

## JIRA Link

[ASTRO-3657](https://rocketcom.atlassian.net/browse/ASTRO-3657)

## Related Issue

## General Notes

## Motivation and Context

Some custom css properties were deprecated, so we want to give developers that customizability back via shadow parts.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] This PR ~~adds or removes~~ a Storybook story. - it changes a storybook story
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
