### PR TITLE
fix(push-button): rm custom prop and inline flex

### DIFF
--- a/packages/web-components/src/components/rux-push-button/rux-push-button.scss
+++ b/packages/web-components/src/components/rux-push-button/rux-push-button.scss
@@ -29,7 +29,6 @@
             justify-content: center;
             align-items: center;
             color: var(--color-text-interactive-default);
-            background-color: var(--pushbutton-background-color);
             border-radius: var(--radius-base);
             // use box shadow instead of border to create borders
             box-shadow: var(--color-border-interactive-default) 0 0 0 1px inset;
@@ -76,7 +75,7 @@
 
         //active
         &__input:checked + .rux-push-button__button {
-            display: flex;
+            display: inline-flex;
             color: var(--color-text-inverse);
             background-color: var(--color-palette-green-500);
             box-shadow: var(--color-palette-green-500) 0 0 0 1px inset;


### PR DESCRIPTION
## Brief Description

removes the unused pushbutton-background-color css custom prop
fixes an issue where checked state became inline flex 

## JIRA Link

ASTRO-4363

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
