### PR TITLE
refactor(input): removed autocomplete attr

### DIFF
--- a/.changeset/eighty-moles-rule.md
+++ b/.changeset/eighty-moles-rule.md
@@ -1,0 +1,8 @@
+---
+"angular-workspace": minor
+"@astrouxds/angular": minor
+"@astrouxds/react": minor
+"@astrouxds/astro-web-components": minor
+---
+
+The `autocomplete` attribute has been removed from `rux-input` due to a limitation with shadow-dom encapsulation not allowing the attribute to be applied correctly.

--- a/packages/angular-workspace/package-lock.json
+++ b/packages/angular-workspace/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "angular-workspace",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "7.1.0",
+      "name": "angular-workspace",
+      "version": "7.1.1",
       "dependencies": {
         "@angular/animations": "~13.2.0",
         "@angular/common": "~13.2.0",

--- a/packages/angular-workspace/projects/angular/package-lock.json
+++ b/packages/angular-workspace/projects/angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astrouxds/angular",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@astrouxds/angular",
-      "version": "7.1.0",
+      "version": "7.1.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astrouxds/react",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@astrouxds/react",
-      "version": "7.1.0",
+      "version": "7.1.1",
       "devDependencies": {
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.1.0",

--- a/packages/web-components/src/components/rux-input/rux-input.tsx
+++ b/packages/web-components/src/components/rux-input/rux-input.tsx
@@ -129,11 +129,6 @@ export class RuxInput implements FormFieldInterface {
     @Prop() step?: string
 
     /**
-     * The input's autocomplete attribute
-     */
-    @Prop() autocomplete?: string
-
-    /**
      * The input's spellcheck attribute
      */
     @Prop() spellcheck = false
@@ -255,7 +250,6 @@ export class RuxInput implements FormFieldInterface {
             value,
             hasLabel,
             size,
-            autocomplete,
             spellcheck,
             readonly,
             togglePassword,
@@ -331,7 +325,6 @@ export class RuxInput implements FormFieldInterface {
                             class="native-input"
                             id={this.inputId}
                             spellcheck={spellcheck}
-                            autocomplete={togglePassword ? 'off' : autocomplete}
                             readonly={readonly}
                             onChange={_onChange}
                             onInput={_onInput}

--- a/packages/web-components/tests/input.spec.ts
+++ b/packages/web-components/tests/input.spec.ts
@@ -299,24 +299,25 @@ test.describe('Input with form', () => {
         //Assert
         await expect(spellCheckInput).toHaveAttribute('spellcheck', 'true')
     })
-    test('applies autocomplete prop to shadow input', async ({ page }) => {
-        //Arrange
-        const autocomplete = page.locator('#autocomplete')
-        const autocompleteInput = autocomplete.locator('input').nth(1)
+    //! Uncomment autocomplete tests when the attribute is added back in and working.
+    // test('applies autocomplete prop to shadow input', async ({ page }) => {
+    //     //Arrange
+    //     const autocomplete = page.locator('#autocomplete')
+    //     const autocompleteInput = autocomplete.locator('input').nth(1)
 
-        //Assert
-        await expect(autocompleteInput).toHaveAttribute('autocomplete', 'on')
-    })
-    test('changes autocomplete to false if type is password', async ({
-        page,
-    }) => {
-        //Arrange
-        const autocomplete = page.locator('#autocomplete-to-off')
-        const autocompleteInput = autocomplete.locator('input').nth(1)
+    //     //Assert
+    //     await expect(autocompleteInput).toHaveAttribute('autocomplete', 'on')
+    // })
+    // test('changes autocomplete to false if type is password', async ({
+    //     page,
+    // }) => {
+    //     //Arrange
+    //     const autocomplete = page.locator('#autocomplete-to-off')
+    //     const autocompleteInput = autocomplete.locator('input').nth(1)
 
-        //Assert
-        await expect(autocompleteInput).toHaveAttribute('autocomplete', 'off')
-    })
+    //     //Assert
+    //     await expect(autocompleteInput).toHaveAttribute('autocomplete', 'off')
+    // })
     test('submits the correct value in type date', async ({ page }) => {
         //Arrange
         const dateType = page.locator('#date-type')


### PR DESCRIPTION
## Brief Description

Removes the `autocomplete` attribute from rux-input due to it never taking effect. 
This isn't a breaking change because the attribute never worked in the first place; it only had the attribute in the shadow dom, but it wasn't functioning. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4825

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/877
Issue was raised here. Fix for issue will be implemented at a later date. 

## General Notes

We are looking into fixes for this in future, but it has been deprioritized for now. 

## Motivation and Context

We don't want to provide an attribute that doesn't actually work. 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
