### PR TITLE
Mj 4605 placeholder text

### DIFF
--- a/.changeset/late-cheetahs-agree.md
+++ b/.changeset/late-cheetahs-agree.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Fixes the text color of rux-input's placeholder text.

--- a/packages/web-components/src/components/rux-input/rux-input.scss
+++ b/packages/web-components/src/components/rux-input/rux-input.scss
@@ -65,6 +65,9 @@
         cursor: pointer;
         background-position: center;
     }
+    input::placeholder {
+        color: var(--color-text-placeholder);
+    }
     .rux-input {
         input {
             border: none;
@@ -144,9 +147,6 @@
         }
         &--invalid:hover {
             border: 1px solid var(--input-invalid-border-color);
-        }
-        &::placeholder {
-            color: var(--color-text-placeholder);
         }
         .rux-input-prefix,
         .rux-input-suffix {


### PR DESCRIPTION
## Brief Description

Updates rux-input scss to apply the correct placeholder text color. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4605

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/738
## General Notes

## Motivation and Context

input's placeholder text was not the correct color. Refactored the specificity of `::placeholder` a bit to fix this.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
