### PR TITLE
Fm 3863 select menu spacing

### DIFF
--- a/.changeset/smooth-parents-flow.md
+++ b/.changeset/smooth-parents-flow.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": major
+"@astrouxds/angular": major
+"astro-website": major
+"@astrouxds/react": major
+"@astrouxds/astro-web-components": major
+---
+
+Converting stylesheet values to design tokens for spacing and correcting spacing issues for rux-select component.

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -75,10 +75,6 @@ export namespace Components {
          */
         "name": string;
         /**
-          * Sets the checkbox as required
-         */
-        "required": boolean;
-        /**
           * The checkbox value
          */
         "value": string;
@@ -20385,10 +20381,6 @@ declare namespace LocalJSX {
           * Fired when an alteration to the input's value is committed by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
          */
         "onRuxinput"?: (event: CustomEvent<any>) => void;
-        /**
-          * Sets the checkbox as required
-         */
-        "required"?: boolean;
         /**
           * The checkbox value
          */

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -11998,28 +11998,6 @@ export namespace Components {
     }
     interface RuxMenuItemDivider {
     }
-    interface RuxModal {
-        /**
-          * Text for confirmation button
-         */
-        "confirmText": string;
-        /**
-          * Text for close button
-         */
-        "denyText": string;
-        /**
-          * Modal body message
-         */
-        "modalMessage"?: string;
-        /**
-          * Modal header title
-         */
-        "modalTitle"?: string;
-        /**
-          * Shows and hides modal
-         */
-        "open": boolean;
-    }
     interface RuxMonitoringIcon {
         /**
           * Displays an Astro icon matching this string. For a [full list of available icons, see the Icons section in Astro UXDS Guidelines](https://astrouxds.com/ui-components/icons-and-symbols)
@@ -19013,12 +18991,6 @@ declare global {
         prototype: HTMLRuxMenuItemDividerElement;
         new (): HTMLRuxMenuItemDividerElement;
     };
-    interface HTMLRuxModalElement extends Components.RuxModal, HTMLStencilElement {
-    }
-    var HTMLRuxModalElement: {
-        prototype: HTMLRuxModalElement;
-        new (): HTMLRuxModalElement;
-    };
     interface HTMLRuxMonitoringIconElement extends Components.RuxMonitoringIcon, HTMLStencilElement {
     }
     var HTMLRuxMonitoringIconElement: {
@@ -20297,7 +20269,6 @@ declare global {
         "rux-menu": HTMLRuxMenuElement;
         "rux-menu-item": HTMLRuxMenuItemElement;
         "rux-menu-item-divider": HTMLRuxMenuItemDividerElement;
-        "rux-modal": HTMLRuxModalElement;
         "rux-monitoring-icon": HTMLRuxMonitoringIconElement;
         "rux-monitoring-progress-icon": HTMLRuxMonitoringProgressIconElement;
         "rux-notification": HTMLRuxNotificationElement;
@@ -32362,36 +32333,6 @@ declare namespace LocalJSX {
     }
     interface RuxMenuItemDivider {
     }
-    interface RuxModal {
-        /**
-          * Text for confirmation button
-         */
-        "confirmText"?: string;
-        /**
-          * Text for close button
-         */
-        "denyText"?: string;
-        /**
-          * Modal body message
-         */
-        "modalMessage"?: string;
-        /**
-          * Modal header title
-         */
-        "modalTitle"?: string;
-        /**
-          * Event that is fired when modal closes. If modal is closed by clicking on the default confirm or deny buttons (when no footer slot is provided), then true or false will be emitted respectively.
-         */
-        "onRuxmodalclosed"?: (event: CustomEvent<boolean | null>) => void;
-        /**
-          * Event that is fired when modal opens
-         */
-        "onRuxmodalopened"?: (event: CustomEvent<void>) => void;
-        /**
-          * Shows and hides modal
-         */
-        "open"?: boolean;
-    }
     interface RuxMonitoringIcon {
         /**
           * Displays an Astro icon matching this string. For a [full list of available icons, see the Icons section in Astro UXDS Guidelines](https://astrouxds.com/ui-components/icons-and-symbols)
@@ -34096,7 +34037,6 @@ declare namespace LocalJSX {
         "rux-menu": RuxMenu;
         "rux-menu-item": RuxMenuItem;
         "rux-menu-item-divider": RuxMenuItemDivider;
-        "rux-modal": RuxModal;
         "rux-monitoring-icon": RuxMonitoringIcon;
         "rux-monitoring-progress-icon": RuxMonitoringProgressIcon;
         "rux-notification": RuxNotification;
@@ -35210,7 +35150,6 @@ declare module "@stencil/core" {
             "rux-menu": LocalJSX.RuxMenu & JSXBase.HTMLAttributes<HTMLRuxMenuElement>;
             "rux-menu-item": LocalJSX.RuxMenuItem & JSXBase.HTMLAttributes<HTMLRuxMenuItemElement>;
             "rux-menu-item-divider": LocalJSX.RuxMenuItemDivider & JSXBase.HTMLAttributes<HTMLRuxMenuItemDividerElement>;
-            "rux-modal": LocalJSX.RuxModal & JSXBase.HTMLAttributes<HTMLRuxModalElement>;
             "rux-monitoring-icon": LocalJSX.RuxMonitoringIcon & JSXBase.HTMLAttributes<HTMLRuxMonitoringIconElement>;
             "rux-monitoring-progress-icon": LocalJSX.RuxMonitoringProgressIcon & JSXBase.HTMLAttributes<HTMLRuxMonitoringProgressIconElement>;
             "rux-notification": LocalJSX.RuxNotification & JSXBase.HTMLAttributes<HTMLRuxNotificationElement>;

--- a/packages/web-components/src/components/rux-select/rux-select.scss
+++ b/packages/web-components/src/components/rux-select/rux-select.scss
@@ -78,24 +78,24 @@ label {
     background-image: url("data:image/svg+xml,%3Csvg width='31' height='30' viewBox='0 0 31 30' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11.6875 14.6375L14.925 17.875C15.4125 18.3625 16.2 18.3625 16.6875 17.875L19.925 14.6375C20.7125 13.85 20.15 12.5 19.0375 12.5H12.5625C11.45 12.5 10.9 13.85 11.6875 14.6375Z' fill='%234DACFF'/%3E%3C/svg%3E%0A"),
         linear-gradient(
             to left,
-            var(--color-background-surface-selected) 2rem,
-            var(--color-background-base-default) 2rem
+            var(--color-background-surface-selected) var(--spacing-8),
+            var(--color-background-base-default) var(--spacing-8)
         );
     // background-image: url('data:image/svg+xml,%3Csvg%20width%3D%2210%22%20height%3D%225%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%234dacff%22%20d%3D%22M0%200h10L5%205z%22%20fill-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E'),
     //     linear-gradient(
     //         to left,
-    //         var(--color-background-surface-selected) 2rem,
-    //         var(--color-background-base-default) 2rem
+    //         var(--color-background-surface-selected) var(--spacing-8),
+    //         var(--color-background-base-default) var(--spacing-8)
     //     );
-    background-position: center right 0rem, center left 0;
+    background-position: center right var(--spacing-025),
+        center left var(--spacing-0);
     background-repeat: no-repeat;
-    //box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.5);
     &:active:not(:disabled) {
         background-image: url("data:image/svg+xml,%3Csvg width='31' height='30' viewBox='0 0 31 30' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11.6875 14.6375L14.925 17.875C15.4125 18.3625 16.2 18.3625 16.6875 17.875L19.925 14.6375C20.7125 13.85 20.15 12.5 19.0375 12.5H12.5625C11.45 12.5 10.9 13.85 11.6875 14.6375Z' fill='%234DACFF'/%3E%3C/svg%3E%0A"),
             linear-gradient(
                 to left,
-                var(--color-background-surface-selected) 2rem,
-                var(--color-background-base-default) 2rem
+                var(--color-background-surface-selected) var(--spacing-8),
+                var(--color-background-base-default) var(--spacing-8)
             );
     }
     &:hover {
@@ -104,36 +104,40 @@ label {
 }
 
 .rux-select {
+    box-sizing: border-box;
     position: relative;
     background: var(--color-background-base-default);
     appearance: none;
     -webkit-appearance: none;
     -moz-appearance: none;
     width: 100%;
-    border: 1px solid var(--color-border-interactive-muted);
+    box-shadow: var(--color-border-interactive-muted) 0 0 0 1px inset; //replaces border so the border width does not count towards overall component height
+    border: none;
     border-radius: var(--radius-base);
     color: var(--color-background-interactive-default);
     font-family: var(--font-control-body-1-font-family);
     font-size: var(--font-control-body-1-font-size);
     font-weight: var(--font-control-body-1-font-weight);
+    line-height: var(--font-control-body-1-line-height);
     letter-spacing: var(--font-control-body-1-letter-spacing);
     user-select: none;
 
     &--small {
-        padding: 3.5px 8px;
+        padding: var(--spacing-1) var(--spacing-2); //4px 8px
     }
     &--medium {
-        padding: 7.5px 8px;
+        padding: var(--spacing-2); //8px
     }
     &--large {
-        padding: 13.5px 8px;
+        padding: var(--spacing-3) var(--spacing-2); //12px 8px
     }
     &--multiple {
         background: var(--color-background-base-default);
         padding: 0;
         option {
-            padding: 0.438rem 0 0.438rem 1rem; // 7px 0px 7px 16px
-            text-indent: 1rem;
+            padding: calc(var(--spacing-2) - 1px) var(--spacing-0)
+                calc(var(--spacing-2) - 1px) var(--spacing-4); // 7px 0px 7px 16px
+            text-indent: var(--spacing-4);
             &:hover {
                 color: var(--color-background-interactive-hover);
                 background-color: var(--color-background-surface-hover);
@@ -149,31 +153,36 @@ label {
                     color: var(--color-background-interactive-default);
                     background-color: linear-gradient(
                         to left,
-                        var(--color-background-surface-selected) 2rem,
-                        var(--color-background-base-default) 2rem
+                        var(--color-background-surface-selected)
+                            var(--spacing-8),
+                        var(--color-background-base-default) var(--spacing-8)
                     );
                 }
             }
         }
     }
     &--invalid {
-        border: 1px solid var(--color-text-error);
+        box-shadow: var(--color-text-error) 0 0 0 1px inset; //replaces border so the border width does not count towards overall component height
+        border: none;
     }
 
     &:hover {
-        border: 1px solid var(--color-background-interactive-hover);
+        box-shadow: var(--color-background-interactive-hover) 0 0 0 1px inset; //replaces border so the border width does not count towards overall component height
+        border: none;
     }
 
     &:focus {
         outline: none;
-        border: 1px solid var(--color-background-interactive-hover);
+        box-shadow: var(--color-background-interactive-hover) 0 0 0 1px inset; //replaces border so the border width does not count towards overall component height
+        border: none;
     }
 
     &:disabled {
         opacity: 0.4;
         cursor: not-allowed;
         &:hover {
-            border: 1px solid var(--color-border-interactive-muted);
+            box-shadow: var(--color-border-interactive-muted) 0 0 0 1px inset; //replaces border so the border width does not count towards overall component height
+            border: none;
         }
     }
 
@@ -207,7 +216,7 @@ label {
     }
 
     optgroup {
-        text-indent: 1rem;
+        text-indent: var(--spacing-4);
         color: var(--select-menu-text-color);
         font-family: var(--font-body-1-font-family);
         font-size: var(--font-body-1-font-size);

--- a/packages/web-components/src/components/rux-select/rux-select.scss
+++ b/packages/web-components/src/components/rux-select/rux-select.scss
@@ -5,8 +5,8 @@
     scrollbar-color: var(--color-border-interactive-muted)
         var(--color-background-surface-default);
     ::-webkit-scrollbar {
-        width: 16px;
-        height: 16px;
+        width: var(--spacing-4); //16px
+        height: var(--spacing-4); //16px
         background-color: transparent;
     }
 
@@ -15,18 +15,18 @@
             --color-border-interactive-muted,
             rgb(43, 101, 155)
         );
-        border-radius: 8px;
+        border-radius: var(--progress-radius-inner);
         border: 3px solid transparent;
         background-clip: padding-box;
     }
 
     /* visually "centers" because the dark edge of the shadow gives the illusion this is offset */
     ::-webkit-scrollbar-thumb:vertical {
-        border-left-width: 4px;
+        border-left-width: var(--border-width-lg); //4px
     }
 
     ::-webkit-scrollbar-thumb:horizontal {
-        border-top-width: 4px;
+        border-top-width: var(--border-width-lg); //4px
     }
 
     ::-webkit-scrollbar-thumb:active,
@@ -63,29 +63,35 @@
 
 label {
     display: inline-block;
-    margin-bottom: 10px;
+    margin-bottom: calc(var(--spacing-3) - 2px); //10px
     color: var(--color-text-primary);
     font-family: var(--font-control-body-1-font-family);
     font-size: var(--font-control-body-1-font-size);
     font-weight: var(--font-control-body-1-font-weight);
     letter-spacing: var(--font-control-body-1-letter-spacing);
     .rux-label__asterisk {
-        margin-left: 4px;
+        margin-left: var(--spacing-1); //4px
     }
 }
 
 .rux-select:not(.rux-select--multiple) {
-    background-image: url('data:image/svg+xml,%3Csvg%20width%3D%2210%22%20height%3D%225%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%234dacff%22%20d%3D%22M0%200h10L5%205z%22%20fill-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E'),
+    background-image: url("data:image/svg+xml,%3Csvg width='31' height='30' viewBox='0 0 31 30' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11.6875 14.6375L14.925 17.875C15.4125 18.3625 16.2 18.3625 16.6875 17.875L19.925 14.6375C20.7125 13.85 20.15 12.5 19.0375 12.5H12.5625C11.45 12.5 10.9 13.85 11.6875 14.6375Z' fill='%234DACFF'/%3E%3C/svg%3E%0A"),
         linear-gradient(
             to left,
             var(--color-background-surface-selected) 2rem,
             var(--color-background-base-default) 2rem
         );
-    background-position: center right 0.625rem, center left 0;
+    // background-image: url('data:image/svg+xml,%3Csvg%20width%3D%2210%22%20height%3D%225%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%234dacff%22%20d%3D%22M0%200h10L5%205z%22%20fill-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E'),
+    //     linear-gradient(
+    //         to left,
+    //         var(--color-background-surface-selected) 2rem,
+    //         var(--color-background-base-default) 2rem
+    //     );
+    background-position: center right 0rem, center left 0;
     background-repeat: no-repeat;
-    box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.5);
+    //box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.5);
     &:active:not(:disabled) {
-        background-image: url('data:image/svg+xml,%3Csvg%20width%3D%2210%22%20height%3D%225%22%20style%3D%22transform%3A%20rotate%28180deg%29%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%234dacff%22%20d%3D%22M0%200h10L5%205z%22%20fill-rule%3D%22evenodd%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E'),
+        background-image: url("data:image/svg+xml,%3Csvg width='31' height='30' viewBox='0 0 31 30' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11.6875 14.6375L14.925 17.875C15.4125 18.3625 16.2 18.3625 16.6875 17.875L19.925 14.6375C20.7125 13.85 20.15 12.5 19.0375 12.5H12.5625C11.45 12.5 10.9 13.85 11.6875 14.6375Z' fill='%234DACFF'/%3E%3C/svg%3E%0A"),
             linear-gradient(
                 to left,
                 var(--color-background-surface-selected) 2rem,

--- a/packages/web-components/src/components/rux-select/test/index.html
+++ b/packages/web-components/src/components/rux-select/test/index.html
@@ -17,10 +17,10 @@
         <script nomodule src="/build/astro-web-components.esm.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
-        <script
+        <!-- <script
             type="module"
             src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script>
+        ></script> -->
         <style>
             body {
                 padding-left: 2rem;
@@ -43,7 +43,7 @@
     </head>
 
     <body class="dark-theme">
-        <ftl-belt file-id="7tni7pdpLodbs6dGiKwGMz">
+        <!-- <ftl-belt file-id="7tni7pdpLodbs6dGiKwGMz">
             <ftl-holster name="Select Menu" node="25921:122587">
                 <rux-select
                     id="ruxSelect"
@@ -58,7 +58,7 @@
                     <rux-option value="green" label="Green"></rux-option>
                 </rux-select>
             </ftl-holster>
-        </ftl-belt>
+        </ftl-belt> -->
         <section>
             <h2>Single Select</h2>
 

--- a/packages/web-components/src/components/rux-select/test/index.html
+++ b/packages/web-components/src/components/rux-select/test/index.html
@@ -43,27 +43,14 @@
     </head>
 
     <body class="dark-theme">
-        <ftl-belt
-            access-token="figd_9S33KsQIz3Kpi6WvFmR0XmeDhfxbCzwm5RYLt4mv"
-            file-id="7tni7pdpLodbs6dGiKwGMz"
-        >
+        <ftl-belt file-id="7tni7pdpLodbs6dGiKwGMz">
             <ftl-holster name="Select Menu" node="25921:123190">
-                <form id="form" method="POST" action="/form">
-                    <rux-select
-                        id="ruxSelect"
-                        label="Best Thing?"
-                        name="bestThing"
-                    >
-                        <rux-option
-                            label="Select an option"
-                            value=""
-                        ></rux-option>
-                        <rux-option label="Red" value="red"></rux-option>
-                        <rux-option value="blue" label="Blue"></rux-option>
-                        <rux-option value="green" label="Green"></rux-option>
-                    </rux-select>
-                    <button id="formSubmitBtn" type="submit">submit</button>
-                </form>
+                <rux-select id="ruxSelect" label="" name="bestThing">
+                    <rux-option label="Select menu" value=""></rux-option>
+                    <rux-option label="Red" value="red"></rux-option>
+                    <rux-option value="blue" label="Blue"></rux-option>
+                    <rux-option value="green" label="Green"></rux-option>
+                </rux-select>
             </ftl-holster>
         </ftl-belt>
         <section>

--- a/packages/web-components/src/components/rux-select/test/index.html
+++ b/packages/web-components/src/components/rux-select/test/index.html
@@ -17,6 +17,10 @@
         <script nomodule src="/build/astro-web-components.esm.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
+        <script
+            type="module"
+            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
+        ></script>
         <style>
             body {
                 padding-left: 2rem;
@@ -39,6 +43,29 @@
     </head>
 
     <body class="dark-theme">
+        <ftl-belt
+            access-token="figd_9S33KsQIz3Kpi6WvFmR0XmeDhfxbCzwm5RYLt4mv"
+            file-id="7tni7pdpLodbs6dGiKwGMz"
+        >
+            <ftl-holster name="Select Menu" node="25921:123190">
+                <form id="form" method="POST" action="/form">
+                    <rux-select
+                        id="ruxSelect"
+                        label="Best Thing?"
+                        name="bestThing"
+                    >
+                        <rux-option
+                            label="Select an option"
+                            value=""
+                        ></rux-option>
+                        <rux-option label="Red" value="red"></rux-option>
+                        <rux-option value="blue" label="Blue"></rux-option>
+                        <rux-option value="green" label="Green"></rux-option>
+                    </rux-select>
+                    <button id="formSubmitBtn" type="submit">submit</button>
+                </form>
+            </ftl-holster>
+        </ftl-belt>
         <section>
             <h2>Single Select</h2>
 

--- a/packages/web-components/src/components/rux-select/test/index.html
+++ b/packages/web-components/src/components/rux-select/test/index.html
@@ -44,8 +44,14 @@
 
     <body class="dark-theme">
         <ftl-belt file-id="7tni7pdpLodbs6dGiKwGMz">
-            <ftl-holster name="Select Menu" node="25921:123190">
-                <rux-select id="ruxSelect" label="" name="bestThing">
+            <ftl-holster name="Select Menu" node="25921:122587">
+                <rux-select
+                    id="ruxSelect"
+                    label=""
+                    name="bestThing"
+                    size="medium"
+                    invalid
+                >
                     <rux-option label="Select menu" value=""></rux-option>
                     <rux-option label="Red" value="red"></rux-option>
                     <rux-option value="blue" label="Blue"></rux-option>


### PR DESCRIPTION
## Brief Description

Modifying the spacing of the `rux-select` component to match the updated Figma designs.

## JIRA Link

[JIRA-3863](https://rocketcom.atlassian.net/browse/ASTRO-3863)

## Related Issue

## General Notes

The `rux-select` component had as many pixel and rem values converted to spacing tokens as were in the .scss file. Some of the values were also modified to exactly match the design specifications, specifically padding values, and the border attributes were changed to box-shadow in line with our other recent changes so that the border does not take up computed space. This allows the overlay of the Figma design and the code to more closely match. The caret arrow was also changed to match the Figma design.

## Motivation and Context

Our code differed slightly from what is currently in Figma and we no longer want to use hard-coded values where design tokens can be used.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
