### PR TITLE
docs(main): update api to reference data emitted on the event.detail

### DIFF
--- a/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
+++ b/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
@@ -62,7 +62,7 @@ export class RuxDialog {
     })
     ruxDialogOpened!: EventEmitter<void>
     /**
-     * Event that is fired when dialog closes. If dialog is closed by clicking on the default confirm or deny buttons (when no footer slot is provided), then true or false will be emitted respectively.
+     * Event that is fired when dialog closes. If dialog is closed by clicking on the default confirm or deny buttons (when no footer slot is provided), then true or false will be emitted respectively on the event.detail.
      */
     @Event({
         eventName: 'ruxdialogclosed',

--- a/packages/web-components/src/components/rux-menu-item/rux-menu-item.tsx
+++ b/packages/web-components/src/components/rux-menu-item/rux-menu-item.tsx
@@ -60,7 +60,7 @@ export class RuxMenuItem {
     @Prop() download: string | undefined
 
     /**
-     * Emitted when item is clicked. Ex `{value : 10}`
+     * Fires when an item is clicked and emits the value on the event.detail. Ex `{value : 10}`
      */
     @Event({
         eventName: 'ruxmenuitemselected',

--- a/packages/web-components/src/components/rux-modal/rux-modal.tsx
+++ b/packages/web-components/src/components/rux-modal/rux-modal.tsx
@@ -64,7 +64,7 @@ export class RuxModal {
     })
     ruxModalOpened!: EventEmitter<void>
     /**
-     * Event that is fired when modal closes. If modal is closed by clicking on the default confirm or deny buttons (when no footer slot is provided), then true or false will be emitted respectively.
+     * Event that is fired when modal closes. If modal is closed by clicking on the default confirm or deny buttons (when no footer slot is provided), then true or false will be emitted respectively on the event.detail.
      */
     @Event({
         eventName: 'ruxmodalclosed',

--- a/packages/web-components/src/components/rux-push-button/rux-push-button.tsx
+++ b/packages/web-components/src/components/rux-push-button/rux-push-button.tsx
@@ -65,7 +65,7 @@ export class RuxPushButton {
      */
     @Prop({ reflect: true }) size?: 'small' | 'medium' | 'large'
     /**
-     * Fired when an alteration to the input's value is committed by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
+     * Fired when an alteration to the input's value is committed by the user and emits the value on the event.detail - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
      */
     @Event({ eventName: 'ruxchange' }) ruxChange!: EventEmitter
     /**

--- a/packages/web-components/src/components/rux-radio-group/rux-radio-group.tsx
+++ b/packages/web-components/src/components/rux-radio-group/rux-radio-group.tsx
@@ -67,7 +67,7 @@ export class RuxRadioGroup implements FormFieldInterface {
     @Prop({ attribute: 'error-text' }) errorText?: string
 
     /**
-     * Fired when the value of the input changes - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
+     * Fired when the value of the input changes and emits that value on the event.detail. - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
      */
     @Event({ eventName: 'ruxchange' }) ruxChange!: EventEmitter<any>
 

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
@@ -41,7 +41,7 @@ export class RuxSegmentedButton {
     @Prop({ reflect: true }) disabled: boolean = false
 
     /**
-     * Emitted when the value property has changed.
+     * Fires when the value property has changed and emits that value on the event.detail.
      */
     @Event({ eventName: 'ruxchange' })
     ruxChange!: EventEmitter

--- a/packages/web-components/src/components/rux-switch/rux-switch.tsx
+++ b/packages/web-components/src/components/rux-switch/rux-switch.tsx
@@ -54,7 +54,7 @@ export class RuxSwitch {
     @Prop() label?: string
 
     /**
-     * Fired when the value of the input changes - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
+     * Fired when the value of the input changes and emits that value on the event.detail. - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
      */
     @Event({ eventName: 'ruxchange' }) ruxChange!: EventEmitter
 

--- a/packages/web-components/src/components/rux-tabs/rux-tab-panels/rux-tab-panels.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tab-panels/rux-tab-panels.tsx
@@ -34,7 +34,7 @@ export class RuxTabPanels {
     }
 
     /**
-     * Emits a list of the Tab Panels that have been passed in
+     * Emits a list of the Tab Panels on the event.detail which have been passed in
      */
     @Event({ eventName: 'ruxregisterpanels' })
     ruxRegisterPanels!: EventEmitter<HTMLRuxTabPanelsElement[]>

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
@@ -56,7 +56,7 @@ export class RuxTabs {
     }
 
     /**
-     * Fires whenever a new tab is selected, and emits the selected tab.
+     * Fires whenever a new tab is selected, and emits the selected tab on the event.detail.
      */
     @Event({ eventName: 'ruxselected' }) ruxSelected!: EventEmitter
 

--- a/packages/web-components/src/components/rux-timeline/rux-time-region/rux-time-region.tsx
+++ b/packages/web-components/src/components/rux-timeline/rux-time-region/rux-time-region.tsx
@@ -56,7 +56,7 @@ export class RuxTimeRegion {
     @Prop() timezone = 'UTC'
 
     /**
-     * @internal - Emitted when the start or end date changes so that it's parent Track can update the Time Region's position.
+     * @internal - Emitted on the event.detail when the start or end date changes so that it's parent Track can update the Time Region's position.
      */
     @Event({
         eventName: 'ruxtimeregionchange',

--- a/packages/web-components/src/components/rux-tree-node/rux-tree-node.tsx
+++ b/packages/web-components/src/components/rux-tree-node/rux-tree-node.tsx
@@ -42,19 +42,19 @@ export class RuxTreeNode {
     @Prop({ mutable: true, reflect: true }) selected = false
 
     /**
-     * Emit when user selects a tree node
+     * Fires when the user selects a tree node and emits the node's id on the event.detail.
      */
     @Event({ eventName: 'ruxtreenodeselected' })
     ruxTreeNodeSelected!: EventEmitter<string>
 
     /**
-     * Emit when user expands a tree node
+     * Fires when the user expands a tree node and emits the node's id on the event.detail.
      */
     @Event({ eventName: 'ruxtreenodeexpanded' })
     ruxTreeNodeExpanded!: EventEmitter<string>
 
     /**
-     * Emit when user collapses a tree node
+     * Fire when the user collapses a tree node and emits the node's id on the event.detail.
      */
     @Event({ eventName: 'ruxtreenodecollapsed' })
     ruxTreeNodeCollapsed!: EventEmitter<string>


### PR DESCRIPTION
## Brief Description

Update all event comments which emit data when fired to look for that data on the event.detail

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4543

## Related Issue

## General Notes

## Motivation and Context

This change is help devs understand where data is emitted when an event is fired which include data.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
