### PR TITLE
Km 3853 rux log update spacing

### DIFF
--- a/.changeset/angry-houses-suffer.md
+++ b/.changeset/angry-houses-suffer.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+rux-log - add spacing tokens and adjust for astro 7.0 design

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -355,6 +355,10 @@ Our /dist/custom-elements build has been removed in favor of a faster treeshakea
 -   Internal styles have been refactored to use spacing design tokens.
 -   Type=password now uses a native `button` element rather than `rux-button`.
 
+### Log
+
+-   Internal styles have been refactored to use spacing design tokens.
+
 ### Radio
 
 -   Internal styles have been refactored to use spacing design tokens.

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -12095,10 +12095,6 @@ export namespace Components {
           * The background color. Possible values include 'off', 'standby', 'normal', 'caution', 'serious' and 'critical'. See [Astro UXDS Status System](https://astrouxds.com/patterns/status-system/).
          */
         "status"?: Status;
-        /**
-          * Allows long content in a banner to wrap lines
-         */
-        "wrap": boolean;
     }
     interface RuxOption {
         /**
@@ -32476,10 +32472,6 @@ declare namespace LocalJSX {
           * The background color. Possible values include 'off', 'standby', 'normal', 'caution', 'serious' and 'critical'. See [Astro UXDS Status System](https://astrouxds.com/patterns/status-system/).
          */
         "status"?: Status;
-        /**
-          * Allows long content in a banner to wrap lines
-         */
-        "wrap"?: boolean;
     }
     interface RuxOption {
         /**

--- a/packages/web-components/src/components/rux-log/rux-log.scss
+++ b/packages/web-components/src/components/rux-log/rux-log.scss
@@ -18,11 +18,16 @@
 
 .rux-log__filter {
     margin-left: auto;
+    width: 170px;
 }
 
 rux-datetime {
-    min-width: 4.875rem; //78px;
+    min-width: calc(var(--spacing-20) - var(--spacing-050)); //78px;
     display: inline-block;
+}
+
+rux-status {
+    margin: var(--spacing-0) var(--spacing-1);
 }
 
 rux-table-header-cell {
@@ -45,6 +50,6 @@ rux-table-cell {
     width: 2000%;
     align-content: center;
     color: var(--color-text-inverse);
-    background-color: #3a87cf;
-    padding: 0.5rem;
+    background-color: var(--color-background-interactive-default);
+    padding: var(--spacing-2); //8
 }

--- a/packages/web-components/src/components/rux-log/rux-log.scss
+++ b/packages/web-components/src/components/rux-log/rux-log.scss
@@ -20,8 +20,25 @@
     margin-left: auto;
 }
 
+rux-datetime {
+    min-width: 4.875rem; //78px;
+    display: inline-block;
+}
+
 rux-table-header-cell {
     width: 1%;
+    border-width: 1px;
+    border-style: solid;
+    border-color: var(--color-background-base-default);
+    height: calc(
+        var(--spacing-10) + var(--spacing-1) - 2px
+    ); //44 height minus border
+}
+
+rux-table-cell {
+    height: calc(
+        var(--spacing-8) - var(--spacing-050) - 1px
+    ); //30 size - border
 }
 
 .rux-log__notification {

--- a/packages/web-components/src/components/rux-log/rux-log.tsx
+++ b/packages/web-components/src/components/rux-log/rux-log.tsx
@@ -64,6 +64,7 @@ export class RuxLog {
                                                     size="small"
                                                     class="rux-log__filter"
                                                     type="search"
+                                                    placeholder="Search..."
                                                     onRuxinput={(event) =>
                                                         this._setFilter(event)
                                                     }

--- a/packages/web-components/src/components/rux-log/test/__snapshots__/rux-log.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-log/test/__snapshots__/rux-log.spec.tsx.snap
@@ -16,7 +16,7 @@ exports[`rux-log renders 1`] = `
                 <rux-table-header-cell class="rux-log__header-event-cell">
                   <div class="header-event-container">
                     Event
-                    <rux-input class="rux-log__filter" size="small" type="search"></rux-input>
+                    <rux-input class="rux-log__filter" placeholder="Search..." size="small" type="search"></rux-input>
                   </div>
                 </rux-table-header-cell>
               </rux-table-header-row>

--- a/packages/web-components/src/components/rux-log/test/index.html
+++ b/packages/web-components/src/components/rux-log/test/index.html
@@ -26,14 +26,9 @@
         <rux-log></rux-log>
 
         <section>
-            <style>
-                rux-table-row::slotted(rux-table-cell:first-child) {
-                    padding-left: 8px;
-                }
-            </style>
             <h2>Figma testing</h2>
             <ftl-belt file-id="SNsCCfIiWdfvZbBilZXTbW">
-                <ftl-holster name="Big Test" node="11938:204757">
+                <ftl-holster name="Big Test" node="11938:205142">
                     <rux-log id="testing"></rux-log>
                 </ftl-holster>
             </ftl-belt>

--- a/packages/web-components/src/components/rux-log/test/index.html
+++ b/packages/web-components/src/components/rux-log/test/index.html
@@ -17,15 +17,15 @@
         <script nomodule src="/build/astro-web-components.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
-        <script
+        <!-- <script
             type="module"
             src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script>
+        ></script> -->
     </head>
     <body>
         <rux-log></rux-log>
 
-        <section>
+        <!-- <section>
             <h2>Figma testing</h2>
             <ftl-belt file-id="SNsCCfIiWdfvZbBilZXTbW">
                 <ftl-holster name="Big Test" node="11938:205142">
@@ -95,6 +95,6 @@
 
                 log.data = data
             </script>
-        </section>
+        </section> -->
     </body>
 </html>

--- a/packages/web-components/src/components/rux-log/test/index.html
+++ b/packages/web-components/src/components/rux-log/test/index.html
@@ -17,8 +17,89 @@
         <script nomodule src="/build/astro-web-components.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
+        <script
+            type="module"
+            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
+        ></script>
     </head>
     <body>
         <rux-log></rux-log>
+
+        <section>
+            <style>
+                rux-table-row::slotted(rux-table-cell:first-child) {
+                    padding-left: 8px;
+                }
+            </style>
+            <h2>Figma testing</h2>
+            <ftl-belt file-id="SNsCCfIiWdfvZbBilZXTbW">
+                <ftl-holster name="Big Test" node="11938:204757">
+                    <rux-log id="testing"></rux-log>
+                </ftl-holster>
+            </ftl-belt>
+            <script>
+                const log = document.getElementById('testing')
+                const data = [
+                    {
+                        timestamp: new Date(1663804800000),
+                        status: 'normal',
+                        message: 'Quisque in arcu quis metus gravida bibendum',
+                    },
+                    {
+                        timestamp: new Date(1663808844000),
+                        status: 'critical',
+                        message:
+                            'Nullam non felis felis. Donec tempus faucibus gravida',
+                    },
+                    {
+                        timestamp: new Date(1663839915000),
+                        status: 'normal',
+                        message: 'Aenean venenatis fringilla lorem non posuere',
+                    },
+                    {
+                        timestamp: new Date(1663886320000),
+                        status: 'standby',
+                        message:
+                            'Phasellus vulputate dolor non elit rutrum, in imperdiet augue tristique',
+                    },
+                    {
+                        timestamp: new Date(1663885342000),
+                        status: 'caution',
+                        message: 'Nullam faucibus euismod facilisis',
+                    },
+                    {
+                        timestamp: new Date(1663856520000),
+                        status: 'serious',
+                        message:
+                            'Nam sed erat et nunc dictum lacinia id non libero',
+                    },
+                    {
+                        timestamp: new Date(1663888271000),
+                        status: 'normal',
+                        message:
+                            'Aliquam at fringilla turpis. Donec pharetra molestie ultrices',
+                    },
+                    {
+                        timestamp: new Date(1663855620000),
+                        status: 'off',
+                        message:
+                            'Vivamus interdum condimentum dolor et sollicitudin',
+                    },
+                    {
+                        timestamp: new Date(1663889640000),
+                        status: 'normal',
+                        message: 'Curabitur vel viverra arcu, eu viverro odio',
+                    },
+                    {
+                        timestamp: new Date(1557503698781),
+                        status: 'standby',
+                        message:
+                            'In feugiat dui magna, a sodales lectus vestibulum in ',
+                    },
+                ]
+
+                log.data = data
+            </script>
+        </section>
     </body>
 </html>


### PR DESCRIPTION
## Brief Description

rux-log spacing changes, add spacing tokens and align with Astro 7.0 design

## JIRA Link

[ASTRO-3853](https://rocketcom.atlassian.net/browse/ASTRO-3853)

## Related Issue

## General Notes

## Motivation and Context

Part of the astro 7.0 spacing initiative!

## Issues and Limitations

I ran into a couple of issues lining up figma specs and the rux-log here. I'll do my best to document them here but if you have questions please ask!

1. This isn't exactly an issue, but I wanted to note that the table header and table body row heights are different (in figma) for rux-log than they are in rux-table even though rux-log is basically a rux-table with data in it. I've stuck to figma design here, but wanted to make a note.

2. In order to maintain simplicity, you'll notice that the log columns don't line up 100% with figma. This is because cells have 8px padding to the left and the right and the figma design doesn't account for this in the Event column message cells.

3. I noticed that the Time and Notification columns were the same width throughout figma specs so I mimicked that in the component by setting widths/margins for the content within them. If this isn't desired it is easily fixed. Same thing for the Search Input.

4. This isn't a spacing issue but I noticed that the log table body doesn't currently work the way design has it in figma. IE: if you assign a height to rux-log you don't get just the body to scroll. (In design, the table body has a styled scroll bar). This is probably something an app developer can take care of with some tweaking.. but we may want to look into how to facilitate this if it is some sort of compliance issue. It is not in the scope of this branch but it is something we may want to revisit.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
