### PR TITLE
docs: update form sandboxes to use 7.0

### DIFF
--- a/packages/web-components/src/stories/astro-sandboxes/forms/angular/basic-form/package.json
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/angular/basic-form/package.json
@@ -18,8 +18,8 @@
         "@angular/platform-browser": "~12.2.0",
         "@angular/platform-browser-dynamic": "~12.2.0",
         "@angular/router": "~12.2.0",
-        "@astrouxds/angular": "6.0.1",
-        "@astrouxds/astro-web-components": "^6.0.1",
+        "@astrouxds/angular": "^7.0.1",
+        "@astrouxds/astro-web-components": "^7.0.1",
         "rxjs": "~6.6.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.11.4"

--- a/packages/web-components/src/stories/astro-sandboxes/forms/react/basic/package.json
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/react/basic/package.json
@@ -5,8 +5,8 @@
     "keywords": [],
     "main": "src/index.js",
     "dependencies": {
-        "@astrouxds/astro-web-components": "6.0.3",
-        "@astrouxds/react": "6.0.3",
+        "@astrouxds/astro-web-components": "^7.0.1",
+        "@astrouxds/react": "^7.0.1",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-scripts": "5.0.1"

--- a/packages/web-components/src/stories/astro-sandboxes/forms/react/validation/package.json
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/react/validation/package.json
@@ -5,8 +5,8 @@
     "keywords": [],
     "main": "src/index.js",
     "dependencies": {
-        "@astrouxds/astro-web-components": "6.0.1",
-        "@astrouxds/react": "6.0.1",
+        "@astrouxds/astro-web-components": "^7.0.1",
+        "@astrouxds/react": "^7.0.1",
         "formik": "2.2.9",
         "react": "17.0.2",
         "react-dom": "17.0.2",

--- a/packages/web-components/src/stories/astro-sandboxes/forms/svelte/basic/package.json
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/svelte/basic/package.json
@@ -11,7 +11,7 @@
         "sirv-cli": "^0.3.1"
     },
     "dependencies": {
-        "@astrouxds/astro-web-components": "6.0.1",
+        "@astrouxds/astro-web-components": "^7.0.1",
         "svelte": "^3.32.3"
     },
     "scripts": {

--- a/packages/web-components/src/stories/astro-sandboxes/forms/svelte/validation/package.json
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/svelte/validation/package.json
@@ -11,7 +11,7 @@
         "sirv-cli": "^0.3.1"
     },
     "dependencies": {
-        "@astrouxds/astro-web-components": "6.0.1",
+        "@astrouxds/astro-web-components": "^7.0.1",
         "svelte": "^3.32.3",
         "svelte-forms-lib": "1.10.7",
         "yup": "0.32.9"

--- a/packages/web-components/src/stories/astro-sandboxes/forms/vue/basic/package.json
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/vue/basic/package.json
@@ -8,7 +8,7 @@
         "lint": "vue-cli-service lint"
     },
     "dependencies": {
-        "@astrouxds/astro-web-components": "6.0.1",
+        "@astrouxds/astro-web-components": "^7.0.1",
         "@vue/cli-plugin-babel": "4.1.1",
         "vue": "2.6.14"
     },

--- a/packages/web-components/src/stories/astro-sandboxes/forms/vue/validation/package.json
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/vue/validation/package.json
@@ -8,7 +8,7 @@
         "lint": "vue-cli-service lint"
     },
     "dependencies": {
-        "@astrouxds/astro-web-components": "6.0.1",
+        "@astrouxds/astro-web-components": "^7.0.1",
         "@vue/cli-plugin-babel": "4.1.1",
         "vee-validate": "4.4.11",
         "vue": "3.2.11",


### PR DESCRIPTION
## Brief Description

Updates sandbox form examples to use latest astro version (^7.0.1)

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4664

## Related Issue

## General Notes

## Motivation and Context

Makes our form examples on SB up to date. 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
