### PR TITLE
docs: Fix a dated reference to Edge support

### DIFF
--- a/packages/astro-uxds/_content/components/_readme.md
+++ b/packages/astro-uxds/_content/components/_readme.md
@@ -29,4 +29,4 @@ While the initial components were purposefully created to be framework-agnostic,
 - Code is generic; it follows a similar format to popular frameworks like Angular and React, without being prescriptive.
 - All the major JS frameworks were built to reflect the ideas of WebComponents and/or influenced the Web Component v1 specification; Web Components are an accepted and respected pattern in the JS community
 - Localized Web Component HTML and CSS minimizes or eliminates the need for complicated CSS naming structures e.g., `.rux-button--small__light`
-- Web Components are a W3 standard, requiring no vendor lock-in or decisions about which frameworks to use. Chrome, Firefox, and Safari support Web Components v1 without the need for polyfills. Microsoft has committed to supporting the standard in a future version of Edge. Note: IE11+ supports Web Components via polyfills.
+- Web Components are a W3 standard, requiring no vendor lock-in or decisions about which frameworks to use. All modern browsers support Web Components. Microsoft has committed to supporting the standard in a future version of Edge. Note: IE11+ supports Web Components via polyfills.


### PR DESCRIPTION
## Brief Description

This updates the web components documentation to update a dated reference to Edge support.

## JIRA Link

There is no ticket.

## Related Issue

## General Notes

## Motivation and Context

It inaccurately reflects the current state of the web.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers

☝️ None of these are related to the change.