### PR TITLE
Km 4480 segmented button spacing tokens

### DIFF
--- a/.changeset/eighty-falcons-notice.md
+++ b/.changeset/eighty-falcons-notice.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+rux-segemented-button add spacing tokens and align to Astro 7.0 design

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
@@ -26,24 +26,17 @@
 .rux-segmented-button {
     display: inline-flex;
     // Default is small for 6.0 - will update default to be medium in 7.0
-    height: 1.625rem;
-    padding: 0;
-    margin: 0;
+    padding: var(--spacing-0);
+    margin: var(--spacing-0);
     list-style: none;
     border-radius: var(--radius-base);
     background-color: var(--color-background-base-default);
-    &--large {
-        height: 2.875rem;
-    }
-    &--medium {
-        height: 2.125rem;
-    }
 }
 
 .rux-segmented-button__segment {
     width: auto;
-    margin: 0;
-    padding: 0;
+    margin: var(--spacing-0);
+    padding: var(--spacing-0);
 
     //omit the right border on next sibling to avoid double borders
     + .rux-segmented-button__segment {
@@ -62,20 +55,19 @@
     }
 
     label {
-        display: flex;
+        display: inline-flex;
         justify-content: center;
         align-items: center;
         width: auto;
-        height: 1.5625rem;
-        margin: 0;
-        padding: 0 0.75rem;
+        margin: var(--spacing-0);
         border: 1px solid var(--color-background-interactive-default);
         color: var(--color-background-interactive-default);
         background-color: var(--color-background-base-default);
-        font-family: var(--font-body-1-font-family);
-        font-size: var(--font-body-1-font-size);
-        letter-spacing: var(--font-body-1-letter-spacing);
-        font-weight: var(--font-body-1-font-weight);
+        font-family: var(--font-control-body-1-font-family);
+        font-size: var(--font-control-body-1-font-size);
+        letter-spacing: var(--font-control-body-1-letter-spacing);
+        font-weight: var(--font-control-body-1-font-weight);
+        line-height: var(--font-control-body-1-line-height);
         -webkit-user-select: none;
         -moz-user-select: none;
         -ms-user-select: none;
@@ -91,16 +83,16 @@
 
     .rux-segmented-button-label {
         // Defaults to small in 6.0 - will default to medium in 7
-        height: 1.625rem;
-        padding: 0.219rem 1rem; // 16px
+        height: calc(var(--spacing-6) + var(--spacing-1)); //28px
+        padding: var(--spacing-1) var(--spacing-4); // 4px 16px for small
 
         &--large {
-            height: 2.875rem;
-            padding: 0.844rem 1rem; //13.5px 16px
+            height: calc(var(--spacing-10) + var(--spacing-1)); //44px
+            padding: var(--spacing-3) var(--spacing-4); //12px 16px
         }
         &--medium {
-            height: 2.125rem;
-            padding: 0.469rem 1rem; //7.5px 16px
+            height: calc(var(--spacing-8) + var(--spacing-1)); //36px
+            padding: var(--spacing-2) var(--spacing-4); //8px 16px
         }
     }
 

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
@@ -58,7 +58,8 @@
         display: inline-flex;
         justify-content: center;
         align-items: center;
-        width: auto;
+        box-sizing: border-box;
+        width: 100%;
         margin: var(--spacing-0);
         border: 1px solid var(--color-background-interactive-default);
         color: var(--color-background-interactive-default);

--- a/packages/web-components/src/components/rux-segmented-button/test/index.html
+++ b/packages/web-components/src/components/rux-segmented-button/test/index.html
@@ -17,6 +17,7 @@
         <script nomodule src="/build/astro-web-components.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
+        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
     </head>
 
     <body>
@@ -63,28 +64,33 @@
             })
         </script>
 
+        <!-- <ftl-belt access-token="" file-id="">
         <section>
             <h2>Figma testing</h2>
             <div style="padding: 5rem">
-                <rux-segmented-button
-                    id="FigmaTest"
-                    size="small"
-                ></rux-segmented-button
-                ><br /><br />
-                <rux-segmented-button
-                    id="FigmaTest"
-                    size="medium"
-                ></rux-segmented-button
-                ><br /><br />
-                <rux-segmented-button
-                    id="FigmaTest"
-                    size="large"
-                ></rux-segmented-button>
+                <ftl-holster name="Small" node="19977:128342">
+                    <rux-segmented-button
+                        id="FigmaTest"
+                    ></rux-segmented-button>
+                </ftl-holster>
+                <ftl-holster name="Medium" node="19977:128352">
+                    <div><rux-segmented-button
+                        id="FigmaTest"
+                        size="medium"
+                    ></rux-segmented-button></div>
+                </ftl-holster>
+                <ftl-holster name="Large" node="19977:128362">
+                    <rux-segmented-button
+                        id="FigmaTest"
+                        size="large"
+                    ></rux-segmented-button>
+                </ftl-holster>
             </div>
 
             <script>
                 const buttonSets = document.querySelectorAll('#FigmaTest')
                 const options = [
+                    { label: 'Option', selected: true},
                     { label: 'Option' },
                     { label: 'Option' },
                     { label: 'Option' },
@@ -95,5 +101,6 @@
                 }
             </script>
         </section>
+    </ftl-belt> -->
     </body>
 </html>

--- a/packages/web-components/src/components/rux-segmented-button/test/index.html
+++ b/packages/web-components/src/components/rux-segmented-button/test/index.html
@@ -65,6 +65,35 @@
 
         <section>
             <h2>Figma testing</h2>
+            <div style="padding: 5rem">
+                <rux-segmented-button
+                    id="FigmaTest"
+                    size="small"
+                ></rux-segmented-button
+                ><br /><br />
+                <rux-segmented-button
+                    id="FigmaTest"
+                    size="medium"
+                ></rux-segmented-button
+                ><br /><br />
+                <rux-segmented-button
+                    id="FigmaTest"
+                    size="large"
+                ></rux-segmented-button>
+            </div>
+
+            <script>
+                const buttonSets = document.querySelectorAll('#FigmaTest')
+                const options = [
+                    { label: 'Option' },
+                    { label: 'Option' },
+                    { label: 'Option' },
+                ]
+
+                for (let buttonSet of buttonSets) {
+                    buttonSet.data = options
+                }
+            </script>
         </section>
     </body>
 </html>

--- a/packages/web-components/src/components/rux-segmented-button/test/index.html
+++ b/packages/web-components/src/components/rux-segmented-button/test/index.html
@@ -62,5 +62,9 @@
                 console.log('disabled --- heard change')
             })
         </script>
+
+        <section>
+            <h2>Figma testing</h2>
+        </section>
     </body>
 </html>


### PR DESCRIPTION
## Brief Description

Added spacing tokens to rux-segmented-buttons and aligned to Astro design

## JIRA Link

[ASTRO-4480](https://rocketcom.atlassian.net/browse/ASTRO-4480)

## Related Issue

## General Notes

Just a note while I was in there I noticed that there is a comment about defaulting to medium in 7.0 and it does not seem to be implemented yet. I couldn't find a ticket but there might be one.

## Motivation and Context

Part of the astro spacing initiative!

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
