### PR TITLE
new magnifying icon and size

### DIFF
--- a/.changeset/purple-apes-promise.md
+++ b/.changeset/purple-apes-promise.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+rux-iunput search - turn the magnifying glass around

--- a/packages/web-components/src/components/rux-input/rux-input.scss
+++ b/packages/web-components/src/components/rux-input/rux-input.scss
@@ -96,9 +96,11 @@
             -webkit-appearance: none;
             -moz-appearance: none;
             padding-left: var(--spacing-8); //32px
-            background: var(--color-background-base-default)
-                url("data:image/svg+xml,%3Csvg width='40' height='40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M35.37 26.457a15.282 15.282 0 000-21.918c-6.176-6.052-16.187-6.052-22.361 0a15.274 15.274 0 00-1.541 20.166c-.367.147-.713.37-1.014.665L.926 34.709a3.056 3.056 0 000 4.383 3.208 3.208 0 004.472 0l9.528-9.339c.352-.345.604-.753.756-1.186 6.137 3.831 14.347 3.124 19.687-2.11zM24.193 4.043c6.454 0 11.686 5.129 11.686 11.455 0 6.326-5.232 11.455-11.686 11.455-6.455 0-11.687-5.129-11.687-11.455 0-6.326 5.232-11.455 11.687-11.455z' fill='%234dacff' fill-rule='evenodd'/%3E%3C/svg%3E")
-                8px/0.975rem no-repeat;
+            background-color: var(--color-background-base-default);
+            background-image: url("data:image/svg+xml,%3Csvg width='20' height='24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M14.71 14H15.5L19.74 18.26C20.15 18.67 20.15 19.34 19.74 19.75C19.33 20.16 18.66 20.16 18.25 19.75L14 15.5V14.71L13.73 14.43C12.33 15.63 10.42 16.25 8.39002 15.91C5.61002 15.44 3.39002 13.12 3.05002 10.32C2.53002 6.09 6.09002 2.53 10.32 3.05C13.12 3.39 15.44 5.61 15.91 8.39C16.25 10.42 15.63 12.33 14.43 13.73L14.71 14ZM5.00002 9.5C5.00002 11.99 7.01002 14 9.50002 14C11.99 14 14 11.99 14 9.5C14 7.01 11.99 5 9.50002 5C7.01002 5 5.00002 7.01 5.00002 9.5Z' fill='%234dacff' fill-rule='evenodd'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: 8px center;
+            background-size: 1.05rem;
         }
         &--focused {
             box-shadow: var(--color-background-interactive-hover) 0 0 0 1px

--- a/packages/web-components/src/components/rux-input/test/index.html
+++ b/packages/web-components/src/components/rux-input/test/index.html
@@ -25,239 +25,36 @@
     </head>
 
     <body class="dark-theme">
-        <!-- <h2>Figma spacing test</h2>
-        <ftl-belt access-token="" file-id="">
-            <style>
-                #ruxInputSizingLEFT::part(help-text), #ruxInputSizingLEFT::part(error-text){
-                    display:flex;
-                    justify-content: right;
-                }
-            </style>
-            
-
-        <ftl-holster name="help and error text" node="995:2547" style="position:relative;">
-            <div style="position: absolute; top: 182px; left: 302px;">
+        <!--<h2>Figma spacing test</h2>
+        <ftl-belt access-token="" file-id="SNsCCfIiWdfvZbBilZXTbW">
+         <ftl-holster name="search small" node="41357:132326" style="position:relative;">
+            <div style="width: 170px">
                 <rux-input
-                    id="ruxInputSizing"
-                    name="ruxInput"
-                    value="Input test"
-                    size="medium"
-                    label="medium"
-                    error-text="Error text"
-                    invalid
-                ></rux-input>
-            </div>
-            <div style="position: absolute; top: 182px; left: 30px;">
-                <rux-input
-                    id="ruxInputSizing"
-                    name="ruxInput"
-                    value="Input test"
-                    label="medium"
-                    help-text="Help test"
-                ></rux-input>
-            </div>
-            <div style="position: absolute;top: 272px;left: 30px;width: 212px;">
-                <rux-input
-                    id="ruxInputSizingLEFT"
-                    name="ruxInput"
-                    value="Input test"
-                    label="medium"
-                    help-text="Help test"
-                ></rux-input>
-            </div>
-            <div style="position: absolute;top: 272px;left: 302px;width: 212px;">
-                <rux-input
-                    id="ruxInputSizingLEFT"
-                    name="ruxInput"
-                    value="Input test"
-                    label="medium"
-                    error-text="Error text"
-                    invalid
+                    type="search"
+                    size="small"
+                    placeholder="Search..."
                 ></rux-input>
             </div>
         </ftl-holster>
 
+        <ftl-holster name="search medium" node="26010:126254" style="position:relative;">
+            <div style="width: 170px">
+                <rux-input
+                    type="search"
+                    placeholder="Search..."
+                ></rux-input>
+            </div>
+        </ftl-holster>
 
-            
-            <h3>Password</h3>
-            <ftl-holster name="Small" node="26010:126009">
-                <div style="width: 170px">
-                    <rux-input
-                        type="password"
-                        placeholder="Password input"
-                        size="small"
-                    ></rux-input>
-                </div>
-            </ftl-holster>
-
-            <ftl-holster name="Medium" node="26010:126001">
-                <div style="width: 170px">
-                    <rux-input
-                        type="password"
-                        placeholder="Password input"
-                        value="Password input"
-                        size="medium"
-                    ></rux-input>
-                </div>
-            </ftl-holster>
-            <ftl-holster name="Medium Masked" node="26010:126025">
-                <div style="width: 167px">
-                    <rux-input
-                        type="password"
-                        placeholder="Reindeer Flotilla"
-                        size="medium"
-                    ></rux-input>
-                </div>
-            </ftl-holster>
-
-            <ftl-holster name="Large" node="26010:126017">
-                <div style="width: 167px">
-                    <rux-input
-                        type="password"
-                        placeholder="Reindeer Flotilla"
-                        size="large"
-                    ></rux-input>
-                </div>
-            </ftl-holster>
-        </ftl-belt>
-        <p>Small</p>
-
-        <rux-input
-            id="ruxInputSizing"
-            name="ruxInput"
-            value="Input test"
-            size="small"
-        ></rux-input>
-
-        <p>medium</p>
-
-        <rux-input
-            id="ruxInputSizing"
-            name="ruxInput"
-            value="Input test"
-            size="medium"
-        ></rux-input>
-
-        <p>large</p>
-
-        <rux-input
-            id="ruxInputSizing"
-            name="ruxInput"
-            value="Input test"
-            size="large"
-        ></rux-input>
-
-        <h3>With Icon</h3>
-        <p>small</p>
-
-        <div style="width: 200px">
-            <rux-input
-                id="ruxInputSizing"
-                name="ruxInput"
-                value="Input test"
-                size="small"
-                ><rux-icon slot="prefix" size="20px" icon="star"></rux-icon
-            ></rux-input>
-        </div>
-
-        <p>medium</p>
-
-        <div style="width: 200px">
-            <rux-input
-                id="ruxInputSizing"
-                name="ruxInput"
-                value="Input test"
-                size="medium"
-                ><rux-icon slot="prefix" size="20px" icon="star"></rux-icon
-            ></rux-input>
-        </div>
-
-        <p>large</p>
-
-        <div style="width: 194px">
-            <rux-input
-                id="ruxInputSizing"
-                name="ruxInput"
-                value="Input test"
-                size="large"
-                ><rux-icon slot="prefix" size="20px" icon="star"></rux-icon
-            ></rux-input>
-        </div>
-
-        <h3>With Icons</h3>
-        <p>small</p>
-
-        <div style="width: 200px">
-            <rux-input
-                id="ruxInputSizing"
-                name="ruxInput"
-                value="Input test"
-                size="small"
-            >
-                <rux-icon slot="prefix" size="20px" icon="star"></rux-icon>
-                <rux-icon slot="suffix" size="20px" icon="star"></rux-icon>
-            </rux-input>
-        </div>
-
-        <p>medium</p>
-
-        <div style="width: 200px">
-            <rux-input
-                id="ruxInputSizing"
-                name="ruxInput"
-                value="Input test"
-                size="medium"
-            >
-                <rux-icon slot="prefix" size="20px" icon="star"></rux-icon>
-                <rux-icon slot="suffix" size="20px" icon="star"></rux-icon>
-            </rux-input>
-        </div>
-
-        <div style="width: 200px">
-            <rux-input
-                id="ruxInputSizing"
-                name="ruxInput"
-                value="Input test"
-                size="small"
-            >
-                <rux-icon slot="suffix" size="20px" icon="star"></rux-icon>
-            </rux-input>
-        </div>
-
-        <p>large</p>
-
-        <div style="width: 194px">
-            <rux-input
-                id="ruxInputSizing"
-                name="ruxInput"
-                value="Input test"
-                size="large"
-            >
-                <rux-icon slot="prefix" size="20px" icon="star"></rux-icon>
-                <rux-icon slot="suffix" size="20px" icon="star"></rux-icon>
-            </rux-input>
-        </div>
-
-        <h3>Search</h3>
-
-        <div style="width: 200px">
-            <rux-input
-                type="search"
-                placeholder="Enter search term"
-            ></rux-input>
-        </div>
-
-        <h3>Date</h3>
-
-        <div style="width: 200px">
-            <rux-input type="date"></rux-input>
-        </div>
-
-        <h3>Time</h3>
-
-        <div style="width: 200px">
-            <rux-input type="time"></rux-input>
-        </div> -->
+        <ftl-holster name="search large" node="41357:132341" style="position:relative;">
+            <div style="width: 170px">
+                <rux-input
+                    type="search"
+                    size="large"
+                    placeholder="Search..."
+                ></rux-input>
+            </div>
+        </ftl-holster> -->
 
         <h1>Previous Tests</h1>
         <!--


### PR DESCRIPTION
## Brief Description

In <rux-input type="search"> I flipped the search icon around to align to Astro 7.0 design. I also cleaned up some of the figma testing in /test/ page

## JIRA Link

[ASTRO-4631](https://rocketcom.atlassian.net/browse/ASTRO-4631)

## Related Issue

## General Notes

## Motivation and Context

Aligns to Astro 7.0 design in figma, and also it was just driving me crazy.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
