### PR TITLE
chore: bump react-output-target, stencil, ran builds

### DIFF
--- a/packages/angular-workspace/projects/angular/src/directives/proxies-list.ts
+++ b/packages/angular-workspace/projects/angular/src/directives/proxies-list.ts
@@ -1,4 +1,7 @@
 //@ts-nocheck
+//@ts-nocheck
+//@ts-nocheck
+//@ts-nocheck
 
 import * as d from './proxies';
 

--- a/packages/react/src/react-component-lib/createComponent.tsx
+++ b/packages/react/src/react-component-lib/createComponent.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { createElement } from "react";
 
 import {
   attachProps,
+  camelToDashCase,
   createForwardRef,
   dashToPascalCase,
-  defineCustomElement,
   isCoveredByReact,
   mergeRefs,
 } from "./utils";
@@ -31,9 +31,11 @@ export const createReactComponent = <
     originalProps: StencilReactInternalProps<ElementType>,
     propsToPass: any
   ) => ExpandedPropsTypes,
-  customElement?: any
+  defineCustomElement?: () => void
 ) => {
-  defineCustomElement(tagName, customElement);
+  if (defineCustomElement !== undefined) {
+    defineCustomElement();
+  }
 
   const displayName = dashToPascalCase(tagName);
   const ReactComponent = class extends React.Component<
@@ -67,14 +69,22 @@ export const createReactComponent = <
         ...cProps
       } = this.props;
 
-      let propsToPass = Object.keys(cProps).reduce((acc, name) => {
+      let propsToPass = Object.keys(cProps).reduce((acc: any, name) => {
+        const value = (cProps as any)[name];
+
         if (name.indexOf("on") === 0 && name[2] === name[2].toUpperCase()) {
           const eventName = name.substring(2).toLowerCase();
           if (typeof document !== "undefined" && isCoveredByReact(eventName)) {
-            (acc as any)[name] = (cProps as any)[name];
+            acc[name] = value;
           }
         } else {
-          (acc as any)[name] = (cProps as any)[name];
+          // we should only render strings, booleans, and numbers as attrs in html.
+          // objects, functions, arrays etc get synced via properties on mount.
+          const type = typeof value;
+
+          if (type === "string" || type === "boolean" || type === "number") {
+            acc[camelToDashCase(name)] = value;
+          }
         }
         return acc;
       }, {});
@@ -92,7 +102,14 @@ export const createReactComponent = <
         style,
       };
 
-      return React.createElement(tagName, newProps, children);
+      /**
+       * We use createElement here instead of
+       * React.createElement to work around a
+       * bug in Vite (https://github.com/vitejs/vite/issues/6104).
+       * React.createElement causes all elements to be rendered
+       * as <tagname> instead of the actual Web Component.
+       */
+      return createElement(tagName, newProps, children);
     }
 
     static get displayName() {

--- a/packages/web-components/docs.d.ts
+++ b/packages/web-components/docs.d.ts
@@ -53,6 +53,9 @@ export interface JsonDocsProp {
     name: string
     type: string
     mutable: boolean
+    /**
+     * The name of the attribute that is exposed to configure a compiled web component
+     */
     attr?: string
     reflectToAttr: boolean
     docs: string

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "~1.0.1",
-                "@stencil/core": "~2.10.0",
+                "@stencil/core": "~2.18.0",
                 "date-fns": "~2.21.1",
                 "date-fns-tz": "~1.3.3"
             },
@@ -22,7 +22,7 @@
                 "@playwright/test": "~1.25.2",
                 "@stencil/angular-output-target": "~0.4.0",
                 "@stencil/eslint-plugin": "~0.4.0",
-                "@stencil/react-output-target": "~0.1.0",
+                "@stencil/react-output-target": "~0.3.1",
                 "@stencil/sass": "~1.4.1",
                 "@storybook/addon-a11y": "~6.4.18",
                 "@storybook/addon-actions": "~6.4.18",
@@ -3184,9 +3184,9 @@
             }
         },
         "node_modules/@stencil/core": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.10.0.tgz",
-            "integrity": "sha512-15rWMTPQ/sp0lSV82HVCXkIya3QLN+uBl7pqK4JnTrp4HiLrzLmNbWjbvgCs55gw0lULbCIGbRIEsFz+Pe/Q+A==",
+            "version": "2.18.0",
+            "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.0.tgz",
+            "integrity": "sha512-NLEY8Jq59smyiivBAxHKipsp9YkkW/K/Vm90zAyXQqukb12i2SFucWHJ1Ik7ropVlhmMVvigyxXgRfQ9quIqtg==",
             "bin": {
                 "stencil": "bin/stencil"
             },
@@ -3216,12 +3216,12 @@
             }
         },
         "node_modules/@stencil/react-output-target": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.1.0.tgz",
-            "integrity": "sha512-NWeN2S43dwWDIousfojzGXIMkJJhfcdS1JxpwgE7IOqy4tZ+nqlDLPhM6tXvZ3eq4rJm8bkF+3/WbPJNR9xR7Q==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.3.1.tgz",
+            "integrity": "sha512-6d9pPhyajFfdxkqU/pPP2SzI7wn+EklySQc4KXlI/xcdvC2H9BzLmhmR40fR1q2TQoJbJui/nvSWhbYqkE3OBQ==",
             "dev": true,
             "peerDependencies": {
-                "@stencil/core": ">=1.8.0"
+                "@stencil/core": "^2.9.0"
             }
         },
         "node_modules/@stencil/sass": {
@@ -49659,9 +49659,9 @@
             "requires": {}
         },
         "@stencil/core": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.10.0.tgz",
-            "integrity": "sha512-15rWMTPQ/sp0lSV82HVCXkIya3QLN+uBl7pqK4JnTrp4HiLrzLmNbWjbvgCs55gw0lULbCIGbRIEsFz+Pe/Q+A=="
+            "version": "2.18.0",
+            "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.0.tgz",
+            "integrity": "sha512-NLEY8Jq59smyiivBAxHKipsp9YkkW/K/Vm90zAyXQqukb12i2SFucWHJ1Ik7ropVlhmMVvigyxXgRfQ9quIqtg=="
         },
         "@stencil/eslint-plugin": {
             "version": "0.4.0",
@@ -49674,9 +49674,9 @@
             }
         },
         "@stencil/react-output-target": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.1.0.tgz",
-            "integrity": "sha512-NWeN2S43dwWDIousfojzGXIMkJJhfcdS1JxpwgE7IOqy4tZ+nqlDLPhM6tXvZ3eq4rJm8bkF+3/WbPJNR9xR7Q==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.3.1.tgz",
+            "integrity": "sha512-6d9pPhyajFfdxkqU/pPP2SzI7wn+EklySQc4KXlI/xcdvC2H9BzLmhmR40fR1q2TQoJbJui/nvSWhbYqkE3OBQ==",
             "dev": true,
             "requires": {}
         },

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -42,20 +42,20 @@
     },
     "dependencies": {
         "@floating-ui/dom": "~1.0.1",
-        "@stencil/core": "~2.10.0",
+        "@stencil/core": "~2.18.0",
         "date-fns": "~2.21.1",
         "date-fns-tz": "~1.3.3"
     },
     "license": "MIT",
     "devDependencies": {
         "@astrouxds/astro-figma-export": "~1.0.1",
-        "@astrouxds/tokens": "^1.0.0",
         "@astrouxds/storybook-addon-docs-stencil": "~1.0.10",
+        "@astrouxds/tokens": "^1.0.0",
         "@babel/core": "~7.13.16",
         "@playwright/test": "~1.25.2",
         "@stencil/angular-output-target": "~0.4.0",
         "@stencil/eslint-plugin": "~0.4.0",
-        "@stencil/react-output-target": "~0.1.0",
+        "@stencil/react-output-target": "~0.3.1",
         "@stencil/sass": "~1.4.1",
         "@storybook/addon-a11y": "~6.4.18",
         "@storybook/addon-actions": "~6.4.18",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -12572,6 +12572,90 @@ export namespace Components {
         "setSelected": (value: boolean) => Promise<void>;
     }
 }
+export interface RuxAccordionItemCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxAccordionItemElement;
+}
+export interface RuxCheckboxCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxCheckboxElement;
+}
+export interface RuxDialogCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxDialogElement;
+}
+export interface RuxInputCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxInputElement;
+}
+export interface RuxMenuCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxMenuElement;
+}
+export interface RuxNotificationCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxNotificationElement;
+}
+export interface RuxOptionCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxOptionElement;
+}
+export interface RuxOptionGroupCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxOptionGroupElement;
+}
+export interface RuxPopUpCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxPopUpElement;
+}
+export interface RuxPushButtonCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxPushButtonElement;
+}
+export interface RuxRadioCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxRadioElement;
+}
+export interface RuxRadioGroupCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxRadioGroupElement;
+}
+export interface RuxSegmentedButtonCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxSegmentedButtonElement;
+}
+export interface RuxSelectCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxSelectElement;
+}
+export interface RuxSliderCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxSliderElement;
+}
+export interface RuxSwitchCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxSwitchElement;
+}
+export interface RuxTabPanelsCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxTabPanelsElement;
+}
+export interface RuxTabsCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxTabsElement;
+}
+export interface RuxTextareaCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxTextareaElement;
+}
+export interface RuxTimeRegionCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxTimeRegionElement;
+}
+export interface RuxTreeNodeCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLRuxTreeNodeElement;
+}
 declare global {
     interface HTMLRuxAccordionElement extends Components.RuxAccordion, HTMLStencilElement {
     }
@@ -20362,7 +20446,7 @@ declare namespace LocalJSX {
         /**
           * Fired when an element has expanded
          */
-        "onRuxexpanded"?: (event: CustomEvent<any>) => void;
+        "onRuxexpanded"?: (event: RuxAccordionItemCustomEvent<any>) => void;
     }
     interface RuxButton {
         /**
@@ -20430,15 +20514,15 @@ declare namespace LocalJSX {
         /**
           * Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)
          */
-        "onRuxblur"?: (event: CustomEvent<any>) => void;
+        "onRuxblur"?: (event: RuxCheckboxCustomEvent<any>) => void;
         /**
           * Fired when the value of the input changes - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
          */
-        "onRuxchange"?: (event: CustomEvent<any>) => void;
+        "onRuxchange"?: (event: RuxCheckboxCustomEvent<any>) => void;
         /**
           * Fired when an alteration to the input's value is committed by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
          */
-        "onRuxinput"?: (event: CustomEvent<any>) => void;
+        "onRuxinput"?: (event: RuxCheckboxCustomEvent<any>) => void;
         /**
           * The checkbox value
          */
@@ -20594,11 +20678,11 @@ declare namespace LocalJSX {
         /**
           * Event that is fired when dialog closes. If dialog is closed by clicking on the default confirm or deny buttons (when no footer slot is provided), then true or false will be emitted respectively on the event.detail.
          */
-        "onRuxdialogclosed"?: (event: CustomEvent<boolean | null>) => void;
+        "onRuxdialogclosed"?: (event: RuxDialogCustomEvent<boolean | null>) => void;
         /**
           * Event that is fired when dialog opens
          */
-        "onRuxdialogopened"?: (event: CustomEvent<void>) => void;
+        "onRuxdialogopened"?: (event: RuxDialogCustomEvent<void>) => void;
         /**
           * Shows and hides dialog
          */
@@ -32300,19 +32384,19 @@ declare namespace LocalJSX {
         /**
           * Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)
          */
-        "onRuxblur"?: (event: CustomEvent<any>) => void;
+        "onRuxblur"?: (event: RuxInputCustomEvent<any>) => void;
         /**
           * Fired when the value of the input changes - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
          */
-        "onRuxchange"?: (event: CustomEvent<any>) => void;
+        "onRuxchange"?: (event: RuxInputCustomEvent<any>) => void;
         /**
           * Fired when an element has gained focus - [HTMLElement/focus_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)
          */
-        "onRuxfocus"?: (event: CustomEvent<any>) => void;
+        "onRuxfocus"?: (event: RuxInputCustomEvent<any>) => void;
         /**
           * Fired when an alteration to the input's value is committed by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
          */
-        "onRuxinput"?: (event: CustomEvent<any>) => void;
+        "onRuxinput"?: (event: RuxInputCustomEvent<any>) => void;
         /**
           * The input placeholder text
          */
@@ -32373,7 +32457,7 @@ declare namespace LocalJSX {
         /**
           * Emits when a rux-menu-item is selected. Emits the rux-menu-item selected in the event detail.
          */
-        "onRuxmenuselected"?: (event: CustomEvent<any>) => void;
+        "onRuxmenuselected"?: (event: RuxMenuCustomEvent<any>) => void;
     }
     interface RuxMenuItem {
         /**
@@ -32459,7 +32543,7 @@ declare namespace LocalJSX {
         /**
           * Fires when the notification banner is closed
          */
-        "onRuxclosed"?: (event: CustomEvent<boolean>) => void;
+        "onRuxclosed"?: (event: RuxNotificationCustomEvent<boolean>) => void;
         /**
           * Set to true to display the Banner and begin countdown to close (if a close-after Number value is provided).
          */
@@ -32482,7 +32566,7 @@ declare namespace LocalJSX {
           * The option label
          */
         "label": string;
-        "onRux-option-changed"?: (event: CustomEvent<void>) => void;
+        "onRux-option-changed"?: (event: RuxOptionCustomEvent<void>) => void;
         /**
           * The option value
          */
@@ -32493,17 +32577,17 @@ declare namespace LocalJSX {
           * The option group label
          */
         "label"?: string;
-        "onRux-option-group-changed"?: (event: CustomEvent<void>) => void;
+        "onRux-option-group-changed"?: (event: RuxOptionGroupCustomEvent<void>) => void;
     }
     interface RuxPopUp {
         /**
           * Emits when the pop up has closed.
          */
-        "onRuxpopupclosed"?: (event: CustomEvent<any>) => void;
+        "onRuxpopupclosed"?: (event: RuxPopUpCustomEvent<any>) => void;
         /**
           * Emits when the pop up has opened
          */
-        "onRuxpopupopened"?: (event: CustomEvent<any>) => void;
+        "onRuxpopupopened"?: (event: RuxPopUpCustomEvent<any>) => void;
         /**
           * Determines if the pop up is open or closed
          */
@@ -32559,11 +32643,11 @@ declare namespace LocalJSX {
         /**
           * Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)
          */
-        "onRuxblur"?: (event: CustomEvent<any>) => void;
+        "onRuxblur"?: (event: RuxPushButtonCustomEvent<any>) => void;
         /**
           * Fired when an alteration to the input's value is committed by the user and emits the value on the event.detail - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
          */
-        "onRuxchange"?: (event: CustomEvent<any>) => void;
+        "onRuxchange"?: (event: RuxPushButtonCustomEvent<any>) => void;
         /**
           * Changes size of a push button from medium to small or large by setting sizing classes rux-button--small rux-button--large
          */
@@ -32593,7 +32677,7 @@ declare namespace LocalJSX {
         /**
           * Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)
          */
-        "onRuxblur"?: (event: CustomEvent<any>) => void;
+        "onRuxblur"?: (event: RuxRadioCustomEvent<any>) => void;
         /**
           * The radio value
          */
@@ -32623,7 +32707,7 @@ declare namespace LocalJSX {
         /**
           * Fired when the value of the input changes and emits that value on the event.detail. - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
          */
-        "onRuxchange"?: (event: CustomEvent<any>) => void;
+        "onRuxchange"?: (event: RuxRadioGroupCustomEvent<any>) => void;
         /**
           * Marks that a selection from the radio-group is requried.
          */
@@ -32651,7 +32735,7 @@ declare namespace LocalJSX {
         /**
           * Fires when the value property has changed and emits that value on the event.detail.
          */
-        "onRuxchange"?: (event: CustomEvent<any>) => void;
+        "onRuxchange"?: (event: RuxSegmentedButtonCustomEvent<any>) => void;
         /**
           * When passed in on load, this selects the first button segment with a matching label. When the selected segment changes, this property updates with the currently selected value, which reflects back to the component attribute. If no button segment label matches this string, then no segment is selected. This value takes priority over setting selected boolean property on the items in the data array.
          */
@@ -32701,11 +32785,11 @@ declare namespace LocalJSX {
         /**
           * Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)
          */
-        "onRuxblur"?: (event: CustomEvent<any>) => void;
+        "onRuxblur"?: (event: RuxSelectCustomEvent<any>) => void;
         /**
           * Event Emitted when the Value of the Select is Changed
          */
-        "onRuxchange"?: (event: CustomEvent<void>) => void;
+        "onRuxchange"?: (event: RuxSelectCustomEvent<void>) => void;
         /**
           * Sets the field as required
          */
@@ -32755,15 +32839,15 @@ declare namespace LocalJSX {
         /**
           * Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)
          */
-        "onRuxblur"?: (event: CustomEvent<any>) => void;
+        "onRuxblur"?: (event: RuxSliderCustomEvent<any>) => void;
         /**
           * Fired when the element's value is altered by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
          */
-        "onRuxchange"?: (event: CustomEvent<any>) => void;
+        "onRuxchange"?: (event: RuxSliderCustomEvent<any>) => void;
         /**
           * Fired when the value of the input changes - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
          */
-        "onRuxinput"?: (event: CustomEvent<any>) => void;
+        "onRuxinput"?: (event: RuxSliderCustomEvent<any>) => void;
         /**
           * Step amount of slider value.
          */
@@ -32803,15 +32887,15 @@ declare namespace LocalJSX {
         /**
           * Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)
          */
-        "onRuxblur"?: (event: CustomEvent<any>) => void;
+        "onRuxblur"?: (event: RuxSwitchCustomEvent<any>) => void;
         /**
           * Fired when the value of the input changes and emits that value on the event.detail. - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
          */
-        "onRuxchange"?: (event: CustomEvent<any>) => void;
+        "onRuxchange"?: (event: RuxSwitchCustomEvent<any>) => void;
         /**
           * Fired when an alteration to the input's value is committed by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
          */
-        "onRuxinput"?: (event: CustomEvent<any>) => void;
+        "onRuxinput"?: (event: RuxSwitchCustomEvent<any>) => void;
         /**
           * The switch value
          */
@@ -32837,7 +32921,7 @@ declare namespace LocalJSX {
         /**
           * Emits a list of the Tab Panels on the event.detail which have been passed in
          */
-        "onRuxregisterpanels"?: (event: CustomEvent<HTMLRuxTabPanelsElement[]>) => void;
+        "onRuxregisterpanels"?: (event: RuxTabPanelsCustomEvent<HTMLRuxTabPanelsElement[]>) => void;
     }
     interface RuxTable {
     }
@@ -32861,7 +32945,7 @@ declare namespace LocalJSX {
         /**
           * Fires whenever a new tab is selected, and emits the selected tab on the event.detail.
          */
-        "onRuxselected"?: (event: CustomEvent<any>) => void;
+        "onRuxselected"?: (event: RuxTabsCustomEvent<any>) => void;
         /**
           * If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses.
          */
@@ -32909,15 +32993,15 @@ declare namespace LocalJSX {
         /**
           * Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)
          */
-        "onRuxblur"?: (event: CustomEvent<any>) => void;
+        "onRuxblur"?: (event: RuxTextareaCustomEvent<any>) => void;
         /**
           * Fired when the value of the input changes - [HTMLElement/input_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
          */
-        "onRuxchange"?: (event: CustomEvent<any>) => void;
+        "onRuxchange"?: (event: RuxTextareaCustomEvent<any>) => void;
         /**
           * Fired when an alteration to the input's value is committed by the user - [HTMLElement/change_event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
          */
-        "onRuxinput"?: (event: CustomEvent<any>) => void;
+        "onRuxinput"?: (event: RuxTextareaCustomEvent<any>) => void;
         /**
           * The textarea placeholder text
          */
@@ -32948,7 +33032,7 @@ declare namespace LocalJSX {
           * Optionally hide the bottom right timestamp.
          */
         "hideTimestamp"?: boolean;
-        "onRuxtimeregionchange"?: (event: CustomEvent<any>) => void;
+        "onRuxtimeregionchange"?: (event: RuxTimeRegionCustomEvent<any>) => void;
         /**
           * Visually indicates a partial time regions. Partial time regions are time regions that start or end outside of the current range of the timeline.
          */
@@ -33011,15 +33095,15 @@ declare namespace LocalJSX {
         /**
           * Fires when the user collapses a tree node and emits the node's id on the event.detail.
          */
-        "onRuxtreenodecollapsed"?: (event: CustomEvent<string>) => void;
+        "onRuxtreenodecollapsed"?: (event: RuxTreeNodeCustomEvent<string>) => void;
         /**
           * Fires when the user expands a tree node and emits the node's id on the event.detail.
          */
-        "onRuxtreenodeexpanded"?: (event: CustomEvent<string>) => void;
+        "onRuxtreenodeexpanded"?: (event: RuxTreeNodeCustomEvent<string>) => void;
         /**
           * Fires when the user selects a tree node and emits the node's id on the event.detail.
          */
-        "onRuxtreenodeselected"?: (event: CustomEvent<string>) => void;
+        "onRuxtreenodeselected"?: (event: RuxTreeNodeCustomEvent<string>) => void;
         /**
           * Sets the selected state
          */

--- a/packages/web-components/src/components/rux-slider/rux-slider.tsx
+++ b/packages/web-components/src/components/rux-slider/rux-slider.tsx
@@ -279,8 +279,8 @@ export class RuxSlider implements FormFieldInterface {
                             class="rux-range"
                             min={min}
                             max={max}
-                            value={value}
                             step={step}
+                            value={value}
                             disabled={disabled}
                             aria-label="slider"
                             aria-disabled={disabled ? 'true' : 'false'}

--- a/packages/web-components/tests/accordion.spec.ts
+++ b/packages/web-components/tests/accordion.spec.ts
@@ -8,7 +8,6 @@ test.describe('Accordion', () => {
         await setBodyContent(
             page,
             `
-            <body>
             <div style="width: 300px;">
             <rux-accordion id="accordion-collapsed">
             <rux-accordion-item>
@@ -184,7 +183,6 @@ test.describe('Accordion', () => {
                 </rux-accordion-item>
             </rux-accordion>
              </div>
-             </body>
              `
         )
     })

--- a/packages/web-components/tests/slider.spec.ts
+++ b/packages/web-components/tests/slider.spec.ts
@@ -58,9 +58,7 @@ test.describe('Slider', () => {
         // waitForTimeout here to ensure that the waitForEvent has started listening
         await Promise.all([
             page.waitForEvent('console', { timeout: 5000 }),
-            page
-                .waitForTimeout(500)
-                .then(() => el.click({ position: { x: 10, y: 10 } })),
+            el.click({ position: { x: 10, y: 10 } }),
         ])
     })
     test('should hear the ruxinput event', async ({ page }) => {
@@ -84,9 +82,7 @@ test.describe('Slider', () => {
 
         await Promise.all([
             page.waitForEvent('console', { timeout: 5000 }),
-            page
-                .waitForTimeout(500)
-                .then(() => el.click({ position: { x: 10, y: 10 } })),
+            el.click({ position: { x: 10, y: 10 } }),
         ])
     })
     test('should hear the ruxblur event', async ({ page }) => {
@@ -113,13 +109,7 @@ test.describe('Slider', () => {
 
         await Promise.all([
             page.waitForEvent('console', { timeout: 5000 }),
-            page
-                .waitForTimeout(500)
-                .then(() =>
-                    el
-                        .click({ position: { x: 10, y: 10 } })
-                        .then(() => btn.click())
-                ),
+            el.click({ position: { x: 10, y: 10 } }).then(() => btn.click()),
         ])
     })
 })


### PR DESCRIPTION
## Brief Description

Bumps the `@stencil/react-output-target` to latest
Bumps `@stencil/core` to latest. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4598

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
