### PR TITLE
Km 2080 add parts to input

### DIFF
--- a/.changeset/many-cycles-cheat.md
+++ b/.changeset/many-cycles-cheat.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+rux-input add part for input-field for styling

--- a/packages/web-components/src/components/rux-input/rux-input.tsx
+++ b/packages/web-components/src/components/rux-input/rux-input.tsx
@@ -24,6 +24,7 @@ let id = 0
  * @part help-text - The help text element
  * @part icon - The icon displayed when toggle-password prop is set
  * @part input - The input element
+ * @part input-field - the styled wrapper around the input element
  * @part label - The input label when `label` prop is set
  * @part required - The asterisk when required is true
  * @part prefix - The container of the prefix slot
@@ -297,6 +298,7 @@ export class RuxInput implements FormFieldInterface {
                     ) : null}
 
                     <div
+                        part="input-field"
                         class={{
                             'rux-input': true,
                             'rux-input--focused': this.hasFocus,

--- a/packages/web-components/src/components/rux-input/test/__snapshots__/rux-input.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-input/test/__snapshots__/rux-input.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`rux-input renders 1`] = `
 <rux-input value="">
   <mock:shadow-root>
     <div class="rux-form-field" part="form-field">
-      <div class="rux-input rux-input--medium">
+      <div class="rux-input rux-input--medium" part="input-field">
         <span class="rux-input-prefix" part="prefix">
           <slot name="prefix"></slot>
         </span>
@@ -30,7 +30,7 @@ exports[`rux-input renders label prop 1`] = `
           </slot>
         </span>
       </label>
-      <div class="rux-input rux-input--medium">
+      <div class="rux-input rux-input--medium" part="input-field">
         <span class="rux-input-prefix" part="prefix">
           <slot name="prefix"></slot>
         </span>
@@ -54,7 +54,7 @@ exports[`rux-input renders label slot 1`] = `
           <slot name="label"></slot>
         </span>
       </label>
-      <div class="rux-input rux-input--medium">
+      <div class="rux-input rux-input--medium" part="input-field">
         <span class="rux-input-prefix" part="prefix">
           <slot name="prefix"></slot>
         </span>
@@ -76,7 +76,7 @@ exports[`rux-input renders rux-icon if type is password 1`] = `
 <rux-input type="password" value="">
   <mock:shadow-root>
     <div class="rux-form-field" part="form-field">
-      <div class="rux-input rux-input--medium">
+      <div class="rux-input rux-input--medium" part="input-field">
         <span class="rux-input-prefix" part="prefix">
           <slot name="prefix"></slot>
         </span>

--- a/packages/web-components/src/components/rux-input/test/index.html
+++ b/packages/web-components/src/components/rux-input/test/index.html
@@ -31,15 +31,25 @@
             }
             #styleTesting::part(input-field){
                 color: green;
-                background-color: white;
+                background-color: lightgrey;
+                box-shadow: 0 0 0 1px yellow;
             }
             #styleTesting::part(input-field):focus-within{
                 box-shadow: 0 0 0 1px orange;
-                background: lightgrey;
+                background: #fff;
+            }
+            #styleTesting::part(icon){
+                color: pink;
+            }
+            #styleTesting rux-icon{
+                color:black;
             }
         </style>
         <div style="width: 500px; margin: 4rem auto;">
-            <rux-input id="styleTesting" name="styleTesting" label="Style Testing" invalid></rux-input>
+            <rux-input id="styleTesting" name="styleTesting" label="Style Testing" type="password">
+                <rux-icon slot="prefix" size="20px" icon="star"></rux-icon>
+                <rux-icon slot="suffix" size="20px" icon="star"></rux-icon>
+            </rux-input>
         </div> -->
         <!-- <h2>Figma spacing test</h2>
         <ftl-belt access-token="" file-id="">

--- a/packages/web-components/src/components/rux-input/test/index.html
+++ b/packages/web-components/src/components/rux-input/test/index.html
@@ -25,6 +25,22 @@
     </head>
 
     <body class="dark-theme">
+        <!-- <style>
+            #styleTesting[invalid]::part(input-field){
+                box-shadow: 0 0 0 1px purple;
+            }
+            #styleTesting::part(input-field){
+                color: green;
+                background-color: white;
+            }
+            #styleTesting::part(input-field):focus-within{
+                box-shadow: 0 0 0 1px orange;
+                background: lightgrey;
+            }
+        </style>
+        <div style="width: 500px; margin: 4rem auto;">
+            <rux-input id="styleTesting" name="styleTesting" label="Style Testing" invalid></rux-input>
+        </div> -->
         <!-- <h2>Figma spacing test</h2>
         <ftl-belt access-token="" file-id="">
             <style>


### PR DESCRIPTION
## Brief Description

Add part: input-field to rux-input to replace css custom styles that were deprecated 

## JIRA Link

[ASTRO-3655](https://rocketcom.atlassian.net/browse/ASTRO-3655)

## Related Issue

## General Notes

Added a part to the element that wraps <input> since that is where most of the styling takes place. In order to style the wrapper on input:focus, a dev must use :focus-within but that pseudo class is well supported and it is clear from the parts descriptions that 'input' and 'input-field' style different parts so it is probably ok. 

## Motivation and Context

Some CSS custom properties were deprecated. This adds the ability to style the input element back to rux-input

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [x] This PR ~~adds or removes~~ changes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
