### PR TITLE
Km 3658 rux tree 6 add parts

### DIFF
--- a/.changeset/fast-panthers-kneel.md
+++ b/.changeset/fast-panthers-kneel.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+rux-tree-node - add parts for styling to replace deprecated custom css properties

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@astrouxds/astro-web-components",
-    "version": "6.12.1",
+    "version": "6.13.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@astrouxds/astro-web-components",
-            "version": "6.12.1",
+            "version": "6.13.0",
             "license": "MIT",
             "dependencies": {
                 "@stencil/core": "~2.5.2",

--- a/packages/web-components/src/components/rux-tree-node/rux-tree-node.tsx
+++ b/packages/web-components/src/components/rux-tree-node/rux-tree-node.tsx
@@ -23,6 +23,8 @@ let id = 0
 /**
  * @slot (default) - The parent node content
  * @slot node - Renders a child node within the current node
+ * @part item - The individual tree node
+ * @part icon - The open/closed indicator arrow that exists on parent nodes
  */
 export class RuxTreeNode {
     private componentId = `node-${++id}`
@@ -273,9 +275,10 @@ export class RuxTreeNode {
                         'tree-node--selected': this.selected,
                     }}
                 >
-                    <div class="parent" tabindex="0">
+                    <div class="parent" tabindex="0" part="item">
                         {this._hasChildren && (
                             <i
+                                part="icon"
                                 onClick={(e) => this._handleArrowClick(e)}
                                 class="arrow"
                             ></i>

--- a/packages/web-components/src/components/rux-tree-node/rux-tree-node.tsx
+++ b/packages/web-components/src/components/rux-tree-node/rux-tree-node.tsx
@@ -23,7 +23,7 @@ let id = 0
 /**
  * @slot (default) - The parent node content
  * @slot node - Renders a child node within the current node
- * @part item - The individual tree node
+ * @part node - The individual tree node
  * @part icon - The open/closed indicator arrow that exists on parent nodes
  */
 export class RuxTreeNode {
@@ -275,7 +275,7 @@ export class RuxTreeNode {
                         'tree-node--selected': this.selected,
                     }}
                 >
-                    <div class="parent" tabindex="0" part="item">
+                    <div class="parent" tabindex="0" part="node">
                         {this._hasChildren && (
                             <i
                                 part="icon"

--- a/packages/web-components/src/components/rux-tree-node/test/__snapshots__/rux-tree-node.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-tree-node/test/__snapshots__/rux-tree-node.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`rux-tree-node renders 1`] = `
 <rux-tree-node aria-expanded="false" aria-selected="false" role="treeitem">
   <mock:shadow-root>
     <div class="tree-node" id="node-1">
-      <div class="parent" tabindex="0">
+      <div class="parent" part="item" tabindex="0">
         <slot></slot>
       </div>
       <div class="children">
@@ -19,8 +19,8 @@ exports[`rux-tree-node renders children 1`] = `
 <rux-tree-node aria-expanded="false" aria-selected="false" role="treeitem">
   <mock:shadow-root>
     <div class="tree-node tree-node--has-children" id="node-2">
-      <div class="parent" tabindex="0">
-        <i class="arrow"></i>
+      <div class="parent" part="item" tabindex="0">
+        <i class="arrow" part="icon"></i>
         <slot></slot>
       </div>
       <div class="children" role="group">
@@ -32,7 +32,7 @@ exports[`rux-tree-node renders children 1`] = `
   <rux-tree-node aria-expanded="false" aria-selected="false" role="treeitem" slot="node">
     <mock:shadow-root>
       <div class="tree-node" id="node-3">
-        <div class="parent" tabindex="0">
+        <div class="parent" part="item" tabindex="0">
           <slot></slot>
         </div>
         <div class="children">

--- a/packages/web-components/src/components/rux-tree-node/test/__snapshots__/rux-tree-node.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-tree-node/test/__snapshots__/rux-tree-node.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`rux-tree-node renders 1`] = `
 <rux-tree-node aria-expanded="false" aria-selected="false" role="treeitem">
   <mock:shadow-root>
     <div class="tree-node" id="node-1">
-      <div class="parent" part="item" tabindex="0">
+      <div class="parent" part="node" tabindex="0">
         <slot></slot>
       </div>
       <div class="children">
@@ -19,7 +19,7 @@ exports[`rux-tree-node renders children 1`] = `
 <rux-tree-node aria-expanded="false" aria-selected="false" role="treeitem">
   <mock:shadow-root>
     <div class="tree-node tree-node--has-children" id="node-2">
-      <div class="parent" part="item" tabindex="0">
+      <div class="parent" part="node" tabindex="0">
         <i class="arrow" part="icon"></i>
         <slot></slot>
       </div>
@@ -32,7 +32,7 @@ exports[`rux-tree-node renders children 1`] = `
   <rux-tree-node aria-expanded="false" aria-selected="false" role="treeitem" slot="node">
     <mock:shadow-root>
       <div class="tree-node" id="node-3">
-        <div class="parent" part="item" tabindex="0">
+        <div class="parent" part="node" tabindex="0">
           <slot></slot>
         </div>
         <div class="children">

--- a/packages/web-components/src/components/rux-tree/test/index.html
+++ b/packages/web-components/src/components/rux-tree/test/index.html
@@ -20,6 +20,49 @@
     </head>
 
     <body>
+        <style>
+            /* add Parts: tree-text-color */
+            rux-tree-node::part(item) {
+                color: red;
+            }
+
+            /* add Parts: tree-border-color*/
+            rux-tree {
+                border: 1px solid purple;
+            }
+            rux-tree-node {
+                border: 1px solid orange;
+            }
+            /* add Parts: tree-accent-color*/
+            rux-tree-node::part(icon)::after {
+                border-color: transparent transparent transparent white;
+            }
+
+            /*add Parts: tree-hover-background-color*/
+            /* add Parts: tree-hover-text-color */
+            rux-tree-node::part(item):hover {
+                background-color: orange;
+                color: green;
+            }
+
+            /*add Parts: Tree-selected-border-color*/
+            rux-tree-node[selected] {
+                border: 1px solid blue;
+            }
+
+            /* add Parts: tree-selected-accent-color */
+            rux-tree-node[selected]::part(item) {
+                color: green;
+            }
+            rux-tree-node[selected]::part(item)::before {
+                color: green;
+            }
+
+            /*add Parts: Tree-expanded-border-color */
+            rux-tree-node[expanded] {
+                border-color: pink;
+            }
+        </style>
         <rux-tree role="tree" class="hydrated">
             <rux-tree-node
                 role="treeitem"

--- a/packages/web-components/src/components/rux-tree/test/index.html
+++ b/packages/web-components/src/components/rux-tree/test/index.html
@@ -20,7 +20,7 @@
     </head>
 
     <body>
-        <style>
+        <!-- <style>
             /* add Parts: tree-text-color */
             rux-tree-node::part(item) {
                 color: red;
@@ -54,15 +54,15 @@
             rux-tree-node[selected]::part(item) {
                 color: green;
             }
-            rux-tree-node[selected]::part(item)::before {
-                color: green;
+            rux-tree-node[selected] {
+                background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='5' height='33' viewBox='0 0 5 33' fill='none'%3E%3Crect width='5' height='33' fill='%23ffffff'/%3E%3C/svg%3E%0A");;
             }
 
             /*add Parts: Tree-expanded-border-color */
             rux-tree-node[expanded] {
                 border-color: pink;
             }
-        </style>
+        </style> -->
         <rux-tree role="tree" class="hydrated">
             <rux-tree-node
                 role="treeitem"

--- a/packages/web-components/src/components/rux-tree/test/index.html
+++ b/packages/web-components/src/components/rux-tree/test/index.html
@@ -22,7 +22,7 @@
     <body>
         <!-- <style>
             /* add Parts: tree-text-color */
-            rux-tree-node::part(item) {
+            rux-tree-node::part(node) {
                 color: red;
             }
 
@@ -40,7 +40,7 @@
 
             /*add Parts: tree-hover-background-color*/
             /* add Parts: tree-hover-text-color */
-            rux-tree-node::part(item):hover {
+            rux-tree-node::part(node):hover {
                 background-color: orange;
                 color: green;
             }
@@ -51,7 +51,7 @@
             }
 
             /* add Parts: tree-selected-accent-color */
-            rux-tree-node[selected]::part(item) {
+            rux-tree-node[selected]::part(node) {
                 color: green;
             }
             rux-tree-node[selected] {


### PR DESCRIPTION
## Brief Description

Add parts to rux-tree-node to replace deprecated css custom properties as a means of styling 

## JIRA Link

[ASTRO-3658](https://rocketcom.atlassian.net/browse/ASTRO-3658)

## Related Issue

## General Notes

## Motivation and Context

some css custom properties were deprecated, leading to a new way of thinking about how one would style the web components. To that end, these shadow parts are meant to return styling. ability to developers

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
