### PR TITLE
Km 4780 rux notification message display

### DIFF
--- a/.changeset/spicy-buses-play.md
+++ b/.changeset/spicy-buses-play.md
@@ -1,0 +1,9 @@
+---
+"@astrouxds/astro-web-components": major
+---
+
+WHAT: rux-notification: remove message prop
+
+WHY: when other named slots are entered into <rux-notification></rux-notification> the message prop is overwritten by unintentional blank spaces and carriage returns. A better pattern might be to have devs enter their message into the default slot.
+
+HOW TO MIGRATE: If you were previously using message="my notification" to add your notification message, please move the message to the default slot within rux-notification such as <rux-notification>My Message</rux-notification>

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -12080,10 +12080,6 @@ export namespace Components {
          */
         "hideClose": boolean;
         /**
-          * Message for the notification banner.
-         */
-        "message": string;
-        /**
           * Set to true to display the Banner and begin countdown to close (if a close-after Number value is provided).
          */
         "open": boolean;
@@ -32540,10 +32536,6 @@ declare namespace LocalJSX {
           * Prevents the user from dismissing the notification. Hides the `actions` slot.
          */
         "hideClose"?: boolean;
-        /**
-          * Message for the notification banner.
-         */
-        "message"?: string;
         /**
           * Fires when the notification banner is closed
          */

--- a/packages/web-components/src/components/rux-notification/rux-notification.tsx
+++ b/packages/web-components/src/components/rux-notification/rux-notification.tsx
@@ -36,11 +36,6 @@ export class RuxNotification {
      *  Set to true to display the Banner and begin countdown to close (if a close-after Number value is provided).
      */
     @Prop({ reflect: true, mutable: true }) open: boolean = false
-
-    /**
-     *  Message for the notification banner.
-     */
-    @Prop() message: string = ''
     /**
      *  The background color. Possible values include 'off', 'standby', 'normal', 'caution', 'serious' and 'critical'. See [Astro UXDS Status System](https://astrouxds.com/patterns/status-system/).
      */
@@ -121,6 +116,7 @@ export class RuxNotification {
     }
 
     render() {
+        console.log()
         return (
             <Host>
                 <div
@@ -176,7 +172,7 @@ export class RuxNotification {
                             }}
                             part="message"
                         >
-                            <slot>{this.message}</slot>
+                            <slot></slot>
                         </div>
 
                         {!this.hideClose ? (

--- a/packages/web-components/src/components/rux-notification/test/__snapshots__/rux-notification.spec.tsx.snap
+++ b/packages/web-components/src/components/rux-notification/test/__snapshots__/rux-notification.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`rux-notification renders 1`] = `
-<rux-notification message="hello there" open="">
+<rux-notification open="">
   <mock:shadow-root>
     <div class="rux-notification-banner rux-notification-banner--large rux-notification-banner--open">
       <div class="rux-notification-banner__inner" part="container">
@@ -9,9 +9,7 @@ exports[`rux-notification renders 1`] = `
           <slot name="prefix"></slot>
         </div>
         <div class="rux-notification-banner__content" part="message">
-          <slot>
-            hello there
-          </slot>
+          <slot></slot>
         </div>
         <div class="rux-notification-banner__actions">
           <slot name="actions">
@@ -21,5 +19,6 @@ exports[`rux-notification renders 1`] = `
       </div>
     </div>
   </mock:shadow-root>
+  hello there
 </rux-notification>
 `;

--- a/packages/web-components/src/components/rux-notification/test/index.html
+++ b/packages/web-components/src/components/rux-notification/test/index.html
@@ -22,6 +22,10 @@
     </head>
 
     <body>
+        <rux-notification open status="standby">
+            <rux-icon icon="apps" slot="prefix"></rux-icon>
+            Insert better example here
+        </rux-notification>
         <section>
             <h2>Default</h2>
             <div style="position: relative; overflow: hidden; height: 200px">
@@ -291,7 +295,16 @@
                 in voluptatem ea dolor quas, distinctio nobis esse praesentium
                 necessitatibus minus cumque corporis?
             </p>
-            <rux-notification open status="critical" small>
+            <rux-notification
+                open
+                status="critical"
+                small
+                message="Notification banner Lorem ipsum dolor sit amet consectetur,
+                    adipisicing elit. Voluptas velit incidunt inventore numquam
+                    voluptates debitis neque perferendis, maxime exercitationem
+                    eligendi possimus ipsa labore aperiam eveniet. Accusantium
+                    nisi autem eligendi quos?"
+            >
                 <p>
                     Notification banner Lorem ipsum dolor sit amet consectetur,
                     adipisicing elit. Voluptas velit incidunt inventore numquam

--- a/packages/web-components/src/components/rux-notification/test/index.html
+++ b/packages/web-components/src/components/rux-notification/test/index.html
@@ -22,6 +22,38 @@
     </head>
 
     <body>
+        <rux-notification open id="notification" status="caution"
+            >Something caution has happened!</rux-notification
+        >
+        <script>
+            const eventSequence = [
+                {
+                    status: 'critical',
+                    message: '1 - something critical',
+                },
+                {
+                    status: 'normal',
+                    message: '2 - something normal',
+                },
+                {
+                    status: 'normal',
+                    message: '3 - something normal again',
+                },
+            ]
+            const notification = document.querySelector('#notification')
+            notification.addEventListener('ruxclosed', () => {
+                if (eventSequence.length > 0) {
+                    // Grab the first notification data
+                    notification.textContent = eventSequence[0].message
+                    notification.status = eventSequence[0].status
+                    // Remove the notification from the stack
+                    eventSequence.shift()
+                    // Reopen the notification
+                    notification.open = true
+                }
+            })
+        </script>
+
         <rux-notification open status="standby">
             <rux-icon icon="apps" slot="prefix"></rux-icon>
             Insert better example here
@@ -29,11 +61,9 @@
         <section>
             <h2>Default</h2>
             <div style="position: relative; overflow: hidden; height: 200px">
-                <rux-notification
-                    open
-                    data-test-id="default"
-                    message="testing time"
-                ></rux-notification>
+                <rux-notification open data-test-id="default"
+                    >testing time</rux-notification
+                >
             </div>
         </section>
 

--- a/packages/web-components/src/components/rux-notification/test/rux-notification.spec.tsx
+++ b/packages/web-components/src/components/rux-notification/test/rux-notification.spec.tsx
@@ -8,14 +8,14 @@ describe('rux-notification', () => {
     it('renders', async () => {
         const page = await newSpecPage({
             components: [RuxNotification],
-            html: `<rux-notification open message="hello there"></rux-notification>`,
+            html: `<rux-notification open>hello there</rux-notification>`,
         })
         expect(page.root).toMatchSnapshot()
     })
     it('sets open to false after the closeAfter time has been met', async () => {
         const ruxNotif = new RuxNotification()
         ruxNotif.open = true
-        ruxNotif.message = 'Hey, Listen!'
+        ruxNotif.innerHTML = 'Hey, Listen!'
         ruxNotif.status = 'critical'
         ruxNotif.closeAfter = 3000
         ruxNotif._updated()
@@ -25,7 +25,7 @@ describe('rux-notification', () => {
     it('changes open to false with the _onClick method', async () => {
         const ruxNotif = new RuxNotification()
         ruxNotif.open = true
-        ruxNotif.message = 'The Light provides'
+        ruxNotif.innerHTML = 'The Light provides'
         ruxNotif.status = 'normal'
         ruxNotif._onClick()
         expect(ruxNotif.open).toBe(false)
@@ -33,7 +33,7 @@ describe('rux-notification', () => {
     it('returns the correct value using the get _closeAfter method', async () => {
         const ruxNotif = new RuxNotification()
         ruxNotif.open = true
-        ruxNotif.message = 'SEVENTH COLUMN'
+        ruxNotif.innerHTML = 'SEVENTH COLUMN'
         ruxNotif.status = 'critical'
         ruxNotif.closeAfter = 3000
         ruxNotif._closeAfter
@@ -42,7 +42,7 @@ describe('rux-notification', () => {
     it('can accept milisecond values for closeAfter and closes notification', async () => {
         const ruxNotif = new RuxNotification()
         ruxNotif.open = true
-        ruxNotif.message = 'The Duality of RuxNotification'
+        ruxNotif.innerHTML = 'The Duality of RuxNotification'
         ruxNotif.status = 'caution'
         ruxNotif.closeAfter = 3000
         ruxNotif._updated()
@@ -53,7 +53,7 @@ describe('rux-notification', () => {
     it('can accept second values for closeAfter and closes notification', async () => {
         const ruxNotif = new RuxNotification()
         ruxNotif.open = true
-        ruxNotif.message = 'The Duality of RuxNotification'
+        ruxNotif.innerHTML = 'The Duality of RuxNotification'
         ruxNotif.status = 'caution'
         ruxNotif.closeAfter = 3
         ruxNotif._updated()
@@ -62,7 +62,7 @@ describe('rux-notification', () => {
     it('get _closeAfter returns 2000 if closeAfter is > 10s or < 2s', async () => {
         const ruxNotif = new RuxNotification()
         ruxNotif.open = true
-        ruxNotif.message = 'Drums, drums in the deep'
+        ruxNotif.innerHTML = 'Drums, drums in the deep'
         ruxNotif.status = 'critical'
         ruxNotif.closeAfter = 1
         ruxNotif._closeAfter

--- a/packages/web-components/src/stories/notification.stories.mdx
+++ b/packages/web-components/src/stories/notification.stories.mdx
@@ -3,8 +3,6 @@ import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
 import { html, render } from 'lit-html'
 const args = extractArgTypes('rux-notification')
 args.open.defaultValue = true
-args.message.defaultValue =
-    'This is a notification banner. It won’t disappear until the user dismisses it.'
 args.status.defaultValue = 'standby'
 
 <Meta
@@ -39,8 +37,7 @@ export const Default = (args) => {
         .closeAfter="${args.closeAfter}"
         .hideClose="${args.hideClose}"
         status="${args.status}"
-        message="${args.message}"
-    ></rux-notification>
+    >Notification Banner</rux-notification>
 </div>
     `
 }
@@ -52,7 +49,6 @@ export const Default = (args) => {
         args={{
             open: true,
             closeAfter: null,
-            message: "This is a notification banner. It won’t disappear until the user dismisses it.",
             status: "standby"
         }}
     >
@@ -90,7 +86,7 @@ A very basic pattern would look like:
     notification.addEventListener('ruxclosed', () => {
         if (eventSequence.length > 0) {
             // Grab the first notification data
-            notification.message = eventSequence[0].message
+            notification.textContent = eventSequence[0].message
             notification.status = eventSequence[0].status
             // Remove the notification from the stack
             eventSequence.shift()
@@ -119,8 +115,7 @@ export const NotificationAutoClose = (args) => {
         ?small="${args.small}"
         .closeAfter="${args.closeAfter}"
         .status="${args.status}"
-        message="This is a notification banner. It will disappear in 2000 ms."
-    ></rux-notification>
+    >Notification banner</rux-notification>
 </div>
     `
 }
@@ -152,8 +147,7 @@ export const HideClose = (args) => {
         .closeAfter="${args.closeAfter}"
         .status="${args.status}"
         .hideClose="${args.hideClose}"
-        message="This is a notification banner. It will disappear in 2000 ms."
-    ></rux-notification>
+    >Notification banner</rux-notification>
 </div>
     `
 }
@@ -182,8 +176,7 @@ export const Small = (args) => {
         ?small="${args.small}"
         .closeAfter="${args.closeAfter}"
         status="${args.status}"
-        message="${args.message}"
-    ></rux-notification>
+    >Notification banner</rux-notification>
 </div>
     `
 }
@@ -203,7 +196,6 @@ export const PrefixSlot = (args) => {
         ?open="${args.open}"
         .closeAfter="${args.closeAfter}"
         status="${args.status}"
-        message="${args.message}"
     >
     <rux-classification-marking classification="unclassified" tag slot="prefix"></rux-classification-marking>
     Notification banner
@@ -220,10 +212,8 @@ export const PrefixSlot = (args) => {
 
 ### Default Slot
 
-Use the default slot for more control over the content inside your Notification, for example, adding a link
+Use the default slot for control over the content inside your Notification, for example, adding a link
 within your message. 
-
-> NOTE: Content placed inside the default slot will override the `message` attribute.
 
 export const DefaultSlot = (args) => {
     return html`
@@ -282,8 +272,7 @@ export const WithSlottedContent = (args) => {
         ?small="${args.small}"
         .closeAfter="${args.closeAfter}"
         status="${args.status}"
-        message="${args.message}"
-    ></rux-notification>
+    >Notification banner</rux-notification>
 </div>
     `
 }
@@ -438,7 +427,6 @@ export const AllVariants = () => html`
         name="All Variants"
         argTypes={{
             closeAfter: { table: { disable: true } },
-            message: { table: { disable: true } },
             open: { table: { disable: true } },
             status: { table: { disable: true } }
         }}


### PR DESCRIPTION
## Brief Description

Removed the message prop from rux-notification. This is a major breaking change.

## JIRA Link

[ASTRO-4780](https://rocketcom.atlassian.net/browse/ASTRO-4780)

## General Notes

**The Problem**
When a named slot is added to <rux-notification> the fallback prop 'message' for the default slot is no longer displayed.

For example:
` <rux-notification open status="standby" message="Insert better example here"> `
`   <rux-icon icon="apps" slot="prefix"></rux-icon> `
` </rux-notification> `

Should display the 'apps' icon to the left of a standby icon and the message 'Insert better example here' to the right.
However, it doesn't display the message.

**The Reason**
This is actually expected web component behavior, even though at a glance it doesn't seem like that. the prop "message" displays as a fallback for the default slot. When default slot is empty it should display. However, the default slot is not actually empty. There are hidden spaces and carriage returns surrounding <rux-icon slot="apps"></rux-icon> that are filling the default slot. This can be tested by rewriting the code above on one line with no spaces like so:
` <rux-notification open status="standby" message="Insert better example here"><rux-icon icon="apps" slot="prefix"></rux-icon></rux-notification> `

The 'message' should then appear as expected.

[Source](https://stackoverflow.com/questions/53182353/fallback-content-on-an-unnamed-slot-is-never-displayed)

**The Solution**
One possibility would be to write a method that seeks out and ignores these spaces and carriage returns.. but that could get complicated and messy quite quickly.

Instead, I've chosen to remove the message prop and change the instructions for this component. I believe that this is a better choice on a couple of levels.

1) I think that adding the message inside of the <rux-notification>Notification Message here!</rux-notification> is more intuitive in the long run. Using props as fallback for text can get confusing in corner cases. For example, what if a dev utilizes both the message prop and the default slot?
` <rux-notification message="This is my notification">J/K It's here</rux-notification> `
What is the expected outcome? Should it render both? Just the default slot? Just the message?

2) Our [storybook on notification](https://astro-components.netlify.app/?path=/docs/components-notification--default-story#default-slot) actually already calls out that things put into the default slot will override 'message' in this case it's just doing it for an unexpected reason.

3) Other comparable web-component libraries that use slots for this component handle the main content of an alert or notification component in a similar manner. [shoelace](https://shoelace.style/components/alert),[ kor](https://kor-ui.com/components/notifications), or do not list a default slot: [Carbon](https://web-components.carbondesignsystem.com/?path=/docs/components-notifications--inline)

## Issues and Limitations

While this is a simple fix, it is going to be a big ugly breaking change when it goes into production, so if we decide to implement it later and just add some documentation for now, or go a different direction entirely, I can test out other solutions. :)

## Types of changes

- [x] Bug fix
- [ ] New feature
- [x] Breaking change

## Checklist

- [x] This PR changes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
