### PR TITLE
Mj 4650 monit icon part

### DIFF
--- a/.changeset/shiny-falcons-hope.md
+++ b/.changeset/shiny-falcons-hope.md
@@ -1,0 +1,9 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+Moved the `monitoring-label` part to the parent div of its previous location in order to provide more customizability.

--- a/packages/web-components/src/common/functional-components/MonitoringLabel.tsx
+++ b/packages/web-components/src/common/functional-components/MonitoringLabel.tsx
@@ -9,8 +9,8 @@ const MonitoringLabel: FunctionalComponent<MonitoringLabelProps> = ({
     label,
     sublabel,
 }) => (
-    <div class="rux-advanced-status__label">
-        <span part="monitoring-label">{label}</span>
+    <div class="rux-advanced-status__label" part="monitoring-label">
+        <span>{label}</span>
         <span
             class={`rux-advanced-status__sublabel ${
                 !sublabel ? 'rux-advanced-status__hidden' : ''

--- a/packages/web-components/src/components/rux-monitoring-icon/test/__snapshots__/rux-monitoring-icon.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-monitoring-icon/test/__snapshots__/rux-monitoring-icon.spec.tsx.snap
@@ -13,8 +13,8 @@ exports[`rux-monitoring-icon renders 1`] = `
           10K
         </div>
       </div>
-      <div class="rux-advanced-status__label">
-        <span part="monitoring-label">
+      <div class="rux-advanced-status__label" part="monitoring-label">
+        <span>
           Altitude for satellite X
         </span>
         <span class="rux-advanced-status__sublabel" part="monitoring-sublabel">

--- a/packages/web-components/src/components/rux-monitoring-progress-icon/test/__snapshots__/rux-monitoring-progress-icon.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-monitoring-progress-icon/test/__snapshots__/rux-monitoring-progress-icon.spec.tsx.snap
@@ -19,8 +19,8 @@ exports[`rux-monitoring-progress-icon renders 1`] = `
           345K
         </div>
       </div>
-      <div class="rux-advanced-status__label">
-        <span part="monitoring-label">
+      <div class="rux-advanced-status__label" part="monitoring-label">
+        <span>
           Label
         </span>
         <span class="rux-advanced-status__sublabel" part="monitoring-sublabel">


### PR DESCRIPTION
## Brief Description

Moves a the monitoring-label up a level to the parent div of the label span.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4650

## Related Issue

Tom noticed that you can't change the label off of `overflow: hidden`. This fixes that.

## General Notes

## Motivation and Context

The part wasn't helpful at all. Moved it to where it is helpful.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
