### PR TITLE
opacity token correction

### DIFF
--- a/.changeset/polite-pianos-allow.md
+++ b/.changeset/polite-pianos-allow.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+rux-checkbox: change --disabled-opacity to correct --opacity-disabled design token

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
@@ -29,7 +29,7 @@ label {
     cursor: pointer;
 
     &--disabled {
-        opacity: var(--disabled-opacity);
+        opacity: var(--opacity-disabled);
         cursor: not-allowed;
     }
 


### PR DESCRIPTION
## Brief Description

Changes --disabled-opacity token to --opacity-disabled in rux-checkbox
I also ran a general search for --disabled-opacity to ensure that there weren't other instances. I didn't find any

## JIRA Link

[ASTRO-4686](https://rocketcom.atlassian.net/browse/ASTRO-4686)

## Related Issue

## General Notes

## Motivation and Context

I just noticed the token was wrong and thus it wasn't giving checkbox standard opacity for disabled elements.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
