### PR TITLE
docs(popup): updated cherry picking section

### DIFF
--- a/packages/starter-kits/angular-starter/package.json
+++ b/packages/starter-kits/angular-starter/package.json
@@ -18,8 +18,8 @@
     "@angular/platform-browser": "~12.2.0",
     "@angular/platform-browser-dynamic": "~12.2.0",
     "@angular/router": "~12.2.0",
-    "@astrouxds/angular": "^6.11.0",
-    "@astrouxds/astro-web-components": "^6.11.0",
+    "@astrouxds/angular": "^7.0.0",
+    "@astrouxds/astro-web-components": "^7.0.0",
     "rxjs": "~6.6.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"

--- a/packages/starter-kits/react-starter/package.json
+++ b/packages/starter-kits/react-starter/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "bin": "init.js",
   "dependencies": {
-    "@astrouxds/react": "^6.11.0",
+    "@astrouxds/react": "^7.0.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",

--- a/packages/starter-kits/svelte-starter/package.json
+++ b/packages/starter-kits/svelte-starter/package.json
@@ -11,7 +11,7 @@
     "sirv-cli": "^0.3.1"
   },
   "dependencies": {
-    "@astrouxds/astro-web-components": "^6.11.0",
+    "@astrouxds/astro-web-components": "^7.0.0",
     "svelte": "^3.49.0"
   },
   "scripts": {

--- a/packages/starter-kits/vue-starter/package.json
+++ b/packages/starter-kits/vue-starter/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@astrouxds/astro-web-components": "^6.11.0",
+    "@astrouxds/astro-web-components": "^7.0.0",
     "core-js": "^3.6.5",
     "vue": "^3.0.0"
   },

--- a/packages/web-components/src/stories/popup.stories.mdx
+++ b/packages/web-components/src/stories/popup.stories.mdx
@@ -62,7 +62,7 @@ export const Default = (args) => {
 
 ## Usage
 
-Make use of [Menu](?path=/docs/components-pop-up-menu--default-story) [Menu Item](?path=/docs/components-pop-up-menu-item--default-story) and [Menu Item Divider](?path=/docs/components-pop-up-menu-item-divider--default-story) to compose your own Pop Up.
+Make use of [Menu](?path=/docs/components-pop-up-menu--default-story), [Menu Item](?path=/docs/components-pop-up-menu-item--default-story), and [Menu Item Divider](?path=/docs/components-pop-up-menu-item-divider--default-story) to compose your own Pop Up.
 Every `rux-pop-up` should use the named `trigger` slot to render the trigger element for the pop up menu.
 The menu will attempt to position according to the `placement` prop if provided, or will use auto-placement if not.
 
@@ -133,5 +133,12 @@ If you're already utilizing a build system that supports tree shaking and want t
 
 ```js
 import RuxPopUp from '@astrouxds/astro-web-components/dist/components/rux-pop-up.js'
+import RuxMenu from '@astrouxds/astro-web-components/dist/components/rux-menu.js'
+import RuxMenuItem from '@astrouxds/astro-web-components/dist/components/rux-menu-item.js'
+import RuxMenuItemDivider from '@astrouxds/astro-web-components/dist/components/rux-menu-item-divider.js'
+
 customElements.define('rux-pop-up', RuxPopUp)
+customElements.define('rux-menu', RuxMenu)
+customElements.define('rux-menu-item', RuxMenuItem)
+customElements.define('rux-menu-item-divider', RuxMenuItemDivider)
 ```


### PR DESCRIPTION
## Brief Description

Updates cherry picking section in popup to include all relevant components.
Bumps the `@astrouxds/astro-web-components` version in all starter kits to `^7.0.0`. Also bumps the `astrouxds/angular` and `astrouxds/react` deps in ang/react starter kits to `^7.0.0`

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4651

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
