### PR TITLE
Mj 4530 click to close

### DIFF
--- a/.changeset/clever-melons-collect.md
+++ b/.changeset/clever-melons-collect.md
@@ -6,4 +6,6 @@
 "@astrouxds/astro-web-components": major
 ---
 
-WHAT: The props of modal-title and modal-message on rux-dialog have been renamed dialog-title and dialog-message. WHY: The was a vestige of the modal to dialog renaming. HOW TO MIGRATE: Change all instances of modal-title or modal-message props to dialog-title and dialog-message.
+WHAT: The props of modal-title and modal-message on rux-dialog have been renamed header and message.
+WHY: Prop names are more accurate and less-verbose now.
+HOW TO MIGRATE: Change all instances of modal-title or modal-message props to header and message.

--- a/.changeset/clever-melons-collect.md
+++ b/.changeset/clever-melons-collect.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": major
+"@astrouxds/angular": major
+"astro-website": major
+"@astrouxds/react": major
+"@astrouxds/astro-web-components": major
+---
+
+WHAT: The props of modal-title and modal-message on rux-dialog have been renamed dialog-title and dialog-message. WHY: The was a vestige of the modal to dialog renaming. HOW TO MIGRATE: Change all instances of modal-title or modal-message props to dialog-title and dialog-message.

--- a/packages/web-components/src/components/rux-dialog/readme.md
+++ b/packages/web-components/src/components/rux-dialog/readme.md
@@ -60,14 +60,14 @@ Or use slots to render the header, content and footer.
 
 ## Properties
 
-| Property        | Attribute        | Description                                 | Type                  | Default     |
-| --------------- | ---------------- | ------------------------------------------- | --------------------- | ----------- |
-| `clickToClose`  | `click-to-close` | Allows dialog to close when clicking off it | `boolean`             | `false`     |
-| `confirmText`   | `confirm-text`   | Text for confirmation button                | `string`              | `'Confirm'` |
-| `denyText`      | `deny-text`      | Text for close button                       | `string`              | `'Cancel'`  |
-| `dialogMessage` | `dialog-message` | Dialog body message                         | `string \| undefined` | `undefined` |
-| `dialogTitle`   | `dialog-title`   | Dialog header title                         | `string \| undefined` | `undefined` |
-| `open`          | `open`           | Shows and hides dialog                      | `boolean`             | `false`     |
+| Property       | Attribute        | Description                                 | Type                  | Default     |
+| -------------- | ---------------- | ------------------------------------------- | --------------------- | ----------- |
+| `clickToClose` | `click-to-close` | Allows dialog to close when clicking off it | `boolean`             | `false`     |
+| `confirmText`  | `confirm-text`   | Text for confirmation button                | `string`              | `'Confirm'` |
+| `denyText`     | `deny-text`      | Text for close button                       | `string`              | `'Cancel'`  |
+| `header`       | `header`         | Dialog header title                         | `string \| undefined` | `undefined` |
+| `message`      | `message`        | Dialog body message                         | `string \| undefined` | `undefined` |
+| `open`         | `open`           | Shows and hides dialog                      | `boolean`             | `false`     |
 
 
 ## Events

--- a/packages/web-components/src/components/rux-dialog/readme.md
+++ b/packages/web-components/src/components/rux-dialog/readme.md
@@ -60,13 +60,14 @@ Or use slots to render the header, content and footer.
 
 ## Properties
 
-| Property       | Attribute       | Description                  | Type                  | Default     |
-| -------------- | --------------- | ---------------------------- | --------------------- | ----------- |
-| `confirmText`  | `confirm-text`  | Text for confirmation button | `string`              | `'Confirm'` |
-| `denyText`     | `deny-text`     | Text for close button        | `string`              | `'Cancel'`  |
-| `modalMessage` | `modal-message` | Dialog body message          | `string \| undefined` | `undefined` |
-| `modalTitle`   | `modal-title`   | Dialog header title          | `string \| undefined` | `undefined` |
-| `open`         | `open`          | Shows and hides dialog       | `boolean`             | `false`     |
+| Property        | Attribute        | Description                                 | Type                  | Default     |
+| --------------- | ---------------- | ------------------------------------------- | --------------------- | ----------- |
+| `clickToClose`  | `click-to-close` | Allows dialog to close when clicking off it | `boolean`             | `false`     |
+| `confirmText`   | `confirm-text`   | Text for confirmation button                | `string`              | `'Confirm'` |
+| `denyText`      | `deny-text`      | Text for close button                       | `string`              | `'Cancel'`  |
+| `dialogMessage` | `dialog-message` | Dialog body message                         | `string \| undefined` | `undefined` |
+| `dialogTitle`   | `dialog-title`   | Dialog header title                         | `string \| undefined` | `undefined` |
+| `open`          | `open`           | Shows and hides dialog                      | `boolean`             | `false`     |
 
 
 ## Events

--- a/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
+++ b/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
@@ -39,11 +39,11 @@ export class RuxDialog {
     /**
      * Dialog body message
      */
-    @Prop() dialogMessage?: string
+    @Prop() message?: string
     /**
      * Dialog header title
      */
-    @Prop() dialogTitle?: string
+    @Prop() header?: string
     /**
      * Text for confirmation button
      */
@@ -192,8 +192,8 @@ export class RuxDialog {
     render() {
         const {
             open,
-            dialogMessage,
-            dialogTitle,
+            message,
+            header,
             confirmText,
             denyText,
             _handleDialogChoice,
@@ -211,8 +211,7 @@ export class RuxDialog {
                             <header
                                 class={{
                                     hidden:
-                                        !this.hasHeader &&
-                                        dialogTitle === undefined,
+                                        !this.hasHeader && header === undefined,
                                     'rux-dialog__header': true,
                                 }}
                                 part="header"
@@ -221,7 +220,7 @@ export class RuxDialog {
                                     name="header"
                                     onSlotchange={this._handleSlotChange}
                                 >
-                                    {dialogTitle}
+                                    {header}
                                 </slot>
                             </header>
 
@@ -230,13 +229,13 @@ export class RuxDialog {
                                     class={{
                                         hidden:
                                             !this.hasMessage &&
-                                            dialogMessage === undefined,
+                                            message === undefined,
                                         'rux-dialog__message': true,
                                     }}
                                     part="message"
                                 >
                                     <slot onSlotchange={this._handleSlotChange}>
-                                        {dialogMessage}
+                                        {message}
                                     </slot>
                                 </div>
                             </div>

--- a/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
+++ b/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
@@ -39,11 +39,11 @@ export class RuxDialog {
     /**
      * Dialog body message
      */
-    @Prop() modalMessage?: string
+    @Prop() dialogMessage?: string
     /**
      * Dialog header title
      */
-    @Prop() modalTitle?: string
+    @Prop() dialogTitle?: string
     /**
      * Text for confirmation button
      */
@@ -52,6 +52,12 @@ export class RuxDialog {
      * Text for close button
      */
     @Prop() denyText: string = 'Cancel'
+
+    /**
+     * Allows dialog to close when clicking off it
+     */
+    @Prop({ attribute: 'click-to-close' }) clickToClose: boolean = false
+
     /**
      * Event that is fired when dialog opens
      */
@@ -107,12 +113,14 @@ export class RuxDialog {
         }
     }
 
-    // close modal if click happens outside of dialog
+    // close dialog if click happens outside of dialog
     @Listen('click', { target: 'window' })
     handleClick(ev: MouseEvent) {
-        const wrapper = this._getWrapper()
-        if (ev.composedPath()[0] === wrapper) {
-            this.open = false
+        if (this.clickToClose) {
+            const wrapper = this._getWrapper()
+            if (ev.composedPath()[0] === wrapper) {
+                this.open = false
+            }
         }
     }
 
@@ -184,8 +192,8 @@ export class RuxDialog {
     render() {
         const {
             open,
-            modalMessage,
-            modalTitle,
+            dialogMessage,
+            dialogTitle,
             confirmText,
             denyText,
             _handleDialogChoice,
@@ -204,7 +212,7 @@ export class RuxDialog {
                                 class={{
                                     hidden:
                                         !this.hasHeader &&
-                                        modalTitle === undefined,
+                                        dialogTitle === undefined,
                                     'rux-dialog__header': true,
                                 }}
                                 part="header"
@@ -213,7 +221,7 @@ export class RuxDialog {
                                     name="header"
                                     onSlotchange={this._handleSlotChange}
                                 >
-                                    {modalTitle}
+                                    {dialogTitle}
                                 </slot>
                             </header>
 
@@ -222,13 +230,13 @@ export class RuxDialog {
                                     class={{
                                         hidden:
                                             !this.hasMessage &&
-                                            modalMessage === undefined,
+                                            dialogMessage === undefined,
                                         'rux-dialog__message': true,
                                     }}
                                     part="message"
                                 >
                                     <slot onSlotchange={this._handleSlotChange}>
-                                        {modalMessage}
+                                        {dialogMessage}
                                     </slot>
                                 </div>
                             </div>

--- a/packages/web-components/src/components/rux-dialog/test/index.html
+++ b/packages/web-components/src/components/rux-dialog/test/index.html
@@ -23,15 +23,15 @@
         <section>
             <rux-dialog
                 open
-                modal-title="hello"
-                modal-message="world"
+                dialog-title="hello"
+                dialog-message="world"
             ></rux-dialog>
         </section>
         <section>
             <rux-dialog
                 id="props"
-                modal-message="Props Message"
-                modal-title="Props Title"
+                dialog-message="Props Message"
+                dialog-title="Props Title"
             ></rux-dialog>
             <rux-button id="openprops">Open Props Version</rux-button>
         </section>
@@ -56,7 +56,7 @@
         <section>
             <rux-dialog
                 id="mix"
-                modal-title="Mixed"
+                dialog-title="Mixed"
                 deny-text="Custom Deny Text"
             >
                 <div slot="message">
@@ -76,7 +76,7 @@
             <rux-button id="dyn" style="padding: 15px 0px"
                 >Open changing slot</rux-button
             >
-            <rux-dialog id="change" modal-title="Title"> </rux-dialog>
+            <rux-dialog id="change" dialog-title="Title"> </rux-dialog>
         </section>
         <script>
             const props = document.getElementById('props')

--- a/packages/web-components/src/stories/dialog.stories.mdx
+++ b/packages/web-components/src/stories/dialog.stories.mdx
@@ -26,8 +26,8 @@ export const Dialog = (args) => {
 <div style="display: flex; flex-flow: column; justify-content: center;">
     <rux-dialog
         ?open="${args.open}"
-        dialog-message="${args.dialogMessage}"
-        dialog-title="${args.dialogTitle}"
+        message="${args.message}"
+        header="${args.header}"
         confirm-text="${args.confirmText}"
         deny-text="${args.denyText}"
     ></rux-dialog>
@@ -39,8 +39,8 @@ export const Dialog = (args) => {
     <Story
         args={{
             open: true,
-            dialogMessage: 'Dialog message',
-            dialogTitle: 'Dialog title',
+            message: 'Dialog message',
+            header: 'Dialog header',
             confirmText: 'Release',
             denyText: 'Cancel',
             clickToClose: false,
@@ -92,8 +92,8 @@ export const WithSlots = (args) => {
             clickToClose: false,
         }}
         argTypes={{
-            dialogTitle: { table: { disable: true}},
-            dialogMessage: { table: { disable: true}},
+            header: { table: { disable: true}},
+            message: { table: { disable: true}},
             confirmText: { table: { disable: true}},
             denyText: { table: { disable: true}}
         }}

--- a/packages/web-components/src/stories/dialog.stories.mdx
+++ b/packages/web-components/src/stories/dialog.stories.mdx
@@ -26,8 +26,8 @@ export const Dialog = (args) => {
 <div style="display: flex; flex-flow: column; justify-content: center;">
     <rux-dialog
         ?open="${args.open}"
-        modal-message="${args.modalMessage}"
-        modal-title="${args.modalTitle}"
+        dialog-message="${args.dialogMessage}"
+        dialog-title="${args.dialogTitle}"
         confirm-text="${args.confirmText}"
         deny-text="${args.denyText}"
     ></rux-dialog>
@@ -39,10 +39,11 @@ export const Dialog = (args) => {
     <Story
         args={{
             open: true,
-            modalMessage: 'Dialog message',
-            modalTitle: 'Dialog title',
+            dialogMessage: 'Dialog message',
+            dialogTitle: 'Dialog title',
             confirmText: 'Release',
             denyText: 'Cancel',
+            clickToClose: false,
         }}
         name="Dialog"
     >
@@ -88,10 +89,11 @@ export const WithSlots = (args) => {
     <Story
         args={{
             open: true,
+            clickToClose: false,
         }}
         argTypes={{
-            modalTitle: { table: { disable: true}},
-            modalMessage: { table: { disable: true}},
+            dialogTitle: { table: { disable: true}},
+            dialogMessage: { table: { disable: true}},
             confirmText: { table: { disable: true}},
             denyText: { table: { disable: true}}
         }}
@@ -137,6 +139,9 @@ using a `rux-button` to open the Dialog, and another `rux-button` in the `footer
     })
 </script>
 ```
+
+The prop `click-to-close` controls whether or not the rux-dialog can be closed by clicking off of it. If false, 
+the user will have to make a choice (ie, confirm/deny) before they can close the dialog.
 
 ### Applying Focus
 

--- a/packages/web-components/tests/dialog.spec.ts
+++ b/packages/web-components/tests/dialog.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test'
-import { startTestEnv, setBodyContent } from './utils/_startTestEnv'
+import {
+    startTestEnv,
+    setBodyContent,
+    startTestInBefore,
+} from './utils/_startTestEnv'
 
 test.describe('Dialog', () => {
     startTestEnv()
@@ -29,7 +33,7 @@ test.describe('Dialog', () => {
         await setBodyContent(
             page,
             `
-        <rux-dialog dialog-title="Title" dialog-message="Message"></rux-dialog>
+        <rux-dialog dialog-title="Title" dialog-message="Message" click-to-close></rux-dialog>
         <rux-button id="toggle">Open/Close</rux-button>
     `
         )
@@ -201,10 +205,80 @@ test.describe('Dialog', () => {
             page.waitForTimeout(1000).then(() => page.keyboard.press('Escape')),
         ])
     })
-    /*
+})
+test.describe(
+    'Dialog does not close on an off click unless click-to-close is true',
+    () => {
+        test.beforeEach(async ({ page }) => {
+            await startTestInBefore(page)
+            await setBodyContent(
+                page,
+                `   <rux-dialog id="ctc-false" dialog-title="Click to close = False" dialog-message="world"></rux-dialog>
+                <rux-dialog id="ctc-true" dialog-title="Click to close = True" dialog-message="world" click-to-close></rux-dialog>
+                <rux-button id="true">Open click-to-close true</rux-button>
+                <rux-button id="false">Open click-to-close false</rux-button>
+            `
+            )
+            await page.addScriptTag({
+                content: `
+            document.addEventListener('ruxdialogclosed', (e) => console.log(e.detail))
+            const openTrue = document.getElementById('true');
+            const openFalse = document.getElementById('false');
+            const ctcTrueModal = document.getElementById('ctc-true')
+            const ctcFalseModal = document.getElementById('ctc-false')
+    
+            openTrue.addEventListener('click', () => {
+                ctcTrueModal.open = true
+            })
+            openFalse.addEventListener('click', () => {
+                ctcFalseModal.open = true
+            })
+        `,
+            })
+        })
+        test('it reamins open when click-to-close is false', async ({
+            page,
+        }) => {
+            await page.locator('#false').click()
+            const ctcFalseModal = page.locator('#ctc-false')
+            await ctcFalseModal
+                .evaluate((e) => e.hasAttribute('open'))
+                .then((e) => {
+                    expect(e).toBeTruthy()
+                })
+            //click off, it should remain open.
+            await page.locator('body').click({ position: { x: 10, y: 10 } })
+            //ctcFalseModal should still be open
+            await ctcFalseModal
+                .evaluate((e) => e.hasAttribute('open'))
+                .then((e) => {
+                    expect(e).toBeTruthy()
+                })
+        })
+        test('it closes on an off click when click-to-close is true', async ({
+            page,
+        }) => {
+            await page.locator('#true').click()
+            const ctcTrueModal = page.locator('#ctc-true')
+            await ctcTrueModal
+                .evaluate((e) => e.hasAttribute('open'))
+                .then((e) => {
+                    expect(e).toBeTruthy()
+                })
+            //click off, it should remain open.
+            await page.locator('body').click({ position: { x: 10, y: 10 } })
+            //ctcFalseModal should still be open
+            await ctcTrueModal
+                .evaluate((e) => e.hasAttribute('open'))
+                .then((e) => {
+                    expect(e).toBeFalsy()
+                })
+        })
+        /*
         Need to test: 
         - With slots? Not sure if that's acutally beneficial. 
         - Better way to test events rather than console? 
         - current e2e has tests for dialog props changing - I don't think these are helpful. Thoughts? 
     */
-})
+    }
+)

--- a/packages/web-components/tests/dialog.spec.ts
+++ b/packages/web-components/tests/dialog.spec.ts
@@ -22,18 +22,18 @@ test.describe('Dialog', () => {
         await setBodyContent(
             page,
             `
-        <rux-dialog dialog-title="Title" dialog-message="Message"></rux-dialog>
+        <rux-dialog header="Title" message="Message"></rux-dialog>
     `
         )
         const el = page.locator('rux-dialog')
-        await expect(el).toHaveAttribute('dialog-message', 'Message')
-        await expect(el).toHaveAttribute('dialog-title', 'Title')
+        await expect(el).toHaveAttribute('message', 'Message')
+        await expect(el).toHaveAttribute('header', 'Title')
     })
     test('it opens and closes', async ({ page }) => {
         await setBodyContent(
             page,
             `
-        <rux-dialog dialog-title="Title" dialog-message="Message" click-to-close></rux-dialog>
+        <rux-dialog header="Title" message="Message" click-to-close></rux-dialog>
         <rux-button id="toggle">Open/Close</rux-button>
     `
         )
@@ -69,7 +69,7 @@ test.describe('Dialog', () => {
         await setBodyContent(
             page,
             `
-        <rux-dialog open dialog-title="Title" dialog-message="Message"></rux-dialog>
+        <rux-dialog open header="Title" message="Message"></rux-dialog>
         <rux-button id="toggle">Open/Close</rux-button>
     `
         )
@@ -93,7 +93,7 @@ test.describe('Dialog', () => {
         await setBodyContent(
             page,
             `
-        <rux-dialog open dialog-title="Title" dialog-message="Message"></rux-dialog>
+        <rux-dialog open header="Title" message="Message"></rux-dialog>
         <rux-button id="toggle">Open/Close</rux-button>
     `
         )
@@ -119,7 +119,7 @@ test.describe('Dialog', () => {
         await setBodyContent(
             page,
             `
-        <rux-dialog open dialog-title="Title" dialog-message="Message"></rux-dialog>
+        <rux-dialog open header="Title" message="Message"></rux-dialog>
         <rux-button id="toggle">Open/Close</rux-button>
     `
         )
@@ -142,7 +142,7 @@ test.describe('Dialog', () => {
         await setBodyContent(
             page,
             `
-        <rux-dialog open dialog-title="Title" dialog-message="Message"></rux-dialog>
+        <rux-dialog open header="Title" message="Message"></rux-dialog>
         <rux-button id="toggle">Open/Close</rux-button>
     `
         )
@@ -165,7 +165,7 @@ test.describe('Dialog', () => {
         await setBodyContent(
             page,
             `
-        <rux-dialog open dialog-title="Title" dialog-message="Message"></rux-dialog>
+        <rux-dialog open header="Title" message="Message"></rux-dialog>
     `
         )
         page.addScriptTag({
@@ -188,7 +188,7 @@ test.describe('Dialog', () => {
         await setBodyContent(
             page,
             `
-        <rux-dialog open dialog-title="Title" dialog-message="Message"></rux-dialog>
+        <rux-dialog open header="Title" message="Message"></rux-dialog>
     `
         )
         page.addScriptTag({
@@ -213,8 +213,8 @@ test.describe(
             await startTestInBefore(page)
             await setBodyContent(
                 page,
-                `   <rux-dialog id="ctc-false" dialog-title="Click to close = False" dialog-message="world"></rux-dialog>
-                <rux-dialog id="ctc-true" dialog-title="Click to close = True" dialog-message="world" click-to-close></rux-dialog>
+                `   <rux-dialog id="ctc-false" header="Click to close = False" message="world"></rux-dialog>
+                <rux-dialog id="ctc-true" header="Click to close = True" message="world" click-to-close></rux-dialog>
                 <rux-button id="true">Open click-to-close true</rux-button>
                 <rux-button id="false">Open click-to-close false</rux-button>
             `

--- a/packages/web-components/tests/dialog.spec.ts
+++ b/packages/web-components/tests/dialog.spec.ts
@@ -18,19 +18,18 @@ test.describe('Dialog', () => {
         await setBodyContent(
             page,
             `
-        <rux-dialog modal-title="Title" modal-message="Message"></rux-dialog>
+        <rux-dialog dialog-title="Title" dialog-message="Message"></rux-dialog>
     `
         )
         const el = page.locator('rux-dialog')
-        //! These will need to change to dialog-message and dialog-title in the future.
-        await expect(el).toHaveAttribute('modal-message', 'Message')
-        await expect(el).toHaveAttribute('modal-title', 'Title')
+        await expect(el).toHaveAttribute('dialog-message', 'Message')
+        await expect(el).toHaveAttribute('dialog-title', 'Title')
     })
     test('it opens and closes', async ({ page }) => {
         await setBodyContent(
             page,
             `
-        <rux-dialog modal-title="Title" modal-message="Message"></rux-dialog>
+        <rux-dialog dialog-title="Title" dialog-message="Message"></rux-dialog>
         <rux-button id="toggle">Open/Close</rux-button>
     `
         )
@@ -66,7 +65,7 @@ test.describe('Dialog', () => {
         await setBodyContent(
             page,
             `
-        <rux-dialog open modal-title="Title" modal-message="Message"></rux-dialog>
+        <rux-dialog open dialog-title="Title" dialog-message="Message"></rux-dialog>
         <rux-button id="toggle">Open/Close</rux-button>
     `
         )
@@ -90,7 +89,7 @@ test.describe('Dialog', () => {
         await setBodyContent(
             page,
             `
-        <rux-dialog open modal-title="Title" modal-message="Message"></rux-dialog>
+        <rux-dialog open dialog-title="Title" dialog-message="Message"></rux-dialog>
         <rux-button id="toggle">Open/Close</rux-button>
     `
         )
@@ -116,7 +115,7 @@ test.describe('Dialog', () => {
         await setBodyContent(
             page,
             `
-        <rux-dialog open modal-title="Title" modal-message="Message"></rux-dialog>
+        <rux-dialog open dialog-title="Title" dialog-message="Message"></rux-dialog>
         <rux-button id="toggle">Open/Close</rux-button>
     `
         )
@@ -139,7 +138,7 @@ test.describe('Dialog', () => {
         await setBodyContent(
             page,
             `
-        <rux-dialog open modal-title="Title" modal-message="Message"></rux-dialog>
+        <rux-dialog open dialog-title="Title" dialog-message="Message"></rux-dialog>
         <rux-button id="toggle">Open/Close</rux-button>
     `
         )
@@ -162,7 +161,7 @@ test.describe('Dialog', () => {
         await setBodyContent(
             page,
             `
-        <rux-dialog open modal-title="Title" modal-message="Message"></rux-dialog>
+        <rux-dialog open dialog-title="Title" dialog-message="Message"></rux-dialog>
     `
         )
         page.addScriptTag({
@@ -185,7 +184,7 @@ test.describe('Dialog', () => {
         await setBodyContent(
             page,
             `
-        <rux-dialog open modal-title="Title" modal-message="Message"></rux-dialog>
+        <rux-dialog open dialog-title="Title" dialog-message="Message"></rux-dialog>
     `
         )
         page.addScriptTag({


### PR DESCRIPTION
## Brief Description

This re-adds the `click-to-close` prop that went missing somehow. Look for it on milk cartons I guess.
Also changes the prop names of `modalTitle` and `modalMessage` to `header`, `message`.
Adds tests and updates SB as well.

## JIRA Link

prop name changes -> https://rocketcom.atlassian.net/browse/ASTRO-4457
click-to-close prop -> https://rocketcom.atlassian.net/browse/ASTRO-4530

## Related Issue

## General Notes

## Motivation and Context

The click-to-close prop keeps dialog inline with our compliance while also providing external users the ability to customize it.
The prop names needed to be changed to reflect the renamed component. 

## Issues and Limitations

I noticed that on `main`'s version of dialog, the tabbing through buttons on the dialog works great and shows which button is focused. The `next` version does not. The keyboard presses still work but tabbing doesn't seem to be. 
I checked this version against the version in main, and couldn't notice any differences in code or scss. I even copied the main code into next at one point to make sure and it still didn't work. I also tried removing the `shadow: {delegatesFocus: true}` on the next version to match the main version, still no luck. The only thing left that I can think of is next is on stencil version 2.10, main is on 2.5. Maybe something changed in those versions. 

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
