### PR TITLE
rux-segmented-button change default size

### DIFF
--- a/.changeset/slimy-clocks-taste.md
+++ b/.changeset/slimy-clocks-taste.md
@@ -1,9 +1,9 @@
 ---
-"angular-workspace": minor
-"@astrouxds/angular": minor
-"astro-website": minor
-"@astrouxds/react": minor
-"@astrouxds/astro-web-components": minor
+"angular-workspace": major
+"@astrouxds/angular": major
+"astro-website": major
+"@astrouxds/react": major
+"@astrouxds/astro-web-components": major
 ---
 
 WHAT: rux-segmented-button: change default size from small to medium

--- a/.changeset/slimy-clocks-taste.md
+++ b/.changeset/slimy-clocks-taste.md
@@ -1,0 +1,11 @@
+---
+"angular-workspace": minor
+"@astrouxds/angular": minor
+"astro-website": minor
+"@astrouxds/react": minor
+"@astrouxds/astro-web-components": minor
+---
+
+WHAT: rux-segmented-button: change default size from small to medium
+WHY: to align with other Astro inputs/buttons which default to medium
+HOW TO MIGRATTE: Add size="small" to segmented buttons you wish to remain small sized.

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
@@ -25,7 +25,6 @@
 
 .rux-segmented-button {
     display: inline-flex;
-    // Default is small for 6.0 - will update default to be medium in 7.0
     padding: var(--spacing-0);
     margin: var(--spacing-0);
     list-style: none;
@@ -83,17 +82,20 @@
     }
 
     .rux-segmented-button-label {
-        // Defaults to small in 6.0 - will default to medium in 7
-        height: calc(var(--spacing-6) + var(--spacing-1)); //28px
-        padding: var(--spacing-1) var(--spacing-4); // 4px 16px for small
+        &--small {
+            height: calc(var(--spacing-6) + var(--spacing-1)); //28px
+            padding: var(--spacing-1) var(--spacing-4); // 4px 16px for small
+        }
+
+        // Defaults to medium
+        &--medium {
+            height: calc(var(--spacing-8) + var(--spacing-1)); //36px
+            padding: var(--spacing-2) var(--spacing-4); //8px 16px
+        }
 
         &--large {
             height: calc(var(--spacing-10) + var(--spacing-1)); //44px
             padding: var(--spacing-3) var(--spacing-4); //12px 16px
-        }
-        &--medium {
-            height: calc(var(--spacing-8) + var(--spacing-1)); //36px
-            padding: var(--spacing-2) var(--spacing-4); //8px 16px
         }
     }
 

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
@@ -82,15 +82,13 @@
     }
 
     .rux-segmented-button-label {
+        // Defaults to medium
+        height: calc(var(--spacing-8) + var(--spacing-1)); //36px
+        padding: var(--spacing-2) var(--spacing-4); //8px 16px
+
         &--small {
             height: calc(var(--spacing-6) + var(--spacing-1)); //28px
             padding: var(--spacing-1) var(--spacing-4); // 4px 16px for small
-        }
-
-        // Defaults to medium
-        &--medium {
-            height: calc(var(--spacing-8) + var(--spacing-1)); //36px
-            padding: var(--spacing-2) var(--spacing-4); //8px 16px
         }
 
         &--large {

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
@@ -33,7 +33,7 @@ export class RuxSegmentedButton {
     /**
      * Changes size of segmented button from small to medium or large.
      */
-    @Prop({ reflect: true }) size: 'small' | 'medium' | 'large' = 'medium'
+    @Prop({ reflect: true }) size?: 'small' | 'medium' | 'large'
 
     /**
      * Sets the disabled attribute.
@@ -115,7 +115,6 @@ export class RuxSegmentedButton {
                 class={{
                     'rux-segmented-button': true,
                     'rux-segmented-button--small': this.size === 'small',
-                    'rux-segmented-button--medium': this.size === 'medium',
                     'rux-segmented-button--large': this.size === 'large',
                 }}
             >
@@ -138,8 +137,6 @@ export class RuxSegmentedButton {
                                 'rux-segmented-button-label': true,
                                 'rux-segmented-button-label--small':
                                     this.size === 'small',
-                                'rux-segmented-button-label--medium':
-                                    this.size === 'medium',
                                 'rux-segmented-button-label--large':
                                     this.size === 'large',
                             }}

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
@@ -33,7 +33,7 @@ export class RuxSegmentedButton {
     /**
      * Changes size of segmented button from small to medium or large.
      */
-    @Prop({ reflect: true }) size?: 'small' | 'medium' | 'large'
+    @Prop({ reflect: true }) size: 'small' | 'medium' | 'large' = 'medium'
 
     /**
      * Sets the disabled attribute.
@@ -114,6 +114,7 @@ export class RuxSegmentedButton {
             <ul
                 class={{
                     'rux-segmented-button': true,
+                    'rux-segmented-button--small': this.size === 'small',
                     'rux-segmented-button--medium': this.size === 'medium',
                     'rux-segmented-button--large': this.size === 'large',
                 }}
@@ -135,6 +136,8 @@ export class RuxSegmentedButton {
                             part="label"
                             class={{
                                 'rux-segmented-button-label': true,
+                                'rux-segmented-button-label--small':
+                                    this.size === 'small',
                                 'rux-segmented-button-label--medium':
                                     this.size === 'medium',
                                 'rux-segmented-button-label--large':


### PR DESCRIPTION
## Brief Description

Changed the default side of rux-segmented-button to medium.

## JIRA Link

[ASTRO-4503](https://rocketcom.atlassian.net/browse/ASTRO-4503)

## Related Issue

## General Notes

## Motivation and Context

This change brings rux-segmented-button defaults (medium size) inline with other components in 7.0

## Issues and Limitations

I'm not sure if I chose the correct changes here? It IS a breaking change if anyone was not declaring a size and expects the small sizing.. but it didn't seem major. If I should redo the changes let me know.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [x] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
