### PR TITLE
fix(menu-item): restore 6.0 props

### DIFF
--- a/.changeset/blue-experts-tan.md
+++ b/.changeset/blue-experts-tan.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+---
+
+Menu Item - Restored `href`, `target`, `rel` and `download` attributes

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -12008,9 +12008,25 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
+          * This attribute instructs browsers to download a URL instead of navigating to it, so the user will be prompted to save it as a local file. If the attribute has a value, it is used as the pre-filled file name in the Save prompt (the user can still change the file name if they want).
+         */
+        "download": string | undefined;
+        /**
+          * Contains a URL or a URL fragment that the hyperlink points to. If this property is set, an anchor tag will be rendered.
+         */
+        "href": string | undefined;
+        /**
+          * Specifies the relationship of the target object to the link object. The value is a space-separated list of [link types](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types).
+         */
+        "rel": string | undefined;
+        /**
           * sets the menu item as selected
          */
         "selected": boolean;
+        /**
+          * Specifies where to display the linked URL. Only applies when an `href` is provided. Special keywords: `"_blank"`, `"_self"`, `"_parent"`, `"_top"`.
+         */
+        "target": string | undefined;
         /**
           * the value returned when item is selected.
          */
@@ -12118,13 +12134,13 @@ export namespace Components {
     }
     interface RuxPopUp {
         /**
-          * Turns autoUpdate on or off which makes the pop-up move to stay in view based on scroll. Defaults to false.
-         */
-        "disableAutoUpdate": boolean;
-        /**
           * When provided, will close the pop-up when a single selection is made.
          */
         "closeOnSelect": boolean;
+        /**
+          * Turns autoUpdate on or off which makes the pop-up move to stay in view based on scroll. Defaults to false.
+         */
+        "disableAutoUpdate": boolean;
         /**
           * Closes the pop up and returns false.
          */
@@ -32473,9 +32489,25 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
+          * This attribute instructs browsers to download a URL instead of navigating to it, so the user will be prompted to save it as a local file. If the attribute has a value, it is used as the pre-filled file name in the Save prompt (the user can still change the file name if they want).
+         */
+        "download"?: string | undefined;
+        /**
+          * Contains a URL or a URL fragment that the hyperlink points to. If this property is set, an anchor tag will be rendered.
+         */
+        "href"?: string | undefined;
+        /**
+          * Specifies the relationship of the target object to the link object. The value is a space-separated list of [link types](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types).
+         */
+        "rel"?: string | undefined;
+        /**
           * sets the menu item as selected
          */
         "selected"?: boolean;
+        /**
+          * Specifies where to display the linked URL. Only applies when an `href` is provided. Special keywords: `"_blank"`, `"_self"`, `"_parent"`, `"_top"`.
+         */
+        "target"?: string | undefined;
         /**
           * the value returned when item is selected.
          */
@@ -32589,13 +32621,13 @@ declare namespace LocalJSX {
     }
     interface RuxPopUp {
         /**
-          * Turns autoUpdate on or off which makes the pop-up move to stay in view based on scroll. Defaults to false.
-         */
-        "disableAutoUpdate"?: boolean;
-        /**
           * When provided, will close the pop-up when a single selection is made.
          */
         "closeOnSelect"?: boolean;
+        /**
+          * Turns autoUpdate on or off which makes the pop-up move to stay in view based on scroll. Defaults to false.
+         */
+        "disableAutoUpdate"?: boolean;
         /**
           * Emits when the pop up has closed.
          */

--- a/packages/web-components/src/components/rux-menu-item/rux-menu-item.scss
+++ b/packages/web-components/src/components/rux-menu-item/rux-menu-item.scss
@@ -2,7 +2,14 @@
     display: block;
 }
 
+a.rux-menu-item {
+    text-decoration: none;
+    &:hover {
+        text-decoration: underline;
+    }
+}
 .rux-menu-item {
+    display: block;
     position: relative;
     padding: var(--spacing-2); //8
     color: var(--color-text-interactive-default);

--- a/packages/web-components/src/components/rux-menu-item/rux-menu-item.scss
+++ b/packages/web-components/src/components/rux-menu-item/rux-menu-item.scss
@@ -4,9 +4,6 @@
 
 a.rux-menu-item {
     text-decoration: none;
-    &:hover {
-        text-decoration: underline;
-    }
 }
 .rux-menu-item {
     display: block;

--- a/packages/web-components/src/components/rux-menu-item/rux-menu-item.tsx
+++ b/packages/web-components/src/components/rux-menu-item/rux-menu-item.tsx
@@ -20,18 +20,51 @@ export class RuxMenuItem {
      */
     @Prop({ mutable: true }) value?: string
 
+    /**
+     * Contains a URL or a URL fragment that the hyperlink points to.
+     * If this property is set, an anchor tag will be rendered.
+     */
+    @Prop() href: string | undefined
+
+    /**
+     * Specifies where to display the linked URL.
+     * Only applies when an `href` is provided.
+     * Special keywords: `"_blank"`, `"_self"`, `"_parent"`, `"_top"`.
+     */
+    @Prop() target: string | undefined
+
+    /**
+     * Specifies the relationship of the target object to the link object.
+     * The value is a space-separated list of [link types](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types).
+     */
+    @Prop() rel: string | undefined
+
+    /**
+     * This attribute instructs browsers to download a URL instead of navigating to
+     * it, so the user will be prompted to save it as a local file. If the attribute
+     * has a value, it is used as the pre-filled file name in the Save prompt
+     * (the user can still change the file name if they want).
+     */
+    @Prop() download: string | undefined
+
     render() {
+        const { disabled, selected, href, rel, download, target } = this
+        const TagType = href ? 'a' : 'div'
+        const attributes =
+            TagType === 'a' ? { download, href, rel, target } : {}
+
         return (
             <Host value={this.value}>
-                <div
+                <TagType
+                    {...attributes}
                     class={{
                         'rux-menu-item': true,
-                        'rux-menu-item--selected': this.selected,
-                        'rux-menu-item--disabled': this.disabled,
+                        'rux-menu-item--selected': selected,
+                        'rux-menu-item--disabled': disabled,
                     }}
                 >
                     <slot></slot>
-                </div>
+                </TagType>
             </Host>
         )
     }


### PR DESCRIPTION
## Brief Description

This PR restores a few attributes on menu item from 6.0: `href`, `rel`, `target` and `download.`

These were removed in 7.0 intentionally but weren't properly documented. The intention was that you would use the slot instead if you wanted an ahref:

```
<rux-menu-item>
  <a href="#">whatup</a>
</rux-menu-item>
```

vs.
```
<rux-menu-item href="#>
  whatup
</rux-menu-item>
```

After closer inspection, you would need to manually have to tinker with the padding otherwise the link would only trigger if you clicked exactly on the a element. Instead we decided to keep the 6.0 API.


## JIRA Link

ASTRO-4811

## Related Issue

https://github.com/RocketCommunicationsInc/astro/issues/862

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
