### PR TITLE
refactor: remove spacing-label local vars in favor of DT

### DIFF
--- a/packages/web-components/src/components/rux-checkbox-group/rux-checkbox-group.scss
+++ b/packages/web-components/src/components/rux-checkbox-group/rux-checkbox-group.scss
@@ -26,7 +26,7 @@
     font-weight: var(--font-body-1-font-weight);
     letter-spacing: var(--font-body-1-letter-spacing);
     line-height: var(--font-body-1-line-height);
-    margin-bottom: var(--spacing-input-label-top);
+    margin-bottom: var(--spacing-2);
     &__asterisk {
         margin-left: 4px;
     }

--- a/packages/web-components/src/components/rux-slider/rux-slider.scss
+++ b/packages/web-components/src/components/rux-slider/rux-slider.scss
@@ -20,7 +20,7 @@
 .rux-form-field {
     flex-direction: column;
     label {
-        margin-bottom: var(--spacing-input-label-top);
+        margin-bottom: var(--spacing-2);
     }
 }
 

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -90,7 +90,7 @@
     font-size: var(--font-control-body-1-font-size);
     font-weight: var(--font-control-body-1-font-weight);
     letter-spacing: var(--font-control-body-1-letter-spacing);
-    margin-bottom: var(--spacing-input-label-top);
+    margin-bottom: var(--spacing-2);
     &__asterisk {
         margin-left: var(--spacing-1);
     }

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -17,12 +17,6 @@
         rgb(77, 172, 255)
     );
     --indeterminate-nub-color: #4dacff;
-    /*
-    Dev only
-    ==========================================================================
-  */
-    --spacing-input-label-top: 0.375rem;
-    --spacing-input-label-left: 0.625rem; //10px;
 }
 
 .light-theme {

--- a/packages/web-components/src/stories/checkbox-group.stories.mdx
+++ b/packages/web-components/src/stories/checkbox-group.stories.mdx
@@ -204,7 +204,7 @@ rux-checkbox-group::part(form-field) {
     align-items: center;
 }
 rux-checkbox-group::part(label) {
-    margin-right: var(--spacing-input-label-left);
+    margin-right: var(--spacing-2);
 }
 ```
 
@@ -216,7 +216,7 @@ export const HorizontalLabel = (args) => {
         flex-direction: row;
     }
     #left-example::part(label) {
-        margin-right: var(--spacing-input-label-left);
+        margin-right: var(--spacing-2);
     }
 </style>
 <rux-checkbox-group id="left-example"

--- a/packages/web-components/src/stories/input.stories.mdx
+++ b/packages/web-components/src/stories/input.stories.mdx
@@ -592,7 +592,7 @@ rux-input::part(form-field) {
     align-items: center;
 }
 rux-input::part(label) {
-    margin-right: var(--spacing-input-label-left);
+    margin-right: var(--spacing-2);
 }
 ```
 
@@ -604,7 +604,7 @@ export const HorizontalLabel = (args) => {
                 align-items: center;
             }
             #left-example::part(label) {
-                margin-right: var(--spacing-input-label-left);
+                margin-right: var(--spacing-2);
                 margin-bottom: 0;
             }
         </style>

--- a/packages/web-components/src/stories/radio-group.stories.mdx
+++ b/packages/web-components/src/stories/radio-group.stories.mdx
@@ -221,7 +221,7 @@ rux-radio-group::part(form-field) {
     align-items: center;
 }
 rux-radio-group::part(label) {
-    margin-right: var(--spacing-input-label-left);
+    margin-right: var(--spacing-2);
 }
 ```
 
@@ -233,7 +233,7 @@ export const HorizontalLabel = (args) => {
         flex-direction: row;
     }
     #left-example::part(label) {
-        margin-right: var(--spacing-input-label-left);
+        margin-right: var(--spacing-2);
     }
 </style>
 <rux-radio-group

--- a/packages/web-components/src/stories/slider.stories.mdx
+++ b/packages/web-components/src/stories/slider.stories.mdx
@@ -237,7 +237,7 @@ rux-slider::part(form-field) {
     align-items: center;
 }
 rux-slider::part(label) {
-    margin-right: var(--spacing-input-label-left);
+    margin-right: var(--spacing-2);
 }
 ```
 
@@ -249,7 +249,7 @@ export const HorizontalLabel = (args) => {
         flex-direction: row;
     }
     #left-example::part(label) {
-        margin-right: var(--spacing-input-label-left);
+        margin-right: var(--spacing-2);
     }
 </style>
 <rux-slider

--- a/packages/web-components/src/stories/textarea.stories.mdx
+++ b/packages/web-components/src/stories/textarea.stories.mdx
@@ -381,7 +381,7 @@ rux-textarea::part(form-field) {
     flex-direction: row;
 }
 rux-textarea::part(label) {
-    margin-right: var(--spacing-input-label-left);
+    margin-right: var(--spacing-2);
 }
 ```
 
@@ -392,7 +392,7 @@ export const HorizontalLabel = (args) => {
         flex-direction: row;
     }
     #left-example::part(label) {
-        margin-right: var(--spacing-input-label-left);
+        margin-right: var(--spacing-2);
     }
 </style>
 <rux-textarea


### PR DESCRIPTION
## Brief Description

* removes the internal `--spacing-input-label-top` and `--spacing-input-label-left` vars in favor of DT. 
* fixes an issue where some form labels werent consistent across components 

```
<div style="display: flex;">
            <rux-input label="one"></rux-input>
            <rux-textarea label="one"></rux-textarea>
            </div>
```
## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
