### PR TITLE
Km notification display none

### DIFF
--- a/packages/web-components/src/components/rux-notification/rux-notification.scss
+++ b/packages/web-components/src/components/rux-notification/rux-notification.scss
@@ -17,7 +17,7 @@
 }
 
 :host([open]) {
-    display: block;
+    display: contents;
 }
 :host(:not([open])) {
     display: none;

--- a/packages/web-components/src/components/rux-notification/rux-notification.scss
+++ b/packages/web-components/src/components/rux-notification/rux-notification.scss
@@ -14,11 +14,13 @@
     * @prop --height: the Notification's height
     */
     --height: var(--spacing-20); // 80px;
+}
 
+:host([open]) {
     display: block;
-    opacity: 1;
-    transition: all 0.3s ease-out;
-    transform: scaleY(1);
+}
+:host(:not([open])) {
+    display: none;
 }
 
 .rux-notification-banner {
@@ -28,15 +30,9 @@
     border-radius: var(--notification-banner-radius-outer);
     background: var(--notification-banner-color-border);
     width: 100%;
-    transition: height 0.3s ease;
     box-sizing: border-box;
     min-height: var(--height);
 }
-
-// :host(:not([open])) {
-//     transform-origin: top;
-//     transform: scaleY(0);
-// }
 
 .rux-notification-banner__inner {
     display: flex;

--- a/packages/web-components/src/components/rux-notification/rux-notification.tsx
+++ b/packages/web-components/src/components/rux-notification/rux-notification.tsx
@@ -9,7 +9,6 @@ import {
     Element,
     Watch,
     State,
-    Listen,
 } from '@stencil/core'
 import { hasSlot } from '../../utils/utils'
 import { Status, StatusSymbol } from '../../common/commonTypes.module'
@@ -33,7 +32,6 @@ export class RuxNotification {
     @Element() el!: HTMLRuxNotificationElement
 
     @State() hasPrefixSlot = false
-    @State() bannerHeight: number = this.el.offsetHeight
     /**
      *  Set to true to display the Banner and begin countdown to close (if a close-after Number value is provided).
      */
@@ -85,28 +83,9 @@ export class RuxNotification {
         }
     }
 
-    //adds/changes height on rux-notification so that close animation can work based on height of inner banner
-    @Listen('resize', { target: 'window' })
-    handleResize() {
-        if (this.el && this.el.shadowRoot) {
-            const banner = this.el.shadowRoot.querySelector<HTMLElement>(
-                '.rux-notification-banner'
-            )?.offsetHeight
-            if (banner && banner != this.bannerHeight) {
-                this.bannerHeight = banner
-                this.el.style.height = `${banner}px`
-            }
-        }
-    }
-
     connectedCallback() {
         this._handleSlotChange = this._handleSlotChange.bind(this)
         this._updated()
-    }
-
-    //set initial height (for close animation)
-    componentDidLoad() {
-        this.el.style.height = `${this.el.offsetHeight}px`
     }
 
     private _updated() {
@@ -117,18 +96,10 @@ export class RuxNotification {
         }
     }
 
-    closeBannerTransition() {
-        this.el.style.opacity = `0`
-        this.el.style.height = `0px`
-        this.el.style.transform = 'scaleY(0)'
-        this.el.style.transformOrigin = 'top'
-    }
-
     private _onClick() {
         if (this._timeoutRef) {
             clearTimeout(this._timeoutRef)
         }
-        this.closeBannerTransition()
         this.open = false
     }
 

--- a/packages/web-components/src/components/rux-notification/test/__snapshots__/rux-notification.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-notification/test/__snapshots__/rux-notification.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`rux-notification renders 1`] = `
-<rux-notification message="hello there" open="" style="height: undefinedpx;">
+<rux-notification message="hello there" open="">
   <mock:shadow-root>
     <div class="rux-notification-banner rux-notification-banner--large rux-notification-banner--open">
       <div class="rux-notification-banner__inner" part="container">

--- a/packages/web-components/src/components/rux-notification/test/index.html
+++ b/packages/web-components/src/components/rux-notification/test/index.html
@@ -249,7 +249,7 @@
         </ftl-belt> -->
         <section>
             <h1>Notification testing</h1>
-            <rux-notification open status="normal">
+            <rux-notification open status="normal" id="animated">
                 Notification banner
                 <a href="#" style="margin-left: 8px">Link</a>
             </rux-notification>
@@ -260,7 +260,7 @@
                 in voluptatem ea dolor quas, distinctio nobis esse praesentium
                 necessitatibus minus cumque corporis?
             </p>
-            <rux-notification open status="normal" small>
+            <rux-notification open status="normal" small id="animated">
                 Notification banner
                 <a href="#" style="margin-left: 8px">Link</a>
             </rux-notification>
@@ -303,7 +303,7 @@
                 in voluptatem ea dolor quas, distinctio nobis esse praesentium
                 necessitatibus minus cumque corporis?
             </p>
-            <rux-notification open status="critical" small wrap>
+            <rux-notification open status="critical" small wrap id="animated">
                 <p>
                     Notification banner Lorem ipsum dolor sit amet consectetur,
                     adipisicing elit. Voluptas velit incidunt inventore numquam
@@ -313,6 +313,69 @@
                     <a href="#" style="margin-left: 8px">Link</a>
                 </p>
             </rux-notification>
+            <p>This last one is animated from outside the shadow dom</p>
+            <rux-button id="toggle" onclick="toggleAnimated()"
+                >Toggle Animated</rux-button
+            >
         </section>
+        <style>
+            #animated[open] {
+                display: block;
+                opacity: 1;
+                height: auto;
+            }
+            #animated {
+                display: block;
+                opacity: 0;
+                transition: all 0.3s linear;
+                overflow: hidden;
+                animation-name: collapse;
+                animation-duration: 4s;
+            }
+            #animated:not([open]) {
+                height: 0px !important;
+            }
+
+            @keyframes collapse {
+                0% {
+                    height: auto;
+                }
+                50% {
+                    height: 50%;
+                }
+                99% {
+                    height: 0;
+                }
+                100% {
+                    display: none;
+                }
+            }
+        </style>
+
+        <script>
+            const notifications = document.querySelectorAll('#animated')
+            console.log(notifications)
+            const myObserver = new ResizeObserver((entries) => {
+                for (let entry of entries) {
+                    console.log(entry.target.scrollHeight)
+                    if (entry.target.hasAttribute('open', '')) {
+                        entry.target.style.height = 'auto'
+                        // console.log(entry.contentRect.height)
+                        entry.target.style.height = `${entry.target.scrollHeight}px`
+                    }
+                }
+            })
+            notifications.forEach((notification) => {
+                myObserver.observe(notification)
+            })
+
+            function toggleAnimated() {
+                notifications.forEach((notification) => {
+                    notification.hasAttribute('open')
+                        ? notification.removeAttribute('open')
+                        : notification.setAttribute('open', '')
+                })
+            }
+        </script>
     </body>
 </html>


### PR DESCRIPTION
## Brief Description

Ok, so this is a request to merge into the rux notification changes branch. It removes the animation stuff from <rux-notification>. It just does a display:block, display:none to the host on open/close.

I've also added a proof of concept animation to the bottom of the test page in rux-notification to show that it is possible to add animation. I didn't end up needing to add a part for it but the animation is a LITTLE different than our current. I'm not the best at animation/transition effects so it could probably be better.

I think this branch ALSO has the solve for truncated vs wrapped but I want to merge it then test it before merging into next.

## JIRA Link
[ASTRO-4581](https://rocketcom.atlassian.net/browse/ASTRO-4581)
[ASTRO-4583](https://rocketcom.atlassian.net/browse/ASTRO-4583)

## Related Issue

## General Notes

## Motivation and Context

rux-notification is currently out of compliance as it covers content when open.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
