### PR TITLE
Light theme updates

### DIFF
--- a/.changeset/unlucky-foxes-pretend.md
+++ b/.changeset/unlucky-foxes-pretend.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": minor
+"@astrouxds/angular": minor
+"astro-website": minor
+"@astrouxds/react": minor
+---
+
+Updated light theme styles

--- a/packages/web-components/.storybook/preview-head.html
+++ b/packages/web-components/.storybook/preview-head.html
@@ -21,6 +21,10 @@
         background: var(--color-background-base-default);
     }
 
+    .sbdocs .docs-story {
+        background: var(--color-background-surface-default);
+    }
+
     .sbdocs.sbdocs-h1 {
         font-size: 2.125rem;
         font-weight: 400;
@@ -29,6 +33,11 @@
         margin-block-end: 0.67em;
         margin-inline-start: 0px;
         margin-inline-end: 0px;
+    }
+
+    .sbdocs.sbdocs-h2,
+    .sbdocs.sbdocs-h3 {
+        color: var(--color-text-primary);
     }
 
     .sbdocs.sbdocs-p {

--- a/packages/web-components/src/common/functional-components/FormFieldMessage/form-field-message.scss
+++ b/packages/web-components/src/common/functional-components/FormFieldMessage/form-field-message.scss
@@ -18,7 +18,7 @@
     -webkit-order: 3;
     order: 3;
     margin-top: 0.625rem;
-    color: var(--status-symbol-color-fill-critical);
+    color: var(--color-text-error);
     font-size: var(--font-body-2-bold-font-size);
     font-family: var(--font-body-2-bold-font-family);
     font-weight: var(--font-body-2-bold-font-weight);

--- a/packages/web-components/src/components/rux-checkbox-group/rux-checkbox-group.scss
+++ b/packages/web-components/src/components/rux-checkbox-group/rux-checkbox-group.scss
@@ -35,6 +35,6 @@
     border: 1px solid var(--checkboxgroup-border-color);
     border-radius: var(--radius-base);
     &--invalid {
-        border: 1px solid var(--status-symbol-color-fill-critical);
+        border: 1px solid var(--color-border-error);
     }
 }

--- a/packages/web-components/src/components/rux-clock/rux-clock.scss
+++ b/packages/web-components/src/components/rux-clock/rux-clock.scss
@@ -12,7 +12,7 @@
     /**
     * @prop --clock-border-color: [DEPRECATED] the border color for the clock
     */
-    --clock-border-color: var(--color-background-surface-default);
+    --clock-border-color: var(--gsb-color-background);
 
     /**
     * @prop --clock-label-color: [DEPRECATED] the label color for the clock

--- a/packages/web-components/src/components/rux-input/rux-input.scss
+++ b/packages/web-components/src/components/rux-input/rux-input.scss
@@ -30,7 +30,7 @@
     /**
     * @prop --input-invalid-border-color: [DEPRECATED] the input invalid border color
     */
-    --input-invalid-border-color: var(--status-symbol-color-fill-critical);
+    --input-invalid-border-color: var(--color-border-error);
 
     display: block;
 

--- a/packages/web-components/src/components/rux-notification/rux-notification.scss
+++ b/packages/web-components/src/components/rux-notification/rux-notification.scss
@@ -20,6 +20,7 @@
     width: 100%;
     position: absolute;
     background-color: var(--notification-banner-color-background-standby);
+    border: 1px solid var(--notification-banner-color-border-standby);
     transition: top 0.5s ease;
     box-sizing: border-box;
     font-family: var(--font-heading-5-font-family);
@@ -63,10 +64,9 @@
     padding: 1.063rem 0; //17 0
 }
 
-//TODO: When tokens are made for the icon color, replace the hard coded values below.
-
 :host([status='off']) {
     background-color: var(--notification-banner-color-background-off);
+    border-color: var(--notification-banner-color-border-off);
     rux-icon {
         color: var(--notification-banner-icon-color-fill-off);
     }
@@ -74,6 +74,7 @@
 
 :host([status='standby']) {
     background-color: var(--notification-banner-color-background-standby);
+    border-color: var(--notification-banner-color-border-standby);
     rux-icon {
         color: var(--notification-banner-icon-color-fill-standby);
     }
@@ -81,12 +82,14 @@
 
 :host([status='normal']) {
     background-color: var(--notification-banner-color-background-normal);
+    border-color: var(--notification-banner-color-border-normal);
     rux-icon {
         color: var(--notification-banner-icon-color-fill-normal);
     }
 }
 :host([status='caution']) {
     background-color: var(--notification-banner-color-background-caution);
+    border-color: var(--notification-banner-color-border-caution);
     rux-icon {
         color: var(--notification-banner-icon-color-fill-caution);
     }
@@ -94,12 +97,14 @@
 
 :host([status='serious']) {
     background-color: var(--notification-banner-color-background-serious);
+    border-color: var(--notification-banner-color-border-serious);
     rux-icon {
         color: var(--notification-banner-icon-color-fill-serious);
     }
 }
 :host([status='critical']) {
     background-color: var(--notification-banner-color-background-critical);
+    border-color: var(--notification-banner-color-border-critical);
     rux-icon {
         color: var(--notification-banner-icon-color-fill-critical);
     }

--- a/packages/web-components/src/components/rux-push-button/rux-push-button.scss
+++ b/packages/web-components/src/components/rux-push-button/rux-push-button.scss
@@ -18,9 +18,9 @@
     --pushbutton-selected-border-color: var(--color-palette-green-500);
 
     /** @prop --pushbutton-selected-text-color: [DEPRECATED] the Push Button text color when checked */
-    --pushbutton-selected-text-color: var(--color-text-inverse);
+    --pushbutton-selected-text-color: var(--color-text-default);
 
-    --pushbutton-selected-hover-text-color: var(--color-text-inverse);
+    --pushbutton-selected-hover-text-color: var(--color-text-default);
 
     margin: 0 2px;
     -webkit-user-select: none;
@@ -60,7 +60,7 @@
                 color: var(--color-background-interactive-hover);
                 border-color: var(--color-background-interactive-hover);
                 rux-icon {
-                    color: var(--color-background-interactive-hover);
+                    color: var(--pushbutton-selected-hover-text-color);
                 }
             }
 

--- a/packages/web-components/src/components/rux-radio-group/rux-radio-group.scss
+++ b/packages/web-components/src/components/rux-radio-group/rux-radio-group.scss
@@ -27,7 +27,7 @@
     border-radius: var(--radius-base);
 }
 .rux-radio-group--invalid {
-    border: 1px solid var(--status-symbol-color-fill-critical);
+    border: 1px solid var(--color-border-error);
 }
 
 .rux-label {

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
@@ -13,7 +13,7 @@
 
     /** @prop --segmented-button-hover-background-color: [DEPRECATED] Segmented button hover background color */
     --segmented-button-hover-background-color: var(
-        --color-background-base-hover
+        --color-background-surface-hover
     );
 
     /** @prop --segmented-button-hover-text-color: [DEPRECATED] Segmented button hover text color */

--- a/packages/web-components/src/components/rux-select/rux-select.scss
+++ b/packages/web-components/src/components/rux-select/rux-select.scss
@@ -65,9 +65,7 @@
     --select-menu-border-focus-color: var(--color-background-interactive-hover);
 
     /** @prop --select-menu-invalid-border-color: [DEPRECATED] Border Color of the Invalid Select Input */
-    --select-menu-invalid-border-color: var(
-        --status-symbol-color-fill-critical
-    );
+    --select-menu-invalid-border-color: var(--color-border-error);
 
     /** @prop --select-menu-text-color: [DEPRECATED] Text Color of the Select Input */
     --select-menu-text-color: var(--color-background-interactive-default);

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -15,7 +15,7 @@
     --textarea-background-color: var(--color-background-base-default);
 
     /** @prop --textarea-invalid-border-color: Border color while in an invalid state */
-    --textarea-invalid-border-color: var(--status-symbol-color-fill-critical);
+    --textarea-invalid-border-color: var(--color-border-error);
 
     /**
      * @prop --textarea-focus-border-color: [DEPRECATED] Border color while in a focused state

--- a/packages/web-components/src/components/rux-tree-node/rux-tree-node.scss
+++ b/packages/web-components/src/components/rux-tree-node/rux-tree-node.scss
@@ -60,7 +60,7 @@
 }
 
 :host([aria-selected='true']) {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='5' height='33' viewBox='0 0 5 33' fill='none'%3E%3Crect width='5' height='33' fill='%234DACFF'/%3E%3C/svg%3E%0A");
+    background-image: var(--tree-node-border-left-selected);
     background-repeat: no-repeat;
     .parent {
         &::after {

--- a/packages/web-components/src/components/rux-tree-node/rux-tree-node.scss
+++ b/packages/web-components/src/components/rux-tree-node/rux-tree-node.scss
@@ -142,6 +142,7 @@
     &:hover {
         color: var(--tree-hover-text-color);
         background: var(--tree-hover-background-color);
+        --tree-accent-color: var(--tree-node-arrow-color-fill-hover);
     }
 }
 

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -21,6 +21,25 @@
     );
 
     --tree-node-border-left-selected: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='5' height='33' viewBox='0 0 5 33' fill='none'%3E%3Crect width='5' height='33' fill='%234DACFF'/%3E%3C/svg%3E%0A"); // interactive-default
+
+    --notification-banner-color-border-off: var(
+        --notification-banner-color-background-off
+    );
+    --notification-banner-color-border-standby: var(
+        --notification-banner-color-background-standby
+    );
+    --notification-banner-color-border-normal: var(
+        --notification-banner-color-background-normal
+    );
+    --notification-banner-color-border-caution: var(
+        --notification-banner-color-background-caution
+    );
+    --notification-banner-color-border-serious: var(
+        --notification-banner-color-background-serious
+    );
+    --notification-banner-color-border-critical: var(
+        --notification-banner-color-background-critical
+    );
 }
 
 .light-theme {
@@ -29,4 +48,11 @@
     --tree-node-arrow-color-fill-hover: var(--color-text-inverse);
 
     --tree-node-border-left-selected: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='5' height='33' viewBox='0 0 5 33' fill='none'%3E%3Crect width='5' height='33' fill='%23005A8F'/%3E%3C/svg%3E%0A"); // interactive-muted
+
+    --notification-banner-color-border-standby: var(--color-palette-grey-900);
+    --notification-banner-color-border-standby: var(--color-palette-cyan-900);
+    --notification-banner-color-border-normal: var(--color-palette-green-900);
+    --notification-banner-color-border-caution: var(--color-palette-yellow-900);
+    --notification-banner-color-border-serious: var(--color-palette-orange-900);
+    --notification-banner-color-border-critical: var(--color-palette-red-900);
 }

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -15,8 +15,14 @@
   */
     --spacing-input-label-top: 0.375rem;
     --spacing-input-label-left: 0.625rem; //10px;
+
+    --tree-node-arrow-color-fill-hover: var(
+        --color-background-interactive-default
+    );
 }
 
 .light-theme {
     --status-symbols: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAAAgCAMAAABzRoe3AAAA81BMVEUAAABaPhVcDwE7CQA6gJIAAAAATQAkTlsATgBcPxYrHAciGgkAAABcPxU0coUARgAxNTgnU2IoV2YzNjoAUgAtYXEzODovZngAUQAAUAAwNDg0dIk2d4sAOgAjKCgAGAAADQA+hJVZPBRcPxb62AAA4gD/rz1VSQBk2f//KgQiSldXDgEATQCOmqNXOxQwNDdoRhiGWx+tHAJiEAFZw+b1KAMAywDlnTb5qjv7rDzpnzdMpcNJn7xFlrGMmKGEj5g4eY82d4xxe4IyboIwaHskT15GTFEA2gAArAAAnAAAfgAAfABg0vddyu5cZGpg0fbOjTE6oyFAAAAAJHRSTlMA7cc4Kgj9+vbBJB4GypVn9vPu5t/Y18O8n4B/ckY6FRMdmtlkVn4PAAACq0lEQVRYw+2YaVPaUBSGqWbTWsK+b9pC6ek1lypGW1T2RUDb//9rmpsm3Nyc1DQfOhMc3k/cyUzmfeY5BxISh+xXzi7eJ/Y5ZyfGu30msPobQQSf/5KEmKZeymlarqQ3g28vJfMZVc3kk1LUYkdfA3OE+/duv3GCaACtskKcKOVWQP0i7FKMiHAcDHAc0L9zxwgQwKeAiAB1jZD1ylwuzdWaEK3u71BTAUaD/nbbH4wA1FpUBVdffLliAnD/DieIBKArZGO2nZgboujiLZIA437XSX8MkIyo4PpG7H9zzQTg/pwgEkBdIU9tT56IIjioATx0PXkAqEVWgAXg/pwgEkBLY/1FAq3lmX+V9RcJVLwHcqWQShUqcpgCLgD35wRRAMpk0/ZlQ8r8BkUY27XvZ/P57N7+OIaiv2QjS+1kG2EKuADcHxOEAzQVYvoBTKI0dwIA2Pw/T8HO9JntAYDk60/pYjIcThaUNkIUcAG4PyYIB9DJuo2yJjrf4FHXyhTSVUmqpmHKTiPfHstZ+vJ4aeXxhWblYAVYAO6PCcIBSmSFAVak5F7Pw4DND6TP2ek8DWyKBpAXClbogvVnBAtaCVaABeD+mCAcIMcmCM9Qzr2esSdoBtU/xyrM7BnKCAULdHLpZEILr2wBEnBhGL86OHc94+M/AmhkiQGWRHOvq7C1Gs/doZdgbh23oAr9UnToAgxp6pUvIrQB8gej9wP1/24ZOP2fAD+jAHAFXAAmwP1jNUK2Ai4AE+D+sVpiRwEXgAhQ/3h9jboKuABMIPaP1w8ZV8AFIAKhf8weJXYKBAGIgPeP2cMcVyAIwARu/7g9TnMFggBM4PSP2wuNR4EgABPc2v1j90rpUSAIwAQG6x+7l3qvAkEAJmD94/e3ileBIAATnJwmDjnkTeU3PTFjExFNx+YAAAAASUVORK5CYII=');
+
+    --tree-node-arrow-color-fill-hover: var(--color-text-inverse);
 }

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -40,6 +40,9 @@
     --notification-banner-color-border-critical: var(
         --notification-banner-color-background-critical
     );
+
+    --color-border-error: var(--color-palette-red-500);
+    --color-text-error: var(--color-palette-red-500);
 }
 
 .light-theme {
@@ -55,4 +58,7 @@
     --notification-banner-color-border-caution: var(--color-palette-yellow-900);
     --notification-banner-color-border-serious: var(--color-palette-orange-900);
     --notification-banner-color-border-critical: var(--color-palette-red-900);
+
+    --color-border-error: var(--color-palette-red-700);
+    --color-text-error: var(--color-palette-red-700);
 }

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -19,10 +19,14 @@
     --tree-node-arrow-color-fill-hover: var(
         --color-background-interactive-default
     );
+
+    --tree-node-border-left-selected: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='5' height='33' viewBox='0 0 5 33' fill='none'%3E%3Crect width='5' height='33' fill='%234DACFF'/%3E%3C/svg%3E%0A"); // interactive-default
 }
 
 .light-theme {
     --status-symbols: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAAAgCAMAAABzRoe3AAAA81BMVEUAAABaPhVcDwE7CQA6gJIAAAAATQAkTlsATgBcPxYrHAciGgkAAABcPxU0coUARgAxNTgnU2IoV2YzNjoAUgAtYXEzODovZngAUQAAUAAwNDg0dIk2d4sAOgAjKCgAGAAADQA+hJVZPBRcPxb62AAA4gD/rz1VSQBk2f//KgQiSldXDgEATQCOmqNXOxQwNDdoRhiGWx+tHAJiEAFZw+b1KAMAywDlnTb5qjv7rDzpnzdMpcNJn7xFlrGMmKGEj5g4eY82d4xxe4IyboIwaHskT15GTFEA2gAArAAAnAAAfgAAfABg0vddyu5cZGpg0fbOjTE6oyFAAAAAJHRSTlMA7cc4Kgj9+vbBJB4GypVn9vPu5t/Y18O8n4B/ckY6FRMdmtlkVn4PAAACq0lEQVRYw+2YaVPaUBSGqWbTWsK+b9pC6ek1lypGW1T2RUDb//9rmpsm3Nyc1DQfOhMc3k/cyUzmfeY5BxISh+xXzi7eJ/Y5ZyfGu30msPobQQSf/5KEmKZeymlarqQ3g28vJfMZVc3kk1LUYkdfA3OE+/duv3GCaACtskKcKOVWQP0i7FKMiHAcDHAc0L9zxwgQwKeAiAB1jZD1ylwuzdWaEK3u71BTAUaD/nbbH4wA1FpUBVdffLliAnD/DieIBKArZGO2nZgboujiLZIA437XSX8MkIyo4PpG7H9zzQTg/pwgEkBdIU9tT56IIjioATx0PXkAqEVWgAXg/pwgEkBLY/1FAq3lmX+V9RcJVLwHcqWQShUqcpgCLgD35wRRAMpk0/ZlQ8r8BkUY27XvZ/P57N7+OIaiv2QjS+1kG2EKuADcHxOEAzQVYvoBTKI0dwIA2Pw/T8HO9JntAYDk60/pYjIcThaUNkIUcAG4PyYIB9DJuo2yJjrf4FHXyhTSVUmqpmHKTiPfHstZ+vJ4aeXxhWblYAVYAO6PCcIBSmSFAVak5F7Pw4DND6TP2ek8DWyKBpAXClbogvVnBAtaCVaABeD+mCAcIMcmCM9Qzr2esSdoBtU/xyrM7BnKCAULdHLpZEILr2wBEnBhGL86OHc94+M/AmhkiQGWRHOvq7C1Gs/doZdgbh23oAr9UnToAgxp6pUvIrQB8gej9wP1/24ZOP2fAD+jAHAFXAAmwP1jNUK2Ai4AE+D+sVpiRwEXgAhQ/3h9jboKuABMIPaP1w8ZV8AFIAKhf8weJXYKBAGIgPeP2cMcVyAIwARu/7g9TnMFggBM4PSP2wuNR4EgABPc2v1j90rpUSAIwAQG6x+7l3qvAkEAJmD94/e3ileBIAATnJwmDjnkTeU3PTFjExFNx+YAAAAASUVORK5CYII=');
 
     --tree-node-arrow-color-fill-hover: var(--color-text-inverse);
+
+    --tree-node-border-left-selected: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='5' height='33' viewBox='0 0 5 33' fill='none'%3E%3Crect width='5' height='33' fill='%23005A8F'/%3E%3C/svg%3E%0A"); // interactive-muted
 }

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -52,7 +52,7 @@
 
     --tree-node-border-left-selected: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='5' height='33' viewBox='0 0 5 33' fill='none'%3E%3Crect width='5' height='33' fill='%23005A8F'/%3E%3C/svg%3E%0A"); // interactive-muted
 
-    --notification-banner-color-border-standby: var(--color-palette-grey-900);
+    --notification-banner-color-border-off: var(--color-palette-grey-900);
     --notification-banner-color-border-standby: var(--color-palette-cyan-900);
     --notification-banner-color-border-normal: var(--color-palette-green-900);
     --notification-banner-color-border-caution: var(--color-palette-yellow-900);

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -61,4 +61,6 @@
 
     --color-border-error: var(--color-palette-red-700);
     --color-text-error: var(--color-palette-red-700);
+
+    --color-border-interactive-muted: var(--color-palette-darkblue-400);
 }

--- a/packages/web-components/src/stories/notification.stories.mdx
+++ b/packages/web-components/src/stories/notification.stories.mdx
@@ -130,7 +130,7 @@ export const AllVariants = () => html`
     style="display: flex; flex-flow: column; justify-content: center; margin:20px;"
 >
     <div
-        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+        style="display: flex; position: relative; height: 70px; margin-bottom: 20px; overflow: hidden;"
     >
         <rux-notification
             open
@@ -139,7 +139,7 @@ export const AllVariants = () => html`
         ></rux-notification>
     </div>
     <div
-        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+        style="display: flex; position: relative; height: 70px; margin-bottom: 20px; overflow: hidden;"
     >
         <rux-notification
             open
@@ -148,7 +148,7 @@ export const AllVariants = () => html`
         ></rux-notification>
     </div>
     <div
-        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+        style="display: flex; position: relative; height: 70px; margin-bottom: 20px; overflow: hidden;"
     >
         <rux-notification
             open
@@ -157,7 +157,7 @@ export const AllVariants = () => html`
         ></rux-notification>
     </div>
     <div
-        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+        style="display: flex; position: relative; height: 70px; margin-bottom: 20px; overflow: hidden;"
     >
         <rux-notification
             open
@@ -166,7 +166,7 @@ export const AllVariants = () => html`
         ></rux-notification>
     </div>
     <div
-        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+        style="display: flex; position: relative; height: 70px; margin-bottom: 20px; overflow: hidden;"
     >
         <rux-notification
             open
@@ -175,7 +175,7 @@ export const AllVariants = () => html`
         ></rux-notification>
     </div>
     <div
-        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+        style="display: flex; position: relative; height: 70px; margin-bottom: 20px; overflow: hidden;"
     >
         <rux-notification
             open
@@ -184,7 +184,7 @@ export const AllVariants = () => html`
         ></rux-notification>
     </div>
     <div
-        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+        style="display: flex; position: relative; height: 70px; margin-bottom: 20px; overflow: hidden;"
     >
         <rux-notification
             open
@@ -194,7 +194,7 @@ export const AllVariants = () => html`
         ></rux-notification>
     </div>
     <div
-        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+        style="display: flex; position: relative; height: 70px; margin-bottom: 20px; overflow: hidden;"
     >
         <rux-notification
             open
@@ -204,7 +204,7 @@ export const AllVariants = () => html`
         ></rux-notification>
     </div>
     <div
-        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+        style="display: flex; position: relative; height: 70px; margin-bottom: 20px; overflow: hidden;"
     >
         <rux-notification
             open
@@ -214,7 +214,7 @@ export const AllVariants = () => html`
         ></rux-notification>
     </div>
     <div
-        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+        style="display: flex; position: relative; height: 70px; margin-bottom: 20px; overflow: hidden;"
     >
         <rux-notification
             open
@@ -224,7 +224,7 @@ export const AllVariants = () => html`
         ></rux-notification>
     </div>
     <div
-        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+        style="display: flex; position: relative; height: 70px; margin-bottom: 20px; overflow: hidden;"
     >
         <rux-notification
             open
@@ -234,7 +234,7 @@ export const AllVariants = () => html`
         ></rux-notification>
     </div>
     <div
-        style="display: flex; position: relative; height: 68px; margin-bottom: 20px; overflow: hidden;"
+        style="display: flex; position: relative; height: 70px; margin-bottom: 20px; overflow: hidden;"
     >
         <rux-notification
             open


### PR DESCRIPTION
## Brief Description

implements recent 6.0 light theme changes 

* tree node's arrow fill color on hover
* tree node's border left when selected
* fixes regression in segmented button background color on hover
* push button's text color 
* push button's icon color 
* adds borders around notification 
* fixes regression in clock border color
* swaps red-500 with 700 for errors 


## JIRA Link

ASTRO-4594

## Issues and Limitations

6.0 is already using a subset of the new 7.0 naming convention. Some of these changes require new tokens, but instead of publishing a whole separate, short-lived release of our 6.0-flavored tokens, I just created the ones that we needed locally in the vars.scss. 

Anything that uses an svg as a background image (FormFieldMessage error icon and checkbox) doesn't theme switch bc we can't use css custom props when an svg is inlined, as far as I could figure out. I have a hacky work around for tree node, but I'll address the others in a separate PR. 

New VRTs will need to be generated 

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
