### PR TITLE
fix(tab): hover color on disabled tab

### DIFF
--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
@@ -64,4 +64,8 @@
     color: var(--color-text-interactive-default);
     opacity: var(--opacity-disabled);
     cursor: not-allowed;
+    &:hover {
+        color: var(--color-text-interactive-default);
+        opacity: var(--opacity-disabled);
+    }
 }


### PR DESCRIPTION
## Brief Description

A disabled tab will no longer change text color on hover.

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
