### PR TITLE
Km 4688 rux textarea revert wrapper

### DIFF
--- a/.changeset/tidy-moons-suffer.md
+++ b/.changeset/tidy-moons-suffer.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+fix(rux-textarea) revert code format to remove wrapper and return functionality control to developers

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -18,7 +18,7 @@
     line-height: var(--font-control-body-1-line-height);
     color: var(--color-text-primary);
     background-color: var(--color-background-base-default);
-    min-height: var(--spacing-16); //64
+    height: var(--spacing-16); //64
     width: 100%;
     padding: var(--spacing-2);
     margin: var(--spacing-0);
@@ -35,10 +35,10 @@
     }
     &--small {
         padding: var(--spacing-1) var(--spacing-2); //4px 8px
-        min-height: var(--spacing-14); //56px
+        height: var(--spacing-14); //56px
     }
     &--large {
-        min-height: calc(var(--spacing-16) + var(--spacing-2)); //72px
+        height: calc(var(--spacing-16) + var(--spacing-2)); //72px
         padding: var(--spacing-3) var(--spacing-2); //12px 8px
     }
 

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -10,7 +10,6 @@
 }
 
 .rux-textarea {
-    display: inline-block;
     box-sizing: border-box;
     font-family: var(--font-control-body-1-font-family);
     font-size: var(--font-control-body-1-font-size);
@@ -18,29 +17,13 @@
     font-weight: var(--font-control-body-1-font-weight);
     line-height: var(--font-control-body-1-line-height);
     color: var(--color-text-primary);
-    background-color: transparent;
-    width: 100%;
-    height: 100%;
-    border: 0;
-    padding: var(--spacing-0);
-    margin: var(--spacing-0);
-    resize: none;
-    outline: none;
-}
-
-.rux-textarea-wrapper {
-    box-sizing: border-box;
-    position: relative;
-    display: flex;
+    background-color: var(--color-background-base-default);
     min-height: var(--spacing-16); //64
     width: 100%;
     padding: var(--spacing-2);
     margin: var(--spacing-0);
     border: 1px solid var(--color-border-interactive-muted);
     border-radius: var(--radius-base);
-    background-color: var(--color-background-base-default);
-    resize: both;
-    overflow-y: auto;
 
     &--invalid {
         border: 1px solid var(--color-text-error);

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.tsx
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.tsx
@@ -191,37 +191,29 @@ export class RuxTextarea implements FormFieldInterface {
                             </span>
                         </label>
                     ) : null}
-                    <div
+                    <textarea
+                        name={this.name}
+                        disabled={this.disabled}
+                        aria-invalid={this.invalid ? 'true' : 'false'}
+                        placeholder={this.placeholder}
+                        required={this.required}
+                        minlength={this.minLength}
+                        maxlength={this.maxLength}
+                        value={this.value}
                         class={{
-                            'rux-textarea-wrapper': true,
-                            'rux-textarea-wrapper--disabled': this.disabled,
-                            'rux-textarea-wrapper--invalid': this.invalid,
-                            'rux-textarea-wrapper--small':
-                                this.size === 'small',
-                            'rux-textarea-wrapper--large':
-                                this.size === 'large',
+                            'rux-textarea': true,
+                            'rux-textarea--disabled': this.disabled,
+                            'rux-textarea--invalid': this.invalid,
+                            'rux-textarea--small': this.size === 'small',
+                            'rux-textarea--large': this.size === 'large',
                         }}
-                    >
-                        <textarea
-                            name={this.name}
-                            disabled={this.disabled}
-                            aria-invalid={this.invalid ? 'true' : 'false'}
-                            placeholder={this.placeholder}
-                            required={this.required}
-                            minlength={this.minLength}
-                            maxlength={this.maxLength}
-                            value={this.value}
-                            class={{
-                                'rux-textarea': true,
-                            }}
-                            id={this.inputId}
-                            rows={this.rows}
-                            onChange={this._onChange}
-                            onInput={this._onInput}
-                            onBlur={this._onBlur}
-                            part="textarea"
-                        ></textarea>
-                    </div>
+                        id={this.inputId}
+                        rows={this.rows}
+                        onChange={this._onChange}
+                        onInput={this._onInput}
+                        onBlur={this._onBlur}
+                        part="textarea"
+                    ></textarea>
                 </div>
                 <FormFieldMessage
                     helpText={this.helpText}

--- a/packages/web-components/src/components/rux-textarea/test/__snapshots__/rux-textarea.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-textarea/test/__snapshots__/rux-textarea.spec.tsx.snap
@@ -3,9 +3,7 @@
 exports[`rux-textarea renders 1`] = `
 <rux-textarea value="">
   <mock:shadow-root>
-    <div class="rux-textarea-field" part="form-field">
-      <div class="rux-textarea-wrapper"><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-1" part="textarea" value=""></textarea>
-      </div>
+    <div class="rux-textarea-field" part="form-field"><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-1" part="textarea" value=""></textarea>
     </div>
   </mock:shadow-root>
   <input class="aux-input" type="hidden" value="">
@@ -22,9 +20,7 @@ exports[`rux-textarea renders label prop 1`] = `
             hello
           </slot>
         </span>
-      </label>
-      <div class="rux-textarea-wrapper"><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-2" part="textarea" value=""></textarea>
-      </div>
+      </label><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-2" part="textarea" value=""></textarea>
     </div>
   </mock:shadow-root>
   <input class="aux-input" type="hidden" value="">
@@ -39,9 +35,7 @@ exports[`rux-textarea renders label slot 1`] = `
         <span>
           <slot name="label"></slot>
         </span>
-      </label>
-      <div class="rux-textarea-wrapper"><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-3" part="textarea" value=""></textarea>
-      </div>
+      </label><textarea aria-invalid="false" class="rux-textarea" id="rux-textarea-3" part="textarea" value=""></textarea>
     </div>
   </mock:shadow-root>
   <div slot="label">

--- a/packages/web-components/src/components/rux-textarea/test/index.html
+++ b/packages/web-components/src/components/rux-textarea/test/index.html
@@ -17,10 +17,12 @@
         <script nomodule src="/build/astro-web-components.esm.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
+        {#
         <script
             type="module"
             src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
         ></script>
+        #}
     </head>
 
     <body class="dark-theme">
@@ -50,6 +52,13 @@
                 <rux-textarea id="helpText" name="helpText" help-text="HELP">
                 </rux-textarea>
                 <br />
+                {#
+                <style>
+                    #bothText::part(textarea) {
+                        height: 400px;
+                    }
+                </style>
+                #}
                 <rux-textarea
                     id="bothText"
                     name="bothText"
@@ -89,7 +98,8 @@ Native Text Area</textarea
                 })
             </script>
         </div>
-        <ftl-belt access-token="" file-id="SNsCCfIiWdfvZbBilZXTbW">
+        {#
+        <ftl-belt access-token="" file-id="">
             <section>
                 <h2>Figma Testing</h2>
                 <ftl-holster name="Small text area" node="1043:6671">
@@ -148,5 +158,6 @@ Native Text Area</textarea
                 </ftl-holster>
             </section>
         </ftl-belt>
+        #}
     </body>
 </html>

--- a/packages/web-components/src/components/rux-textarea/test/index.html
+++ b/packages/web-components/src/components/rux-textarea/test/index.html
@@ -51,11 +51,12 @@
                 <rux-textarea id="helpText" name="helpText" help-text="HELP">
                 </rux-textarea>
                 <br />
-                <!--<style>
+                <style>
                     #bothText::part(textarea) {
-                        height: 400px;
+                        resize: none;
+                        height: 200px;
                     }
-                </style>-->
+                </style>
                 <rux-textarea
                     id="bothText"
                     name="bothText"

--- a/packages/web-components/src/components/rux-textarea/test/index.html
+++ b/packages/web-components/src/components/rux-textarea/test/index.html
@@ -17,10 +17,10 @@
         <script nomodule src="/build/astro-web-components.esm.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
-        <!-- <script
+        <script
             type="module"
             src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script> -->
+        ></script>
     </head>
 
     <body class="dark-theme">
@@ -89,63 +89,64 @@ Native Text Area</textarea
                 })
             </script>
         </div>
-        <!-- <ftl-belt access-token="" file-id="">
-        <section>
-            <h2>Figma Testing</h2>
-            <ftl-holster name="Small text area" node="1043:6671">
-                <div style="width: 170px">
-                    <rux-textarea
-                        id="figmatextarea1"
-                        name="figmatest1"
-                        placeholder="Small textarea"
-                        size="small"rux
-                </div>
-            </ftl-holster>
+        <ftl-belt access-token="" file-id="SNsCCfIiWdfvZbBilZXTbW">
+            <section>
+                <h2>Figma Testing</h2>
+                <ftl-holster name="Small text area" node="1043:6671">
+                    <div style="width: 170px">
+                        <rux-textarea
+                            id="figmatextarea1"
+                            name="figmatest1"
+                            placeholder="Small textarea"
+                            size="small"
+                        ></rux-textarea>
+                    </div>
+                </ftl-holster>
 
-            <ftl-holster name="Medium text area" node="1043:6665">
-                <div style="width: 170px">
-                    <rux-textarea
-                        id="figmatextarea1"
-                        name="figmatest1"
-                        placeholder="Medium textarea"
-                    ></rux-textarea>
-                </div>
-            </ftl-holster>
+                <ftl-holster name="Medium text area" node="1043:6665">
+                    <div style="width: 170px">
+                        <rux-textarea
+                            id="figmatextarea1"
+                            name="figmatest1"
+                            placeholder="Medium textarea"
+                        ></rux-textarea>
+                    </div>
+                </ftl-holster>
 
-            <ftl-holster name="Large text area" node="1043:6689">
-                <div style="width: 170px">
-                    <rux-textarea
-                        id="figmatextarea1"
-                        name="figmatest1"
-                        placeholder="Large textarea"
-                        size="large"
-                    ></rux-textarea>
-                </div>
-            </ftl-holster>
+                <ftl-holster name="Large text area" node="1043:6689">
+                    <div style="width: 170px">
+                        <rux-textarea
+                            id="figmatextarea1"
+                            name="figmatest1"
+                            placeholder="Large textarea"
+                            size="large"
+                        ></rux-textarea>
+                    </div>
+                </ftl-holster>
 
-            <ftl-holster name="With Help Text" node="1043:6604">
-                <div style="width: 170px">
-                    <rux-textarea
-                        id="figmatextarea1"
-                        name="figmatest1"
-                        value="Textarea"
-                        help-text="help"
-                    ></rux-textarea>
-                </div>
-            </ftl-holster>
+                <ftl-holster name="With Help Text" node="1043:6604">
+                    <div style="width: 170px">
+                        <rux-textarea
+                            id="figmatextarea1"
+                            name="figmatest1"
+                            value="Textarea"
+                            help-text="help"
+                        ></rux-textarea>
+                    </div>
+                </ftl-holster>
 
-            <ftl-holster name="With Error Text" node="1057:3759">
-                <div style="min-width: 170px">
-                    <rux-textarea
-                        invalid
-                        id="figmatextarea1"
-                        name="figmatest1"
-                        placeholder="Textarea"
-                        error-text="error"
-                    ></rux-textarea>
-                </div>
-            </ftl-holster>
-        </section>
-        </ftl-belt> -->
+                <ftl-holster name="With Error Text" node="1057:3759">
+                    <div style="min-width: 170px">
+                        <rux-textarea
+                            invalid
+                            id="figmatextarea1"
+                            name="figmatest1"
+                            placeholder="Textarea"
+                            error-text="error"
+                        ></rux-textarea>
+                    </div>
+                </ftl-holster>
+            </section>
+        </ftl-belt>
     </body>
 </html>

--- a/packages/web-components/src/components/rux-textarea/test/index.html
+++ b/packages/web-components/src/components/rux-textarea/test/index.html
@@ -17,12 +17,11 @@
         <script nomodule src="/build/astro-web-components.esm.js"></script>
 
         <link rel="stylesheet" href="/build/astro-web-components.css" />
-        {#
-        <script
+
+        <!-- <script
             type="module"
             src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script>
-        #}
+        ></script>-->
     </head>
 
     <body class="dark-theme">
@@ -52,13 +51,11 @@
                 <rux-textarea id="helpText" name="helpText" help-text="HELP">
                 </rux-textarea>
                 <br />
-                {#
-                <style>
+                <!--<style>
                     #bothText::part(textarea) {
                         height: 400px;
                     }
-                </style>
-                #}
+                </style>-->
                 <rux-textarea
                     id="bothText"
                     name="bothText"
@@ -98,8 +95,11 @@ Native Text Area</textarea
                 })
             </script>
         </div>
-        {#
-        <ftl-belt access-token="" file-id="">
+
+        <!--<ftl-belt
+            access-token=""
+            file-id=""
+        >
             <section>
                 <h2>Figma Testing</h2>
                 <ftl-holster name="Small text area" node="1043:6671">
@@ -157,7 +157,6 @@ Native Text Area</textarea
                     </div>
                 </ftl-holster>
             </section>
-        </ftl-belt>
-        #}
+        </ftl-belt>-->
     </body>
 </html>


### PR DESCRIPTION
## Brief Description

Made a change to rux-textarea that reverts the code layout back from
```<div class="wrapper">
<textarea></textarea>
</div>```

To a simpler <textarea></textarea>

## JIRA Link

[ASTRO-4688](https://rocketcom.atlassian.net/browse/ASTRO-4688)
[ASTRO-4691](https://rocketcom.atlassian.net/browse/ASTRO-4691)

## Related Issue
[815](https://github.com/RocketCommunicationsInc/astro/issues/815)
[814](https://github.com/RocketCommunicationsInc/astro/issues/814)

## General Notes

## Motivation and Context

While originally, this change was made to combat a textarea bug in safari, the unintended consequence was to make rux-textarea less intuitive and in some cases less accessible for developers. So we are rolling back that change and things should work as they once did.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
