### PR TITLE
added a z-index to rux-popup

### DIFF
--- a/.changeset/selfish-plants-study.md
+++ b/.changeset/selfish-plants-study.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+fix(rux-pop-up) allow it to overlay components that are below it in code

--- a/packages/web-components/src/components/rux-pop-up/rux-pop-up.scss
+++ b/packages/web-components/src/components/rux-pop-up/rux-pop-up.scss
@@ -22,6 +22,7 @@
     background: var(--color-background-base-default);
     border: 1px solid var(--color-border-interactive-muted);
     transform-style: preserve-3d;
+    z-index: 100; // overlays every component except for rux-dialog and rux-classification-marking
 }
 
 .rux-popup__trigger {


### PR DESCRIPTION
## Brief Description

An [issue](https://github.com/RocketCommunicationsInc/astro/issues/812) came in that showed rux-pop-up fell under some of our normal components which isn't what a user would expect. So I added a z-index to have it overlay components that are below it in code.

## JIRA Link

Here is the issue as reported on GitHub: [issue 812](https://github.com/RocketCommunicationsInc/astro/issues/812)

## Related Issue

## General Notes

It now falls over every component we have, EXCEPT for rux-dialog and rux-classification-marking. I understand that there is an important compliance item which requires classification markings to overlay all other things.

## Motivation and Context

Changes visibility to be more inline with user expectations.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
