### PR TITLE
docs(astruxds): updated text to link to corresponding component page,…

### DIFF
--- a/packages/astro-uxds/_content/patterns/table.md
+++ b/packages/astro-uxds/_content/patterns/table.md
@@ -8,7 +8,7 @@ title: Table
 
 # Table
 
-Tables are a fundamental UX design tool for organizing and displaying data. They are used throughout space applications and may take many forms. The principal table interactions and styles are illustrated below and demonstrated in the [GRM](https://grm-dashboard.astrouxds.com/) and [TT&C](https://ttc-monitor.astrouxds.com/) sample applications. Types of content used in table cells varies by use case, but often includes: text, checkboxes, icons, status indicators, or buttons.
+Tables are a fundamental UX design tool for organizing and displaying data. They are used throughout space applications and may take many forms. The principal table interactions and styles are illustrated below and demonstrated in the [GRM](https://grm-dashboard.astrouxds.com/) and [TT&C](https://ttc-monitor.astrouxds.com/) sample applications. Types of content used in table cells varies by use case, but often includes: [text](/design-guidelines/typography/), [checkboxes](/components/checkbox/), [icons](/components/icons-and-symbols/), [status indicators](/components/status-symbol/), or [buttons](/components/button/).
 
 ## Header
 
@@ -21,10 +21,6 @@ A Table can be configured with a tall header with large hero numbers (if the cou
 ## Filters
 
 Filters, to narrow what is displayed in the Table, may be presented in the header as Select Menus, as a Segmented Button, or as an Input Field. If it is critical that the user knows that not all data is displayed, a warning may be shown when filters are applied. Though it is not a requirement to display filters in the header row of the column to which they correspond, tables created using ag-Grid default to this design pattern.
-
-![Table with filters as Select Menus and wildcard Input Field.](/img/patterns/table-filters.png "Table with filters as Select Menus and wildcard Input Field.")
-
-![Table with filters as Segmented Buttons and wildcard Input Field.](/img/patterns/table-segmented-button.png "Table with filters as Segmented Buttons and wildcard Input Field.")
 
 ## Sorting
 


### PR DESCRIPTION
… removed 2 photos

## Brief Description

Updated the text in Table paragraph to link to corresponding component page. Removed 2 photos as per design's request 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4044

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
