### PR TITLE
docs(vue): deprecated slot eslint rule

### DIFF
--- a/packages/starter-kits/vue-starter/package.json
+++ b/packages/starter-kits/vue-starter/package.json
@@ -33,7 +33,9 @@
     "parserOptions": {
       "parser": "babel-eslint"
     },
-    "rules": {}
+    "rules": {
+      "vue/no-deprecated-slot-attribute": "off"
+    }
   },
   "browserslist": [
     "> 1%",

--- a/packages/web-components/src/stories/astro-uxds/welcome/vue.stories.mdx
+++ b/packages/web-components/src/stories/astro-uxds/welcome/vue.stories.mdx
@@ -123,6 +123,20 @@ module.exports = {
   </rux-tab-panel>
 </rux-tab-panels>
 
+### Disable eslint rule
+Be aware that if you try to pass in any native HTML elements as slots using the `slot` attribute, as of Vue 2.6.0+, Vue's eslint config will throw a [no-deprecated-slot-attribute](https://eslint.vuejs.org/rules/no-deprecated-slot-attribute.html) error at you. 
+This is because Vue 3 removed the `slot` attribute in favor of `v-slot`, but the `slot` attribute is still part of the [HTML Standard](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/slot).
+
+As a workaround, you can disable this eslint rule. 
+
+In your package.json, under `eslintConfig`, add to your rules:
+
+```
+    "rules": {
+      "vue/no-deprecated-slot-attribute": "off"
+    }
+```
+
 ## Using our CSS Variables (Design Tokens).
 
 While our components may solve 60% of your UI needs, you will inevitably find yourself needing to 


### PR DESCRIPTION
## Brief Description

vue is dumb and chirps at you if you use `slot` now 

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
