### PR TITLE
docs: redirect new feat reqs to github disucssions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Feature Request
+    url: https://github.com/RocketCommunicationsInc/astro/discussions/new
+    about: Discuss ideas for new features of changes


### PR DESCRIPTION
## Brief Description

This will redirect users who are opening a feature request issue to the github discussions instead. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4818

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
