### PR TITLE
Mj 4665 starter kits

### DIFF
--- a/packages/starter-kits/react-starter/src/App.js
+++ b/packages/starter-kits/react-starter/src/App.js
@@ -1,16 +1,17 @@
 import "./App.css";
-import { RuxProgress } from "@astrouxds/react";
+import { RuxIndeterminateProgress } from "@astrouxds/react";
 
 function App() {
   return (
     <div className="App">
       <header className="App-header">
         <div>
-          <RuxProgress />
+          <RuxIndeterminateProgress />
         </div>
         <p>
-          Welcome to Astro UXDS web components in React! Check out the README.md
-          for more information on getting started.
+          Welcome to Astro UXDS web components in React! You're ready to start
+          building. <br></br> Check out the README.md for more information on
+          getting started.
         </p>
         <a
           className="App-link"

--- a/packages/starter-kits/svelte-starter/public/index.html
+++ b/packages/starter-kits/svelte-starter/public/index.html
@@ -7,6 +7,11 @@
     <title>Svelte app</title>
 
     <link rel="stylesheet" href="public/bundle.css" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
 
   <body>

--- a/packages/starter-kits/vue-starter/public/index.html
+++ b/packages/starter-kits/vue-starter/public/index.html
@@ -6,7 +6,14 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
     <title><%= htmlWebpackPlugin.options.title %></title>
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
+
   <body>
     <noscript>
       <strong

--- a/packages/web-components/src/stories/astro-uxds/welcome/vue.stories.mdx
+++ b/packages/web-components/src/stories/astro-uxds/welcome/vue.stories.mdx
@@ -63,7 +63,7 @@ Import [Roboto](https://fonts.google.com/specimen/Roboto) in your index.html. We
 ```html
 <link rel="preconnect" href="https://fonts.gstatic.com" />
 <link
-    href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400&family=Roboto:wght@200;300;400;500;600;800&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap"
     rel="stylesheet"
 />
 ```


### PR DESCRIPTION
## Brief Description

Cleans up starter-kits for 7.0
- React
  - Changes `<RuxProgress />` comp to `<RuxIndeterminateProgress />`
- Vue and Svelte
  - Updates `public/index.html` to use the correct roboto font. 
  - Updates Vue story to have correct font in CDN code snippet

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4665

## Related Issue

## General Notes

## Motivation and Context

Matches 7.0 now

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
