### PR TITLE
feat: restore before thumb prop

### DIFF
--- a/packages/astro-uxds/_content/migration.md
+++ b/packages/astro-uxds/_content/migration.md
@@ -692,7 +692,6 @@ The default `size` property is now `medium` instead of `small`.
   - --slider-value-percent
   - --slider-top
   - --slider-track-height
-  - --slider-track-before-thumb-height
 
 **Resolution:** View the CSS Custom Properties Migration doc for more details.
 

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -208,7 +208,6 @@ Our /dist/custom-elements build has been removed in favor of a faster treeshakea
     -   --slider-value-percent
     -   --slider-top
     -   --slider-track-height
-    -   --slider-track-before-thumb-height
 
 ### Switch
 
@@ -343,6 +342,10 @@ Our /dist/custom-elements build has been removed in favor of a faster treeshakea
 -   Internal styles have been refactored to use spacing design tokens.
 
 ### Classification Marking
+
+-   Internal styles have been refactored to use spacing design tokens.
+
+### Dialog
 
 -   Internal styles have been refactored to use spacing design tokens.
 

--- a/packages/web-components/CSS-Prop-Migration.md
+++ b/packages/web-components/CSS-Prop-Migration.md
@@ -118,7 +118,6 @@ If you have a strong, immediate use case, open an issue describing the removed c
 -   --slider-value-percent
 -   --slider-top
 -   --slider-track-height
--   --slider-track-before-thumb-height
 -   --switch-background-color
 -   --switch-hover-on-color
 -   --switch-hover-off-color

--- a/packages/web-components/src/components/rux-slider/rux-slider.scss
+++ b/packages/web-components/src/components/rux-slider/rux-slider.scss
@@ -1,11 +1,14 @@
 @use '../../common/functional-components/FormFieldMessage/form-field-message.scss';
 
 :host {
-    --slider-thumb-size: calc(var(--spacing-4) + var(--spacing-1)); //20
-    --slider-value-percent: 50%;
-    --slider-top: calc(var(--slider-thumb-size) / -2.4);
+    /**
+     * @prop --slider-track-before-thumb-height: the height of the track before the thumb
+     */
     --slider-track-before-thumb-height: var(--spacing-1); //4
-    --slider-tick-padding-top: var(--spacing-0);
+
+    --_slider-thumb-size: calc(var(--spacing-4) + var(--spacing-1)); //20
+    --_slider-value-percent: 50%;
+    --_slider-top: calc(var(--_slider-thumb-size) / -2.4);
 
     display: flex;
     flex-grow: 1;
@@ -52,7 +55,7 @@
 
     #steplist {
         display: grid;
-        padding: var(--spacing-0) calc(var(--slider-thumb-size) / 2); //center first and last dot on thumb at start and end
+        padding: var(--spacing-0) calc(var(--_slider-thumb-size) / 2); //center first and last dot on thumb at start and end
         cursor: default;
 
         .tick-label {
@@ -133,15 +136,15 @@ input[type='range']:focus {
             transparent 100%
         );
     background-size: calc(
-                var(--slider-value-percent) - (var(--slider-thumb-size) / 2)
+                var(--_slider-value-percent) - (var(--_slider-thumb-size) / 2)
             )
             var(--slider-track-before-thumb-height),
-        calc(100% - var(--slider-thumb-size)) 1px,
+        calc(100% - var(--_slider-thumb-size)) 1px,
         var(--spacing-1) var(--spacing-1);
     background-repeat: no-repeat no-repeat;
-    background-position: calc(var(--slider-thumb-size) / 2),
-        calc(100% - (var(--slider-thumb-size) / 2)),
-        calc((var(--slider-thumb-size) / 2) - var(--spacing-050));
+    background-position: calc(var(--_slider-thumb-size) / 2),
+        calc(100% - (var(--_slider-thumb-size) / 2)),
+        calc((var(--_slider-thumb-size) / 2) - var(--spacing-050));
 }
 .rux-range:disabled::-webkit-slider-runnable-track {
     opacity: var(--opacity-disabled);
@@ -174,15 +177,15 @@ input[type='range']:focus {
             transparent 100%
         );
     background-size: calc(
-                var(--slider-value-percent) - (var(--slider-thumb-size) / 2)
+                var(--_slider-value-percent) - (var(--_slider-thumb-size) / 2)
             )
             var(--slider-track-before-thumb-height),
-        calc(100% - var(--slider-thumb-size)) 1px,
+        calc(100% - var(--_slider-thumb-size)) 1px,
         var(--spacing-1) var(--spacing-1);
     background-repeat: no-repeat no-repeat;
-    background-position: calc(var(--slider-thumb-size) / 2),
-        calc(100% - (var(--slider-thumb-size) / 2)),
-        calc((var(--slider-thumb-size) / 2) - var(--spacing-050));
+    background-position: calc(var(--_slider-thumb-size) / 2),
+        calc(100% - (var(--_slider-thumb-size) / 2)),
+        calc((var(--_slider-thumb-size) / 2) - var(--spacing-050));
 }
 .rux-range:disabled::-moz-range-track,
 .rux-range:disabled::-moz-range-progress {
@@ -214,7 +217,7 @@ input[type='range']:focus {
             var(--color-background-interactive-default),
             var(--color-background-interactive-default)
         );
-    background-size: var(--slider-value-percent)
+    background-size: var(--_slider-value-percent)
             var(--slider-track-before-thumb-height),
         100% 1px;
     background-repeat: no-repeat no-repeat;
@@ -236,9 +239,9 @@ input[type='range']:focus {
     -webkit-appearance: none;
     box-sizing: border-box;
     position: relative;
-    top: var(--slider-top);
-    height: var(--slider-thumb-size);
-    width: var(--slider-thumb-size);
+    top: var(--_slider-top);
+    height: var(--_slider-thumb-size);
+    width: var(--_slider-thumb-size);
     border-radius: 100%;
     border: 2px solid var(--color-background-interactive-default);
     background-color: var(--color-background-base-default);
@@ -274,9 +277,9 @@ input[type='range']:focus {
     -moz-appearance: none;
     position: relative;
     box-sizing: border-box;
-    top: var(--slider-top);
-    height: var(--slider-thumb-size);
-    width: var(--slider-thumb-size);
+    top: var(--_slider-top);
+    height: var(--_slider-thumb-size);
+    width: var(--_slider-thumb-size);
     border-radius: 100%;
     border: 2px solid var(--color-background-interactive-default);
     background-color: var(--color-background-base-default);
@@ -301,9 +304,9 @@ input:-moz-focusring {
 /* Thumb -> Ms */
 .rux-range::-ms-thumb {
     position: relative;
-    top: var(--slider-top);
-    height: var(--slider-thumb-size);
-    width: var(--slider-thumb-size);
+    top: var(--_slider-top);
+    height: var(--_slider-thumb-size);
+    width: var(--_slider-thumb-size);
     border-radius: 100%;
     border: 2px solid var(--color-background-interactive-default);
     background-color: var(--color-background-base-default);


### PR DESCRIPTION
## Brief Description

Restores the before thumb height css custom prop on slider. 

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
