### PR TITLE
correct image link

### DIFF
--- a/packages/astro-uxds/_content/components/global-status-bar.md
+++ b/packages/astro-uxds/_content/components/global-status-bar.md
@@ -20,7 +20,7 @@ The Global Status Bar has four main parts: App Icon, App Title, App State, and L
 
 ![Simplest Global Status Bar - Only include the App Title.](/img/components/global-status-simple.png "Simplest Global Status Bar - Only include the App Title.")
 
-![Standard Global Status Bar - App Icon, App Title, App State, and Logged-in Username](/img/components/global-status-very.png "Standard Global Status Bar - App Icon, App Title, App State, and Logged-in Username")
+![Standard Global Status Bar - App Icon, App Title, App State, and Logged-in Username](/img/components/global-status-standard.png "Standard Global Status Bar - App Icon, App Title, App State, and Logged-in Username")
 
 ![Complex Global Status Bar - App Icon, App Title, App State, Logged-in Username, Clock, and Monitoring Icons.](/img/components/global-status-complex.png "Complex Global Status Bar - App Icon, App Title, App State, Logged-in Username, Clock, and Monitoring Icons.")
 

--- a/packages/astro-uxds/_includes/home.template.njk
+++ b/packages/astro-uxds/_includes/home.template.njk
@@ -91,20 +91,6 @@
 							<h4>Upcoming Events</h4>
 							<div class="p-community-events-content">
 								<!--event-->
-								<a href="https://forms.gle/vdoSpJ7gnRy9tXCB8" target="_blank" class="p-community-event" aria-label="Astro ux working group">
-									<span class="p-community-event-date">
-										<span class="-date">10/10/2022</span><br />
-										<span class="-time">11:00 AM PST</span>
-									</span>
-									<hgroup class="p-community-event-heading">
-										<h5>ASTRO UX Working Group</h5>
-										<span class="p-community-event-subheading">Request an invite by email: support@astrouxds.com</span>
-									</hgroup>
-									<small class="p-community-event-actions">
-										<span class="link-arrow event-link">Join the Group</span>
-									</small>
-								</a>
-								<!--event-->
 								<a href="mailto:dnutter@rocketcom.com" class="p-community-event" aria-label="Astro office hours">
 									<span class="p-community-event-date">
 										<span class="-date">10/12/2022</span><br />
@@ -172,6 +158,20 @@
 									</hgroup>
 									<small class="p-community-event-actions">
 										<span class="link-arrow event-link">Contact Us</span>
+									</small>
+								</a>
+								<!--event-->
+								<a href="https://forms.gle/vdoSpJ7gnRy9tXCB8" target="_blank" class="p-community-event" aria-label="Astro ux working group">
+									<span class="p-community-event-date">
+										<span class="-date">11/07/2022</span><br />
+										<span class="-time">11:00 AM PST</span>
+									</span>
+									<hgroup class="p-community-event-heading">
+										<h5>ASTRO UX Working Group</h5>
+										<span class="p-community-event-subheading">Request an invite by email: support@astrouxds.com</span>
+									</hgroup>
+									<small class="p-community-event-actions">
+										<span class="link-arrow event-link">Join the Group</span>
 									</small>
 								</a>
 							</div>


### PR DESCRIPTION
## Brief Description

An image on https://www.astrouxds.com/components/global-status-bar/ page was broken. It turned out that the src was just incorrect so I directed it to the proper image.

While I was in there I also took the opportunity to update the Events on the home page. They do not programmatically update.

## JIRA Link

[ASTRO- 4742](https://rocketcom.atlassian.net/browse/ASTRO-4742)

## Related Issue

## General Notes

## Motivation and Context

link fix
## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
