### PR TITLE
feat(menu): allow for nested content in menu-items

### DIFF
--- a/.changeset/pretty-walls-provide.md
+++ b/.changeset/pretty-walls-provide.md
@@ -1,0 +1,9 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-website": patch
+"@astrouxds/react": patch
+---
+
+Fixes an issue where events would not fire if there was nested content inside a rux-menu-item.

--- a/packages/web-components/src/components/rux-menu/readme.md
+++ b/packages/web-components/src/components/rux-menu/readme.md
@@ -7,9 +7,9 @@
 
 ## Events
 
-| Event             | Description                                                                                   | Type               |
-| ----------------- | --------------------------------------------------------------------------------------------- | ------------------ |
-| `ruxmenuselected` | Emits when a rux-menu-item is selected. Emits the rux-menu-item selected in the event detail. | `CustomEvent<any>` |
+| Event             | Description                                                                             | Type               |
+| ----------------- | --------------------------------------------------------------------------------------- | ------------------ |
+| `ruxmenuselected` | Emits when a rux-menu-item is selected. Emits the selected element in the event detail. | `CustomEvent<any>` |
 
 
 ----------------------------------------------

--- a/packages/web-components/src/components/rux-menu/rux-menu.tsx
+++ b/packages/web-components/src/components/rux-menu/rux-menu.tsx
@@ -11,26 +11,28 @@ export class RuxMenu {
     /**
      * Emits when a rux-menu-item is selected. Emits the rux-menu-item selected in the event detail.
      */
-    @Event({ eventName: 'ruxmenuselected' })
+    @Event({ eventName: 'ruxmenuselected', bubbles: true })
     ruxMenuSelected!: EventEmitter
 
     connectedCallback() {
         this.el.addEventListener('click', (e) => {
-            this._handleSelected(e.target as HTMLRuxMenuItemElement)
+            this._handleSelected(e.target as HTMLElement)
         })
     }
 
-    private _handleSelected(item: HTMLRuxMenuItemElement) {
+    private _handleSelected(item: HTMLElement) {
         //prevent code from running if the clicked element was disabled
-        if (item.disabled) return
-        const menuItems = Array.from(this.el.querySelectorAll('rux-menu-item'))
-        menuItems.forEach((el) => {
-            el.selected = false
-            if (el === item && !el.disabled) {
-                item.selected = true
-                this.ruxMenuSelected.emit(item)
-            }
-        })
+        if (item.hasAttribute('disabled')) return
+        //prevent items that are nested in a disabled rux-menu-item from emitting
+        if (item.closest('rux-menu-item')?.hasAttribute('disabled')) return
+        const menuItems = Array.from(this.el.children)
+        if (menuItems.length > 1) {
+            menuItems.forEach((el) => {
+                el.removeAttribute('selected')
+            })
+            item.closest('rux-menu-item')?.setAttribute('selected', '')
+        }
+        this.ruxMenuSelected.emit(item)
     }
 
     render() {

--- a/packages/web-components/src/components/rux-menu/rux-menu.tsx
+++ b/packages/web-components/src/components/rux-menu/rux-menu.tsx
@@ -9,7 +9,7 @@ export class RuxMenu {
     @Element() el!: HTMLRuxMenuElement
 
     /**
-     * Emits when a rux-menu-item is selected. Emits the rux-menu-item selected in the event detail.
+     * Emits when a rux-menu-item is selected. Emits the selected element in the event detail.
      */
     @Event({ eventName: 'ruxmenuselected' })
     ruxMenuSelected!: EventEmitter

--- a/packages/web-components/src/components/rux-menu/rux-menu.tsx
+++ b/packages/web-components/src/components/rux-menu/rux-menu.tsx
@@ -11,7 +11,7 @@ export class RuxMenu {
     /**
      * Emits when a rux-menu-item is selected. Emits the rux-menu-item selected in the event detail.
      */
-    @Event({ eventName: 'ruxmenuselected', bubbles: true })
+    @Event({ eventName: 'ruxmenuselected' })
     ruxMenuSelected!: EventEmitter
 
     connectedCallback() {
@@ -32,7 +32,9 @@ export class RuxMenu {
             })
             item.closest('rux-menu-item')?.setAttribute('selected', '')
         }
-        this.ruxMenuSelected.emit(item)
+        if (item.closest('rux-menu-item')) {
+            this.ruxMenuSelected.emit(item)
+        }
     }
 
     render() {

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -19,5 +19,39 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body></body>
+    <body>
+        <rux-pop-up close-on-select>
+            <rux-icon icon="apps" slot="trigger"></rux-icon>
+            <rux-menu>
+                <rux-menu-item>
+                    <div style="padding: 2rem">
+                        <rux-button secondary style="margin-right: 1rem"
+                            >Fire Missles</rux-button
+                        >
+                        <rux-button>Don't fire</rux-button>
+                    </div>
+                </rux-menu-item>
+            </rux-menu>
+        </rux-pop-up>
+        <rux-pop-up>
+            <rux-icon icon="altitude" slot="trigger"></rux-icon>
+            <rux-menu>
+                <rux-menu-item>Item 1</rux-menu-item>
+                <rux-menu-item>
+                    <div>Nested Item 2</div>
+                </rux-menu-item>
+                <rux-menu-item>
+                    <div>
+                        <span>Nested item 3</span>
+                    </div>
+                </rux-menu-item>
+            </rux-menu>
+        </rux-pop-up>
+        <script>
+            document.addEventListener('ruxmenuselected', (e) => {
+                console.log('heard ruxmenuselected!')
+                console.log(e.detail)
+            })
+        </script>
+    </body>
 </html>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -19,37 +19,5 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body>
-        <rux-pop-up close-on-select>
-            <rux-icon icon="apps" slot="trigger"></rux-icon>
-            <rux-menu>
-                <rux-menu-item>
-                    <div style="padding: 2rem">
-                        <rux-button secondary style="margin-right: 1rem"
-                            >Fire Missles</rux-button
-                        >
-                        <rux-button>Don't fire</rux-button>
-                    </div>
-                </rux-menu-item>
-            </rux-menu>
-        </rux-pop-up>
-        <rux-pop-up>
-            <rux-icon icon="altitude" slot="trigger"></rux-icon>
-            <rux-menu>
-                <rux-input placeholder="placeholder"></rux-input>
-                <rux-input placeholder="placeholder"></rux-input>
-                <rux-input placeholder="placeholder"></rux-input>
-                <div>
-                    <rux-button secondary>Cancel</rux-button>
-                    <rux-button>Confrim</rux-button>
-                </div>
-            </rux-menu>
-        </rux-pop-up>
-        <script>
-            document.addEventListener('ruxmenuselected', (e) => {
-                console.log('heard ruxmenuselected!')
-                console.log(e.detail)
-            })
-        </script>
-    </body>
+    <body></body>
 </html>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -36,15 +36,13 @@
         <rux-pop-up>
             <rux-icon icon="altitude" slot="trigger"></rux-icon>
             <rux-menu>
-                <rux-menu-item>Item 1</rux-menu-item>
-                <rux-menu-item>
-                    <div>Nested Item 2</div>
-                </rux-menu-item>
-                <rux-menu-item>
-                    <div>
-                        <span>Nested item 3</span>
-                    </div>
-                </rux-menu-item>
+                <rux-input placeholder="placeholder"></rux-input>
+                <rux-input placeholder="placeholder"></rux-input>
+                <rux-input placeholder="placeholder"></rux-input>
+                <div>
+                    <rux-button secondary>Cancel</rux-button>
+                    <rux-button>Confrim</rux-button>
+                </div>
             </rux-menu>
         </rux-pop-up>
         <script>


### PR DESCRIPTION
## Brief Description

Updates rux-menu to handle nested content inside of rux-menu-items. 
Previously, if you had content that wasn't a rux-menu-item or nested content inside a menu-item, the events wouldn't fire like they should. 

## JIRA Link


## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/839

## General Notes

## Motivation and Context

Allows for rux-menu to be used as a container, but also provides selection functionality when used with rux-menu-items. 

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
