### PR TITLE
implement spacing tokens on rux-button

### DIFF
--- a/.changeset/tricky-coins-clap.md
+++ b/.changeset/tricky-coins-clap.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+rux-button - implementt spacing design tokens and align to Astro design

--- a/packages/web-components/src/components/rux-button-group/rux-button-group.scss
+++ b/packages/web-components/src/components/rux-button-group/rux-button-group.scss
@@ -9,7 +9,7 @@
 .rux-button-group {
     display: flex;
     ::slotted(rux-button:not(:last-child)) {
-        margin-right: 0.625rem;
+        margin-right: var(--spacing-2);
     }
 
     &--left {

--- a/packages/web-components/src/components/rux-button/rux-button.scss
+++ b/packages/web-components/src/components/rux-button/rux-button.scss
@@ -11,19 +11,19 @@
     pointer-events: none;
 }
 .rux-button {
+    border: none;
     display: flex;
     position: relative;
-    margin: 0;
+    margin: var(--spacing-0);
     width: inherit;
-    padding: 0 1rem;
-    height: 2.125rem;
-    min-width: 2.25rem;
+    padding: var(--spacing-2) var(--spacing-4);
     border-radius: var(--radius-base);
     color: var(--color-text-inverse);
-    font-family: var(--font-body-1-font-family);
-    font-size: var(--font-body-1-font-size);
-    font-weight: var(--font-body-1-font-weight);
-    letter-spacing: var(--font-body-1-letter-spacing);
+    font-family: var(--font-control-body-1-font-family);
+    font-size: var(--font-control-body-1-font-size);
+    font-weight: var(--font-control-body-1-font-weight);
+    line-height: var(--font-control-body-1-line-height);
+    letter-spacing: var(--font-control-body-1-letter-spacing);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -33,9 +33,9 @@
 
     rux-icon,
     ::slotted(rux-icon) {
-        height: 1rem;
-        width: 1rem;
-        margin-right: 0.625rem;
+        height: calc(var(--spacing-4) + var(--spacing-1)); //20
+        width: calc(var(--spacing-4) + var(--spacing-1)); //20
+        margin-right: var(--spacing-1); //4
         color: var(--color-text-inverse);
     }
 
@@ -54,7 +54,6 @@
     }
 
     &--default {
-        border: 1px solid transparent;
         background-color: var(--color-background-interactive-default);
         &:hover:not([disabled]) {
             border-color: transparent;
@@ -69,12 +68,14 @@
     &--secondary {
         color: var(--color-background-interactive-default);
         background-color: transparent;
-        border: 1px solid var(--color-background-interactive-default);
+        //use box-shadow instead of border
+        box-shadow: var(--color-border-interactive-default) 0 0 0 1px inset;
 
         &:hover:not([disabled]) {
             color: var(--color-background-interactive-hover);
             background-color: transparent;
-            border-color: var(--color-background-interactive-hover);
+            box-shadow: var(--color-background-interactive-hover) 0 0 0 1px
+                inset;
             rux-icon,
             ::slotted(rux-icon) {
                 color: var(--color-background-interactive-hover);
@@ -82,7 +83,8 @@
         }
 
         &:active:not([disabled]) {
-            border-color: var(--color-background-interactive-default);
+            box-shadow: var(--color-background-interactive-default) 0 0 0 1px
+                inset;
             background-color: transparent;
             color: var(--color-background-interactive-default);
             rux-icon,
@@ -97,7 +99,7 @@
     }
     &--borderless {
         color: var(--color-background-interactive-default);
-        border: none;
+        box-shadow: none;
         background: none;
         &:hover:not([disabled]) {
             color: var(--color-background-interactive-hover);
@@ -121,25 +123,26 @@
     }
 
     &--small {
-        height: 1.625rem;
-        padding: 0 1rem;
-        line-height: 1;
+        padding: var(--spacing-1) var(--spacing-4);
+        &.rux-button--icon-only {
+            padding: var(--spacing-1);
+        }
     }
 
     &--large {
-        height: 2.875rem;
-        min-width: 3rem;
-        padding: 0 1rem;
+        padding: var(--spacing-3) var(--spacing-4);
+        &.rux-button--icon-only {
+            padding: var(--spacing-3);
+        }
     }
 
     &--icon-only {
         font-size: 0;
-        width: 3rem;
+        padding: var(--spacing-2);
     }
 }
 
 .rux-button--icon-only ::slotted(rux-icon),
 .rux-button--icon-only rux-icon {
-    margin-left: -0.625rem;
-    margin-right: -0.625rem;
+    margin: 0;
 }

--- a/packages/web-components/src/components/rux-button/rux-button.tsx
+++ b/packages/web-components/src/components/rux-button/rux-button.tsx
@@ -99,7 +99,7 @@ export class RuxButton {
                 >
                     {icon ? (
                         <rux-icon
-                            size="extra-small"
+                            size="auto"
                             icon={icon}
                             exportparts="icon"
                             color={secondary ? 'primary' : 'dark'}

--- a/packages/web-components/src/components/rux-button/test/index.html
+++ b/packages/web-components/src/components/rux-button/test/index.html
@@ -17,6 +17,7 @@
         <script nomodule src="/build/astro-web-components.esm.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
+        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
     </head>
 
     <body class="dark-theme">
@@ -47,5 +48,120 @@
                 })
             </script>
         </div>
+        <!-- <section>
+            <h2>Figma Testing</h2>
+            <ftl-belt access-token="" file-id="">
+<ftl-holster name="Title only" node="467:993">
+                     <rux-button
+                         name="ruxPushStyling"
+                         id="ruxPushStyling"
+                         value="true"
+                         size="medium"
+                     >Primary button</rux-button>
+                 </ftl-holster>
+                 <ftl-holster name="Title only small" node="467:987">
+                     <rux-button
+                         name="ruxPushStyling"
+                         id="ruxPushStyling"
+                         value="true"
+                         size="small"
+                     >Primary button</rux-button>
+                 </ftl-holster>
+                 <ftl-holster name="Title only large" node="467:999">
+                     <rux-button
+                         name="ruxPushStyling"
+                         id="ruxPushStyling"
+                         value="true"
+                         size="large"
+                         label="Push button"
+                     >Primary button</rux-button>
+                 </ftl-holster>
+                 <ftl-holster name="Title and icon" node="467:995">
+                     <rux-button
+                         name="ruxPushStyling"
+                         id="ruxPushStyling"
+                         value="true"
+                         icon="border-clear"
+                         label="Push button"
+                         size="medium"
+                     >Primary button</rux-button>
+                 </ftl-holster>
+                 <ftl-holster name="Title and icon small" node="467:989">
+                     <rux-button
+                         name="ruxPushStyling"
+                         id="ruxPushStyling"
+                         value="true"
+                         size="small"
+                         icon="border-clear"
+                         secondary
+                     >Primary button</rux-button>
+                 </ftl-holster>
+                 <ftl-holster name="Title and icon large" node="467:1001">
+                     <rux-button
+                         name="ruxPushStyling"
+                         id="ruxPushStyling"
+                         value="true"
+                         size="large"
+                         icon="border-clear"
+                     >Primary button</rux-button>
+                 </ftl-holster>
+                 <ftl-holster name="Icon only" node="467:997">
+                     <rux-button
+                         name="ruxPushStyling"
+                         id="ruxPushStyling"
+                         value="true"
+                         icon="border-clear"
+                         size="medium"
+                         icon-only
+                     >Primary button</rux-button>
+                 </ftl-holster>
+                 <ftl-holster name="Icon only small" node="467:991">
+                     <rux-button
+                         name="ruxPushStyling"
+                         id="ruxPushStyling"
+                         value="true"
+                         icon="border-clear"
+                         size="small"
+                         icon-only
+                     ></rux-button>
+                 </ftl-holster>
+                 <ftl-holster name="Icon only large" node="467:1003">
+                     <rux-button
+                         name="ruxPushStyling"
+                         id="ruxPushStyling"
+                         value="true"
+                         icon="border-clear"
+                         size="large"
+                         icon-only
+                         secondary
+                     ></rux-button>
+                 </ftl-holster>
+
+            </ftl-belt>
+            <rux-button-group h-align="right">
+                <rux-button
+                    name="ruxPushStyling"
+                    id="ruxPushStyling"
+                    value="true"
+                    size="large"
+                >Primary button</rux-button>
+                <rux-button
+                    name="ruxPushStyling"
+                    id="ruxPushStyling"
+                    value="true"
+                    icon="border-clear"
+                    size="large"
+                >Button</rux-button>
+                <rux-button
+                    name="ruxPushStyling"
+                    id="ruxPushStyling"
+                    value="true"
+                    icon="border-clear"
+                    size="large"
+                    icon-only
+                    secondary
+                ></rux-button>
+            </rux-button-group>
+        </section> -->
     </body>
 </html>


### PR DESCRIPTION
## Brief Description

Add spacing tokens to. rux-button and bring in line with Astro design specs, also a tiny change to rux-button-group to add a spacing token there as well.

## JIRA Link

[Astro-4479](https://rocketcom.atlassian.net/browse/ASTRO-4479)

## Related Issue

## General Notes

## Motivation and Context

Part of the Astro design token spacing initiative!

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
