### PR TITLE
fix(tabs): allow for dynamic tab additions

### DIFF
--- a/.changeset/light-teachers-fold.md
+++ b/.changeset/light-teachers-fold.md
@@ -1,0 +1,9 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Fixed an issue in rux-tabs where dynamically adding a tab would result in unexpected behavior.

--- a/packages/web-components/src/components/rux-tabs/rux-tab-panels/rux-tab-panels.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tab-panels/rux-tab-panels.tsx
@@ -39,8 +39,6 @@ export class RuxTabPanels {
     @Event({ eventName: 'ruxregisterpanels' })
     ruxRegisterPanels!: EventEmitter<HTMLRuxTabPanelsElement[]>
     private _registerTabPanels(children: HTMLRuxTabPanelsElement[]) {
-        console.log('running registerTabPanels')
-
         this.ruxRegisterPanels.emit(children)
     }
 

--- a/packages/web-components/src/components/rux-tabs/rux-tab-panels/rux-tab-panels.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tab-panels/rux-tab-panels.tsx
@@ -16,10 +16,6 @@ export class RuxTabPanels {
         this._getSlottedChildren = this._getSlottedChildren.bind(this)
     }
 
-    componentDidLoad() {
-        this._registerTabPanels(this._getSlottedChildren())
-    }
-
     private _getSlottedChildren() {
         const slot = this.el?.shadowRoot?.querySelector('slot')
 
@@ -43,6 +39,8 @@ export class RuxTabPanels {
     @Event({ eventName: 'ruxregisterpanels' })
     ruxRegisterPanels!: EventEmitter<HTMLRuxTabPanelsElement[]>
     private _registerTabPanels(children: HTMLRuxTabPanelsElement[]) {
+        console.log('running registerTabPanels')
+
         this.ruxRegisterPanels.emit(children)
     }
 

--- a/packages/web-components/src/components/rux-tabs/rux-tab-panels/rux-tab-panels.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tab-panels/rux-tab-panels.tsx
@@ -13,6 +13,7 @@ export class RuxTabPanels {
 
     connectedCallback() {
         this.el.setAttribute('style', 'position: relative; width: 100%;')
+        this._getSlottedChildren = this._getSlottedChildren.bind(this)
     }
 
     componentDidLoad() {
@@ -21,12 +22,15 @@ export class RuxTabPanels {
 
     private _getSlottedChildren() {
         const slot = this.el?.shadowRoot?.querySelector('slot')
+
         if (slot) {
             const childNodes = slot.assignedNodes({ flatten: true })
             const children = Array.prototype.filter.call(
                 childNodes,
                 (node) => node.nodeType == Node.ELEMENT_NODE
             )
+
+            this._registerTabPanels(children)
             return children
         } else {
             return []
@@ -45,7 +49,7 @@ export class RuxTabPanels {
     render() {
         return (
             <Host>
-                <slot></slot>
+                <slot onSlotchange={this._getSlottedChildren}></slot>
             </Host>
         )
     }

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
@@ -72,6 +72,8 @@ export class RuxTabs {
         e.detail.forEach((panel: HTMLRuxTabPanelElement) => {
             this._panels.push(panel)
         })
+        // run addTabs if this event was heard.
+        this._addTabs()
 
         // Default to first tab if none are selected
         const selectedTab =
@@ -93,6 +95,7 @@ export class RuxTabs {
     private _reset() {
         // hide everything
         // Only reset the tabs and panels that are part of this instance of rux-tabs
+
         this._tabs.forEach((tab) => {
             if (tab.parentElement === this.el) tab.selected = false
         })

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -19,5 +19,41 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body></body>
+    <body>
+        <rux-tabs id="tab-set-id-1">
+            <rux-tab id="tab-id-1">Tab 1 title</rux-tab>
+            <rux-tab id="tab-id-2">Tab 2 title</rux-tab>
+            <rux-tab id="tab-id-3">Tab 3 title</rux-tab>
+        </rux-tabs>
+
+        <rux-tab-panels aria-labelledby="tab-set-id-1">
+            <rux-tab-panel aria-labelledby="tab-id-1"
+                >Tab 1 HTML content</rux-tab-panel
+            >
+            <rux-tab-panel aria-labelledby="tab-id-2"
+                >Tab 2 HTML content</rux-tab-panel
+            >
+            <rux-tab-panel aria-labelledby="tab-id-3"
+                >Tab 3 HTML content</rux-tab-panel
+            >
+        </rux-tab-panels>
+        <rux-button id="add">Add Tab</rux-button>
+        <script>
+            let tabs = document.querySelector('rux-tabs')
+            let panels = document.querySelector('rux-tab-panels')
+            let btn = document.getElementById('add')
+            let count = document.querySelectorAll('rux-tab').length
+            btn.addEventListener('click', () => {
+                let newTab = document.createElement('rux-tab')
+                count++
+                newTab.id = `tab-id-${count}`
+                newTab.textContent = `Tab ${count} title`
+                let newPanel = document.createElement('rux-tab-panel')
+                newPanel.setAttribute('aria-labelledby', `tab-id-${count}`)
+                newPanel.textContent = `Tab ${count} HTML content`
+                tabs.appendChild(newTab)
+                panels.appendChild(newPanel)
+            })
+        </script>
+    </body>
 </html>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -19,41 +19,5 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body>
-        <rux-tabs id="tab-set-id-1">
-            <rux-tab id="tab-id-1">Tab 1 title</rux-tab>
-            <rux-tab id="tab-id-2">Tab 2 title</rux-tab>
-            <rux-tab id="tab-id-3">Tab 3 title</rux-tab>
-        </rux-tabs>
-
-        <rux-tab-panels aria-labelledby="tab-set-id-1">
-            <rux-tab-panel aria-labelledby="tab-id-1"
-                >Tab 1 HTML content</rux-tab-panel
-            >
-            <rux-tab-panel aria-labelledby="tab-id-2"
-                >Tab 2 HTML content</rux-tab-panel
-            >
-            <rux-tab-panel aria-labelledby="tab-id-3"
-                >Tab 3 HTML content</rux-tab-panel
-            >
-        </rux-tab-panels>
-        <rux-button id="add">Add Tab</rux-button>
-        <script>
-            let tabs = document.querySelector('rux-tabs')
-            let panels = document.querySelector('rux-tab-panels')
-            let btn = document.getElementById('add')
-            let count = document.querySelectorAll('rux-tab').length
-            btn.addEventListener('click', () => {
-                let newTab = document.createElement('rux-tab')
-                count++
-                newTab.id = `tab-id-${count}`
-                newTab.textContent = `Tab ${count} title`
-                let newPanel = document.createElement('rux-tab-panel')
-                newPanel.setAttribute('aria-labelledby', `tab-id-${count}`)
-                newPanel.textContent = `Tab ${count} HTML content`
-                tabs.appendChild(newTab)
-                panels.appendChild(newPanel)
-            })
-        </script>
-    </body>
+    <body></body>
 </html>

--- a/packages/web-components/tests/tabs.spec.ts
+++ b/packages/web-components/tests/tabs.spec.ts
@@ -236,6 +236,86 @@ test.describe('Multiple tabs on same page', () => {
         await expect(topContent2).toBeVisible()
         await expect(bottomContent).toBeVisible()
     })
+    test('it can dynamically add tabs that behave correctly', async ({
+        page,
+    }) => {
+        await setBodyContent(
+            page,
+            `
+        <rux-tabs id="tab-set-id-1">
+        <rux-tab id="tab-id-1">Tab 1 title</rux-tab>
+        <rux-tab id="tab-id-2">Tab 2 title</rux-tab>
+        <rux-tab id="tab-id-3">Tab 3 title</rux-tab>
+    </rux-tabs>
+
+    <rux-tab-panels aria-labelledby="tab-set-id-1">
+        <rux-tab-panel aria-labelledby="tab-id-1">Tab 1 HTML content</rux-tab-panel>
+        <rux-tab-panel aria-labelledby="tab-id-2">Tab 2 HTML content</rux-tab-panel>
+        <rux-tab-panel aria-labelledby="tab-id-3">Tab 3 HTML content</rux-tab-panel>
+    </rux-tab-panels>
+    <rux-button id="add">Add Tab</rux-button>
+        `
+        )
+        await page.addScriptTag({
+            content: `
+    let tabs = document.querySelector('rux-tabs')
+    let panels = document.querySelector('rux-tab-panels')
+    let btn = document.getElementById('add')
+    let count = document.querySelectorAll('rux-tab').length
+    btn.addEventListener('click', () => {
+        let newTab = document.createElement('rux-tab')
+        count++
+        newTab.id = 'tab-id-' + count
+        newTab.textContent = 'Tab' + count + ' title'
+        let newPanel = document.createElement('rux-tab-panel')
+        let str = 'tab-id-' + count
+        newPanel.setAttribute('aria-labelledby', str)
+        newPanel.textContent = 'Tab ' + count + ' HTML content'
+        tabs.appendChild(newTab)
+        panels.appendChild(newPanel)
+    })
+    `,
+        })
+
+        //Add new tab by pressing button, select new tab, select diff tab. Check selected at each stage
+        const btn = page.locator('#add')
+        await btn.click()
+        const newTab = page.locator('#tab-id-4')
+        await newTab
+            .evaluate((e) => {
+                return e.hasAttribute('selected')
+            })
+            .then((e) => {
+                expect(e).toBeFalsy()
+            })
+        await newTab.click()
+        await page.waitForTimeout(100)
+        await newTab
+            .evaluate((e) => {
+                return e.hasAttribute('selected')
+            })
+            .then((e) => {
+                expect(e).toBeTruthy()
+            })
+        // click again on first tab, make sure newTab becomes un-selected
+        const firstTab = page.locator('#tab-id-1')
+        await firstTab.click()
+        await page.waitForTimeout(100)
+        await firstTab
+            .evaluate((e) => {
+                return e.hasAttribute('selected')
+            })
+            .then((e) => {
+                expect(e).toBeTruthy
+            })
+        await newTab
+            .evaluate((e) => {
+                return e.hasAttribute('selected')
+            })
+            .then((e) => {
+                expect(e).toBeFalsy()
+            })
+    })
 })
 /*
     Need to test: 


### PR DESCRIPTION
## Brief Description

Fixes an issue where tabs could not be dynamically added. 
- new tabs no longer retain selected state when they shouldn't 
- new panel content no longer shows when it shouldn't 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4719

## Related Issue

## General Notes

## Motivation and Context

Dynamically added rux-tabs were resulting in unexpected results. 

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
