### PR TITLE
Bk 4225 4492 fix label bugs

### DIFF
--- a/packages/web-components/src/common/functional-components/FormFieldMessage/FormFieldMessage.tsx
+++ b/packages/web-components/src/common/functional-components/FormFieldMessage/FormFieldMessage.tsx
@@ -35,29 +35,6 @@ const FormFieldMessage: FunctionalComponent<FormFieldMessageProps> = (
     }
 
     return null
-
-    // function shouldShowHelpText() {
-    //     return helpText && !errorText
-    // }
-
-    // function shouldShowErrorText() {
-    //     return errorText ? true : false
-    // }
-
-    // return (
-    //     (shouldShowHelpText() ? (
-    //         <div class="rux-help-text" part="help-text">
-    //             {children}
-    //             {helpText}
-    //         </div>
-    //     ) : null) ||
-    //     (shouldShowErrorText() ? (
-    //         <div class="rux-error-text" part="error-text">
-    //             {children}
-    //             {errorText}
-    //         </div>
-    //     ) : null)
-    // )
 }
 
 export default FormFieldMessage

--- a/packages/web-components/src/common/functional-components/FormFieldMessage/FormFieldMessage.tsx
+++ b/packages/web-components/src/common/functional-components/FormFieldMessage/FormFieldMessage.tsx
@@ -1,6 +1,6 @@
-import { h } from '@stencil/core'
+import { FunctionalComponent, h } from '@stencil/core'
 
-export interface FormFieldMessageInterface {
+export interface FormFieldMessageProps {
     helpText?: string
     errorText?: string
 }
@@ -10,31 +10,54 @@ export interface FormFieldMessageInterface {
  * @part help-text - The help text element
  */
 
-const FormFieldMessage = (props: FormFieldMessageInterface, children: any) => {
+const FormFieldMessage: FunctionalComponent<FormFieldMessageProps> = (
+    props,
+    children
+) => {
     const { helpText, errorText } = props
 
-    function shouldShowHelpText() {
-        return helpText && !errorText
-    }
-
-    function shouldShowErrorText() {
-        return errorText ? true : false
-    }
-
-    return (
-        (shouldShowHelpText() ? (
-            <div class="rux-help-text" part="help-text">
-                {children}
-                {helpText}
-            </div>
-        ) : null) ||
-        (shouldShowErrorText() ? (
+    if (errorText) {
+        return (
             <div class="rux-error-text" part="error-text">
                 {children}
                 {errorText}
             </div>
-        ) : null)
-    )
+        )
+    }
+
+    if (helpText) {
+        return (
+            <div class="rux-help-text" part="help-text">
+                {children}
+                {helpText}
+            </div>
+        )
+    }
+
+    return null
+
+    // function shouldShowHelpText() {
+    //     return helpText && !errorText
+    // }
+
+    // function shouldShowErrorText() {
+    //     return errorText ? true : false
+    // }
+
+    // return (
+    //     (shouldShowHelpText() ? (
+    //         <div class="rux-help-text" part="help-text">
+    //             {children}
+    //             {helpText}
+    //         </div>
+    //     ) : null) ||
+    //     (shouldShowErrorText() ? (
+    //         <div class="rux-error-text" part="error-text">
+    //             {children}
+    //             {errorText}
+    //         </div>
+    //     ) : null)
+    // )
 }
 
 export default FormFieldMessage

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -72,10 +72,6 @@ export namespace Components {
          */
         "name": string;
         /**
-          * Sets the checkbox as required
-         */
-        "required": boolean;
-        /**
           * The checkbox value
          */
         "value": string;
@@ -20387,10 +20383,6 @@ declare namespace LocalJSX {
           * Fired when an alteration to the input's value is committed by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
          */
         "onRuxinput"?: (event: CustomEvent<any>) => void;
-        /**
-          * Sets the checkbox as required
-         */
-        "required"?: boolean;
         /**
           * The checkbox value
          */

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
@@ -23,6 +23,7 @@
     --checkbox-hover-border-color: var(--color-background-interactive-hover);
 }
 
+.hidden,
 :host([hidden]) {
     display: none;
 }
@@ -39,102 +40,62 @@
 
 .rux-checkbox {
     display: flex;
-    position: relative;
-    line-height: 1.2;
 
-    &--indeterminate {
-        input[type='checkbox'] + label::after {
-            position: absolute;
-            display: flex;
-            content: '';
-            top: 5px;
-            width: 10px;
-            height: 5px;
-            transform: rotate(0deg);
-            border-right: 0;
-            border-top: 0;
-            border-bottom: 2px solid var(--checkbox-checked-color);
-            left: 4px;
-        }
-    }
-
-    input[type='checkbox'] {
-        -webkit-appearance: none;
+    &__input {
         appearance: none;
+        -webkit-appearance: none;
+        width: 18px;
+        height: 18px;
+        margin: 0 10px 0 0;
 
-        + label {
-            position: relative;
-            display: flex;
-            align-items: center;
-            justify-content: flex-start;
-            color: var(--checkbox-label-color);
-            letter-spacing: 0.5px;
-            cursor: pointer;
-            margin-left: -7px;
-
-            // Box
-            &::before {
-                display: flex;
-                content: '';
-                align-self: start;
-                height: 1.125rem;
-                width: 1.125rem;
-
-                margin: 0 0.625rem 0 0;
-                background-color: var(--checkbox-background-color);
-                border: 1px solid var(--checkbox-border-color);
-                border-radius: var(--radius-checkbox);
-            }
+        &--no-label {
+            margin-right: 0;
         }
 
-        // checked
+        background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' fill='%23101923'/%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' stroke='%232B659B'/%3E%3C/svg%3E");
+
         &:checked {
-            + label {
-                &::after {
-                    position: absolute;
-                    display: flex;
-                    content: '';
-                    top: 5px;
-                    height: 6px;
-                    width: 12px;
-                    left: 3px;
-                    border-right: 2px solid var(--checkbox-checked-color);
-                    border-top: 2px solid var(--checkbox-checked-color);
-                    transform: rotate(125deg);
-                }
-                &::before {
-                    border-color: var(--checkbox-border-color);
-                }
+            background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' fill='%23101923'/%3E%3Crect x='14.8988' y='4.80597' width='12' height='2' transform='rotate(125 14.8988 4.80597)' fill='%234DACFF'/%3E%3Crect x='9.16306' y='12.9975' width='2' height='6' transform='rotate(125 9.16306 12.9975)' fill='%234DACFF'/%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' stroke='%232B659B'/%3E%3C/svg%3E");
+        }
+
+        &:indeterminate {
+            background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' fill='%23101923'/%3E%3Crect x='4' y='8' width='10' height='2' fill='%234DACFF'/%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' stroke='%232B659B'/%3E%3C/svg%3E%0A");
+        }
+
+        &:hover {
+            background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' fill='%23101923'/%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' stroke='%2392CBFF'/%3E%3C/svg%3E%0A");
+
+            &:indeterminate {
+                background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' fill='%23101923'/%3E%3Crect x='4' y='8' width='10' height='2' fill='%234DACFF'/%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' stroke='%2392CBFF'/%3E%3C/svg%3E");
+            }
+
+            &:checked {
+                background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' fill='%23101923'/%3E%3Crect x='14.8988' y='4.80597' width='12' height='2' transform='rotate(125 14.8988 4.80597)' fill='%234DACFF'/%3E%3Crect x='9.16302' y='12.9975' width='2' height='6' transform='rotate(125 9.16302 12.9975)' fill='%234DACFF'/%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' stroke='%2392CBFF'/%3E%3C/svg%3E");
             }
         }
 
         &:disabled {
+            cursor: not-allowed;
+            opacity: var(--disabled-opacity);
+
             + label {
                 cursor: not-allowed;
                 opacity: var(--disabled-opacity);
             }
-        }
-    }
 
-    input[type='checkbox']:not(:disabled):hover {
-        + label {
-            &::before {
-                border-color: var(--checkbox-hover-border-color);
+            &:hover {
+                background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' fill='%23101923'/%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' stroke='%232B659B'/%3E%3C/svg%3E");
+            }
+
+            &:checked {
+                background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' fill='%23101923'/%3E%3Crect x='14.8988' y='4.80597' width='12' height='2' transform='rotate(125 14.8988 4.80597)' fill='%234DACFF'/%3E%3Crect x='9.16302' y='12.9975' width='2' height='6' transform='rotate(125 9.16302 12.9975)' fill='%234DACFF'/%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' stroke='%232B659B'/%3E%3C/svg%3E");
+            }
+
+            &:indeterminate {
+                background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' fill='%23101923'/%3E%3Crect x='4' y='8' width='10' height='2' fill='%234DACFF'/%3E%3Crect x='0.5' y='0.5' width='17' height='17' rx='1.5' stroke='%232B659B'/%3E%3C/svg%3E");
             }
         }
     }
-
-    &--has-text {
-        margin-bottom: 0;
-    }
-
-    + .rux-help-text {
-        margin-bottom: 0.75rem;
-    }
-}
-
-.rux-checkbox-label__asterisk {
-    margin-left: 4px;
 }
 
 .rux-help-text {

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
@@ -23,7 +23,6 @@
     --checkbox-hover-border-color: var(--color-background-interactive-hover);
 }
 
-.hidden,
 :host([hidden]) {
     display: none;
 }
@@ -85,12 +84,6 @@
                 background-color: var(--checkbox-background-color);
                 border: 1px solid var(--checkbox-border-color);
                 border-radius: var(--radius-checkbox);
-            }
-        }
-        //If no label is passed in we don't want the margin
-        + .rux-checkbox--no-label {
-            &::before {
-                margin: 0;
             }
         }
 

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
@@ -84,11 +84,6 @@ export class RuxCheckbox implements FormFieldInterface {
     @Prop({ reflect: true }) disabled: boolean = false
 
     /**
-     * Sets the checkbox as required
-     */
-    @Prop() required: boolean = false
-
-    /**
      * Fired when the value of the input changes - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
      */
     @Event({ eventName: 'ruxchange' }) ruxChange!: EventEmitter

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
@@ -7,12 +7,11 @@ import {
     Element,
     Watch,
     Host,
-    State,
 } from '@stencil/core'
 import FormFieldMessage from '../../common/functional-components/FormFieldMessage/FormFieldMessage'
 
 import { FormFieldInterface } from '../../common/interfaces.module'
-import { renderHiddenInput, hasSlot } from '../../utils/utils'
+import { renderHiddenInput } from '../../utils/utils'
 
 let id = 0
 
@@ -20,7 +19,7 @@ let id = 0
  * @slot (default) - the label of the checkbox.
  * @part form-field - the form field wrapper container
  * @part help-text - The help text element
- * @part label - the label of rux-checkbox
+ * @part label - [DEPRECATED] the label of rux-checkbox
  */
 @Component({
     tag: 'rux-checkbox',
@@ -33,8 +32,6 @@ export class RuxCheckbox implements FormFieldInterface {
 
     @Element() el!: HTMLRuxCheckboxElement
 
-    @State() hasLabelSlot = false
-
     /**
      * The help or explanation text
      */
@@ -44,6 +41,7 @@ export class RuxCheckbox implements FormFieldInterface {
      * The checkbox name
      */
     @Prop() name = ''
+
     /**
      * The checkbox value
      */
@@ -58,6 +56,7 @@ export class RuxCheckbox implements FormFieldInterface {
      * Toggles checked state of a checkbox
      */
     @Prop({ reflect: true, mutable: true }) checked: boolean = false
+
     @Watch('checked')
     updateChecked() {
         if (this._inputEl) {
@@ -69,6 +68,7 @@ export class RuxCheckbox implements FormFieldInterface {
      * Toggles indeterminate state of a checkbox. The indeterminate property does not exist in HTML, but can be set in JS. [HTML Checkbox & Indeterminate State](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate)
      */
     @Prop({ reflect: true, mutable: true }) indeterminate: boolean = false
+
     @Watch('indeterminate')
     updateIndeterminate() {
         if (this._inputEl) {
@@ -95,6 +95,7 @@ export class RuxCheckbox implements FormFieldInterface {
      * Fired when an alteration to the input's value is committed by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
      */
     @Event({ eventName: 'ruxinput' }) ruxInput!: EventEmitter
+
     /**
      * Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)
      */
@@ -103,25 +104,13 @@ export class RuxCheckbox implements FormFieldInterface {
     connectedCallback() {
         this._onClick = this._onClick.bind(this)
         this._onInput = this._onInput.bind(this)
-        this._checkForLabelSlot = this._checkForLabelSlot.bind(this)
     }
 
-    componentWillLoad() {
-        this._checkForLabelSlot()
-    }
     componentDidLoad() {
         if (this._inputEl && this.indeterminate) {
             // indeterminate property does not exist in HTML but is accessible via js
             this._inputEl.indeterminate = true
         }
-    }
-
-    get hasLabel() {
-        return this.label ? true : this.hasLabelSlot
-    }
-
-    private _checkForLabelSlot() {
-        this.hasLabelSlot = hasSlot(this.el)
     }
 
     private _onClick(e: Event): void {
@@ -149,12 +138,10 @@ export class RuxCheckbox implements FormFieldInterface {
             checked,
             disabled,
             helpText,
-            name,
-            value,
             indeterminate,
             label,
-            hasLabel,
-            hasLabelSlot,
+            name,
+            value,
         } = this
 
         if (!this.indeterminate) {
@@ -192,23 +179,8 @@ export class RuxCheckbox implements FormFieldInterface {
                             onBlur={this._onBlur}
                             ref={(el) => (this._inputEl = el)}
                         />
-                        <label
-                            htmlFor={checkboxId}
-                            part="label"
-                            class={{
-                                'rux-checkbox--no-label': !hasLabel,
-                            }}
-                        >
-                            {hasLabelSlot ? null : label}
-                            <span
-                                class={{
-                                    hidden: !hasLabel,
-                                }}
-                            >
-                                <slot
-                                    onSlotchange={this._checkForLabelSlot}
-                                ></slot>
-                            </span>
+                        <label htmlFor={checkboxId} part="label">
+                            <span>{label || <slot />}</span>
                         </label>
                     </div>
                 </div>

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
@@ -19,7 +19,7 @@ let id = 0
  * @slot (default) - the label of the checkbox.
  * @part form-field - the form field wrapper container
  * @part help-text - The help text element
- * @part label - [DEPRECATED] the label of rux-checkbox
+ * @part label - the label of rux-checkbox
  */
 @Component({
     tag: 'rux-checkbox',

--- a/packages/web-components/src/components/rux-checkbox/test/__snapshots__/rux-checkbox.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-checkbox/test/__snapshots__/rux-checkbox.spec.tsx.snap
@@ -5,9 +5,9 @@ exports[`rux-checkbox renders 1`] = `
   <mock:shadow-root>
     <div class="rux-form-field" part="form-field">
       <div class="rux-checkbox">
-        <input id="rux-checkbox-2" type="checkbox" value="">
+        <input class="rux-checkbox__input rux-checkbox__input--no-label" id="rux-checkbox-2" type="checkbox" value="">
         <label htmlfor="rux-checkbox-2" part="label">
-          <span>
+          <span class="hidden">
             <slot></slot>
           </span>
         </label>

--- a/packages/web-components/src/components/rux-checkbox/test/__snapshots__/rux-checkbox.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-checkbox/test/__snapshots__/rux-checkbox.spec.tsx.snap
@@ -6,8 +6,8 @@ exports[`rux-checkbox renders 1`] = `
     <div class="rux-form-field" part="form-field">
       <div class="rux-checkbox">
         <input id="rux-checkbox-2" type="checkbox" value="">
-        <label class="rux-checkbox--no-label" htmlfor="rux-checkbox-2" part="label">
-          <span class="hidden">
+        <label htmlfor="rux-checkbox-2" part="label">
+          <span>
             <slot></slot>
           </span>
         </label>

--- a/packages/web-components/src/components/rux-checkbox/test/index.html
+++ b/packages/web-components/src/components/rux-checkbox/test/index.html
@@ -20,6 +20,30 @@
     </head>
 
     <body class="dark-theme">
+        <div>
+            <rux-checkbox></rux-checkbox>
+            <rux-checkbox></rux-checkbox>
+            <rux-checkbox></rux-checkbox>
+            <rux-checkbox></rux-checkbox>
+            <rux-checkbox></rux-checkbox>
+        </div>
+        <div>
+            <rux-checkbox label="Label Prop"></rux-checkbox>
+            <rux-checkbox>Label Slot</rux-checkbox>
+            <rux-checkbox label="Label Prop">Label Slot wth Prop</rux-checkbox>
+            <rux-checkbox checked>Checked</rux-checkbox>
+            <rux-checkbox indeterminate>Indeterminate</rux-checkbox>
+            <rux-checkbox disabled>Disabled</rux-checkbox>
+            <rux-checkbox checked disabled>Checked Disabled</rux-checkbox>
+            <rux-checkbox indeterminate disabled>
+                Indeterminate Disabled
+            </rux-checkbox>
+            <rux-checkbox required>Required</rux-checkbox>
+        </div>
+        <div>
+            <rux-checkbox help-text="Help Text">With Help Text</rux-checkbox>
+        </div>
+        <button id="add">Add</button>
         <div style="padding: 10%; display: flex; justify-content: center">
             <div style="width: 60%">
                 <form id="form" style="width: 100%">
@@ -90,6 +114,17 @@
                         log.appendChild(item)
                     }
                 }
+            </script>
+
+            <script>
+                add.addEventListener('click', () => {
+                    const els = document.querySelectorAll('rux-checkbox')
+                    els.forEach((el) => {
+                        const div = document.createElement('div')
+                        div.innerText = 'Hey now default slot!'
+                        el.appendChild(div)
+                    })
+                })
             </script>
         </div>
     </body>

--- a/packages/web-components/src/utils/utils.ts
+++ b/packages/web-components/src/utils/utils.ts
@@ -10,7 +10,7 @@ export function hasSlot(el: HTMLElement, name?: string | undefined): boolean {
 
     // Look for a default slot
     return [...el.childNodes].some((node) => {
-        //If node is text and not an empy string return true
+        //If node is text and not an empty string return true
         if (
             node.nodeType === node.TEXT_NODE &&
             node?.textContent?.trim() !== ''
@@ -21,7 +21,10 @@ export function hasSlot(el: HTMLElement, name?: string | undefined): boolean {
         //If node is an element with a slot attribute return true
         if (node.nodeType === node.ELEMENT_NODE) {
             const el = node as HTMLElement
-            if (!el.hasAttribute('slot')) {
+            if (
+                !el.hasAttribute('slot') &&
+                el.getAttribute('type') !== 'hidden'
+            ) {
                 return true
             }
         }

--- a/packages/web-components/src/utils/utils.ts
+++ b/packages/web-components/src/utils/utils.ts
@@ -23,6 +23,10 @@ export function hasSlot(el: HTMLElement, name?: string | undefined): boolean {
             const el = node as HTMLElement
             if (
                 !el.hasAttribute('slot') &&
+                /*
+                 * This condition is specifically for checkbox because
+                 * the hidden input becomes slotted content
+                 */
                 el.getAttribute('type') !== 'hidden'
             ) {
                 return true


### PR DESCRIPTION
## Brief Description

Removed the hasLabelSlot State and refactored the conditional rendering of the label "prop" vs the label "slot". 

Recommending the removal of the label "prop" in v7. Added the "Deprecated" tag in the prop comments. 

Removed dead classes.
 
## JIRA Link

[Ticket 4225](https://rocketcom.atlassian.net/browse/ASTRO-4225)
[Ticket 4492](https://rocketcom.atlassian.net/browse/ASTRO-4492)

## Related Issue

## General Notes

## Motivation and Context

This change eliminates the multiple renders when the checkbox is checked or unchecked causing the hasLabelSlot boolean state to switch back to false when it should be true. This is the root cause of the 2 known bug tickets. 

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
