### PR TITLE
style(select): updated borders, updated option hover color when disabled

### DIFF
--- a/packages/web-components/src/components/rux-select/rux-select.scss
+++ b/packages/web-components/src/components/rux-select/rux-select.scss
@@ -15,7 +15,7 @@
             --color-border-interactive-muted,
             rgb(43, 101, 155)
         );
-        border-radius: var(--progress-radius-inner);
+        border-radius: var(--spacing-2); //8
         border: 3px solid transparent;
         background-clip: padding-box;
     }
@@ -144,6 +144,7 @@ label {
                 cursor: not-allowed;
                 &:hover {
                     color: var(--color-background-interactive-default);
+                    opacity: var(--opacity-disabled);
                     background-color: linear-gradient(
                         to left,
                         var(--color-background-surface-selected)
@@ -190,7 +191,7 @@ label {
 
         &:hover {
             color: var(--color-background-interactive-hover);
-            background-color: var(--select-menu-option-hover-background-color);
+            background-color: var(--color-background-surface-hover);
         }
 
         &:focus {

--- a/packages/web-components/src/stories/select.stories.mdx
+++ b/packages/web-components/src/stories/select.stories.mdx
@@ -509,7 +509,7 @@ export const Multiple = (args) => {
         label-id="${args.labelId}"
         .error-text="${args.errorText}"
         help-text="${args.helpText}"
-        .multiple="${args.multiple}"
+        ?multiple="${args.multiple}"
         size="${args.size}"
     >
         <rux-option value="1.1" label="Option 1.1"></rux-option>
@@ -560,7 +560,7 @@ export const MultipleWithOptionGroups = (args) => {
         label-id="${args.labelId}"
         .error-text="${args.errorText}"
         help-text="${args.helpText}"
-        .multiple="${args.multiple}"
+        ?multiple="${args.multiple}"
         size="${args.size}"
     >
         <rux-option value="" label="Select Option"></rux-option>


### PR DESCRIPTION
## Brief Description

Some random style cleanups on select.

- Options that are disabled no longer change color on hover
- Reverted box-shadow borders back to border in order to fix issue in multi-select where border did not encompass the scrollbar 
- removed a random, deprecated css custom prop from the scrollbar styles. 
- Fixed the `multiple` attribute not reflecting properly in SB examples 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4643

## Related Issue

## General Notes

## Motivation and Context

styling inconsistencies 

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
