### PR TITLE
Mj 4519 tab issue

### DIFF
--- a/.changeset/thin-schools-beam.md
+++ b/.changeset/thin-schools-beam.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Fixed an issue where multiple rux-tabs on the same page would hide each others content when selected.

--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.tsx
@@ -25,7 +25,6 @@ export class RuxTab {
 
     connectedCallback() {
         this.el.setAttribute('role', 'tab')
-        this.el.addEventListener('click', this._clickHandler)
 
         //handle small on init
         if (this.el?.parentElement?.getAttributeNode('small')) {

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
@@ -72,6 +72,7 @@ export class RuxTabs {
         e.detail.forEach((panel: HTMLRuxTabPanelElement) => {
             this._panels.push(panel)
         })
+
         // Default to first tab if none are selected
         const selectedTab =
             this._tabs.find((tab) => tab.selected) || this._tabs[0]
@@ -91,14 +92,21 @@ export class RuxTabs {
 
     private _reset() {
         // hide everything
-        this._tabs.forEach((tab) => (tab.selected = false))
-        //* classLIst on rux-tab-panel is an array of strings.
-        this._panels.forEach((panel) => panel.classList.add('hidden'))
+        // Only reset the tabs and panels that are part of this instance of rux-tabs
+        this._tabs.forEach((tab) => {
+            if (tab.parentElement === this.el) tab.selected = false
+        })
+        this._panels.forEach((panel) => {
+            if (
+                panel.parentElement?.getAttribute('aria-labelledby') ===
+                this.el.id
+            )
+                panel.classList.add('hidden')
+        })
     }
 
     private _setTab(selectedTab: HTMLRuxTabElement) {
         this._reset()
-
         // find the panel whose aria-labeldby attribute matches the tab’s id
         const selectedPanel = this._panels.find(
             (panel) =>

--- a/packages/web-components/tests/tabs.spec.ts
+++ b/packages/web-components/tests/tabs.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test'
-import { startTestInBefore, setBodyContent } from './utils/_startTestEnv'
+import {
+    startTestInBefore,
+    setBodyContent,
+    startTestEnv,
+} from './utils/_startTestEnv'
 
 test.describe('Tabs', () => {
     test.beforeEach(async ({ page }) => {
@@ -120,6 +124,121 @@ test.describe('Tabs', () => {
         await expect(ruxTabPanel1).toHaveClass('hydrated hidden')
         await expect(ruxTabPanel2).not.toHaveClass('hydrated hidden')
         await expect(ruxTabPanel3).toHaveClass('hydrated hidden')
+    })
+})
+test.describe('Multiple tabs on same page', () => {
+    test.beforeEach(async ({ page }) => {
+        await startTestInBefore(page)
+
+        await setBodyContent(
+            page,
+            `
+        <div class="mydiv">
+        <rux-tabs id="tab-set-id-1">
+            <rux-tab id="tab-id-1">Top 1 title</rux-tab>
+            <rux-tab id="tab-id-2">Top 2 title</rux-tab>
+            <rux-tab id="tab-id-3">Top 3 title</rux-tab>
+        </rux-tabs>
+
+        <rux-tab-panels aria-labelledby="tab-set-id-1">
+            <rux-tab-panel id="t1content" aria-labelledby="tab-id-1">Top Tab 1 content</rux-tab-panel>
+            <rux-tab-panel id="t2content" aria-labelledby="tab-id-2">Top Tab 2 content</rux-tab-panel>
+            <rux-tab-panel id="t3content" aria-labelledby="tab-id-3">Top Tab 3 content</rux-tab-panel>
+        </rux-tab-panels>
+    </div>
+
+    <div class="mydiv">
+        <rux-tabs id="tab-set-id-2">
+            <rux-tab id="tab-id-11">Middle 1 title</rux-tab>
+            <rux-tab id="tab-id-22">Middle 2 title</rux-tab>
+            <rux-tab id="tab-id-33">Middle 3 title</rux-tab>
+        </rux-tabs>
+
+        <rux-tab-panels aria-labelledby="tab-set-id-2">
+            <rux-tab-panel id="b1content" aria-labelledby="tab-id-11">Middle Tab 1 content</rux-tab-panel>
+            <rux-tab-panel id="b2content" aria-labelledby="tab-id-22">Middle Tab 2 content</rux-tab-panel>
+            <rux-tab-panel id="b3content" aria-labelledby="tab-id-33">Middle Tab 3 content</rux-tab-panel>
+        </rux-tab-panels>
+    </div>
+    <div class="mydiv">
+        <rux-tabs id="tab-set-id-3">
+            <rux-tab id="tab-id-111">Bottom 1 title</rux-tab>
+            <rux-tab id="tab-id-222">Bottom 2 title</rux-tab>
+            <rux-tab id="tab-id-333">Bottom 3 title</rux-tab>
+        </rux-tabs>
+
+        <rux-tab-panels aria-labelledby="tab-set-id-3">
+            <rux-tab-panel id="b1content" aria-labelledby="tab-id-111">Bottom Tab 1 content</rux-tab-panel>
+            <rux-tab-panel id="b2content" aria-labelledby="tab-id-222">Bottom Tab 2 content</rux-tab-panel>
+            <rux-tab-panel id="b3content" aria-labelledby="tab-id-333">Bottom Tab 3 content</rux-tab-panel>
+        </rux-tab-panels>
+    </div>
+        `
+        )
+    })
+
+    test('it should have the first tab of each rux-tabs visible', async ({
+        page,
+    }) => {
+        const topContent = page
+            .locator('rux-tab-panels')
+            .first()
+            .locator('rux-tab-panel')
+            .first()
+        await expect(topContent).toBeVisible()
+        //Should only see the first rux-tab-panel
+        const topContent2 = page
+            .locator('rux-tab-panels')
+            .first()
+            .locator('rux-tab-panel')
+            .nth(1)
+        await expect(topContent2).not.toBeVisible()
+
+        const middleContent = page
+            .locator('rux-tab-panels')
+            .nth(1)
+            .locator('rux-tab-panel')
+            .first()
+        await expect(middleContent).toBeVisible()
+
+        const bottomContent = page
+            .locator('rux-tab-panels')
+            .nth(2)
+            .locator('rux-tab-panel')
+            .first()
+        await expect(bottomContent).toBeVisible()
+    })
+    test('it should not hide other rux-tabs content when a different rux-tab is clicked', async ({
+        page,
+    }) => {
+        const toClick = page
+            .locator('rux-tabs')
+            .first()
+            .locator('rux-tab')
+            .nth(1)
+
+        //This should not be visible until it's tab is clicked.
+        const topContent2 = page
+            .locator('rux-tab-panels')
+            .first()
+            .locator('rux-tab-panel')
+            .nth(1)
+        await expect(topContent2).not.toBeVisible()
+
+        //This should remain visible throughout the test.
+        const bottomContent = page
+            .locator('rux-tab-panels')
+            .nth(2)
+            .locator('rux-tab-panel')
+            .first()
+        await expect(bottomContent).toBeVisible()
+
+        //click the top middle tab
+        await toClick.click()
+
+        //That tab should be visible now, and the other tabs that were visible should still be visible.
+        await expect(topContent2).toBeVisible()
+        await expect(bottomContent).toBeVisible()
     })
 })
 /*


### PR DESCRIPTION
## Brief Description

This adds filtering based on parent element to the `reset()` method on rux-tabs. 
This change allows for multiple rux-tabs to exist on the same page and not hide each others content. 

Here's some code to throw in the `src/index.html` to try it out locally: 
```
    <div class="mydiv">
        <rux-tabs id="tab-set-id-1">
            <rux-tab id="tab-id-1">Top 1 title</rux-tab>
            <rux-tab id="tab-id-2">Top 2 title</rux-tab>
            <rux-tab id="tab-id-3">Top 3 title</rux-tab>
        </rux-tabs>

        <rux-tab-panels aria-labelledby="tab-set-id-1">
            <rux-tab-panel id="t1content" aria-labelledby="tab-id-1">Top Tab 1 content</rux-tab-panel>
            <rux-tab-panel id="t2content" aria-labelledby="tab-id-2">Top Tab 2 content</rux-tab-panel>
            <rux-tab-panel id="t3content" aria-labelledby="tab-id-3">Top Tab 3 content</rux-tab-panel>
        </rux-tab-panels>
    </div>

    <div class="mydiv">
        <rux-tabs id="tab-set-id-2">
            <rux-tab id="tab-id-11">Bottom 1 title</rux-tab>
            <rux-tab id="tab-id-22">Bottom 2 title</rux-tab>
            <rux-tab id="tab-id-33">Bottom 3 title</rux-tab>
        </rux-tabs>

        <rux-tab-panels aria-labelledby="tab-set-id-2">
            <rux-tab-panel id="b1content" aria-labelledby="tab-id-11">Bottom Tab 1 content</rux-tab-panel>
            <rux-tab-panel id="b2content" aria-labelledby="tab-id-22">Bottom Tab 2 content</rux-tab-panel>
            <rux-tab-panel id="b3content" aria-labelledby="tab-id-33">Bottom Tab 3 content</rux-tab-panel>
        </rux-tab-panels>
    </div>
```
Before, if you had two or more rux-tabs on the same page, clicking on a different rux-tabs would hide the already displayed content in another rux-tabs. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4519

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/709
## General Notes
I also removed the ` this.el.addEventListener('click', this._clickHandler)` in rux-tab since it's already adding the onClick event to the `<Host>`. 

## Motivation and Context

Can now use multiple rux-tabs on the same page.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
