### PR TITLE
rux-input add 'input-field' part

### DIFF
--- a/.changeset/thick-humans-applaud.md
+++ b/.changeset/thick-humans-applaud.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+rux-input add new part 'input-field' for styling

--- a/packages/web-components/src/components/rux-input/rux-input.tsx
+++ b/packages/web-components/src/components/rux-input/rux-input.tsx
@@ -23,6 +23,7 @@ let id = 0
  * @part form-field - The form-field wrapper container
  * @part help-text - The help text element
  * @part icon - The icon displayed when toggle-password prop is set
+ * @part input-field - the styled wrapper around the input element
  * @part input - The input element
  * @part label - The input label when `label` prop is set
  * @part required - The asterisk when required is true
@@ -297,6 +298,7 @@ export class RuxInput implements FormFieldInterface {
                     ) : null}
 
                     <div
+                        part="input-field"
                         class={{
                             'rux-input': true,
                             'rux-input--focused': this.hasFocus,

--- a/packages/web-components/src/components/rux-input/test/__snapshots__/rux-input.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-input/test/__snapshots__/rux-input.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`rux-input renders 1`] = `
 <rux-input value="">
   <mock:shadow-root>
     <div class="rux-form-field" part="form-field">
-      <div class="rux-input rux-input--medium">
+      <div class="rux-input rux-input--medium" part="input-field">
         <span class="rux-input-prefix" part="prefix">
           <slot name="prefix"></slot>
         </span>
@@ -30,7 +30,7 @@ exports[`rux-input renders label prop 1`] = `
           </slot>
         </span>
       </label>
-      <div class="rux-input rux-input--medium">
+      <div class="rux-input rux-input--medium" part="input-field">
         <span class="rux-input-prefix" part="prefix">
           <slot name="prefix"></slot>
         </span>
@@ -54,7 +54,7 @@ exports[`rux-input renders label slot 1`] = `
           <slot name="label"></slot>
         </span>
       </label>
-      <div class="rux-input rux-input--medium">
+      <div class="rux-input rux-input--medium" part="input-field">
         <span class="rux-input-prefix" part="prefix">
           <slot name="prefix"></slot>
         </span>
@@ -76,7 +76,7 @@ exports[`rux-input renders rux-icon if type is password 1`] = `
 <rux-input type="password" value="">
   <mock:shadow-root>
     <div class="rux-form-field" part="form-field">
-      <div class="rux-input rux-input--medium">
+      <div class="rux-input rux-input--medium" part="input-field">
         <span class="rux-input-prefix" part="prefix">
           <slot name="prefix"></slot>
         </span>


### PR DESCRIPTION
## Brief Description

Rux-input: added an 'input-field' part to the wrapper surrounding <input> so that it can be styled by the developer.

## JIRA Link

[ASTRO-3655](https://rocketcom.atlassian.net/browse/ASTRO-3655)

## Related Issue

## General Notes

I previously made this branch off of next but remade it for main. :)

## Motivation and Context

Adds the ability to style the input more fully since the custom css styles are being deprecated.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [x] This PR ~~adds or removes~~ changes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
