### PR TITLE
fix(dialog): event detail now correct after reopening same modal

### DIFF
--- a/.changeset/metal-fishes-share.md
+++ b/.changeset/metal-fishes-share.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+Fixed an issue where the event detail on dialog would not reset to default value after it emitted once.

--- a/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
+++ b/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
@@ -137,6 +137,8 @@ export class RuxDialog {
         this.open
             ? this.ruxDialogOpened.emit()
             : this.ruxDialogClosed.emit(this._userInput)
+        //reset userInput after it's emitted
+        this._userInput = null
     }
 
     private _handleDialogChoice(e: MouseEvent) {


### PR DESCRIPTION
## Brief Description

The `e.detail` emitted by `rux-dialog` would not reset to it's default value after the event was emitted. Because of this, if you opened the dialog, clicked confirm, it would emit true. If you opened that same dialog again and clicked off to close it, it would emit true again even though no choice was made. 

Added a test for this case.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4635

## Related Issue

## General Notes

## Motivation and Context

Fixes an inconsistency in the event detail of dialog.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
