### PR TITLE
change right padding to include dropdown indicator

### DIFF
--- a/.changeset/shaggy-days-bow.md
+++ b/.changeset/shaggy-days-bow.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+fix(rux-select) long options no longer fall over the drop down indicator

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -11909,10 +11909,6 @@ export namespace Components {
     }
     interface RuxInput {
         /**
-          * The input's autocomplete attribute
-         */
-        "autocomplete"?: string;
-        /**
           * Disables the button via HTML disabled attribute. Button takes on a distinct visual state. Cursor uses the not-allowed system replacement and all keyboard and mouse events are ignored.
          */
         "disabled": boolean;
@@ -32369,10 +32365,6 @@ declare namespace LocalJSX {
     interface RuxIndeterminateProgress {
     }
     interface RuxInput {
-        /**
-          * The input's autocomplete attribute
-         */
-        "autocomplete"?: string;
         /**
           * Disables the button via HTML disabled attribute. Button takes on a distinct visual state. Cursor uses the not-allowed system replacement and all keyboard and mouse events are ignored.
          */

--- a/packages/web-components/src/components/rux-select/rux-select.scss
+++ b/packages/web-components/src/components/rux-select/rux-select.scss
@@ -124,14 +124,18 @@ label {
     letter-spacing: var(--font-control-body-1-letter-spacing);
     user-select: none;
 
+    //In the following, the right padding accounts for normal padding + size of drop down arrow
     &--small {
         padding: var(--spacing-1) var(--spacing-2); //4px 8px
+        padding-right: calc(var(--spacing-2) + var(--spacing-8));
     }
     &--medium {
         padding: var(--spacing-2); //8px
+        padding-right: calc(var(--spacing-2) + var(--spacing-8));
     }
     &--large {
         padding: var(--spacing-3) var(--spacing-2); //12px 8px
+        padding-right: calc(var(--spacing-2) + var(--spacing-8));
     }
     &--multiple {
         background: var(--color-background-base-default);

--- a/packages/web-components/src/components/rux-select/test/index.html
+++ b/packages/web-components/src/components/rux-select/test/index.html
@@ -62,12 +62,29 @@
         <section>
             <h2>Single Select</h2>
 
-            <form id="form" method="POST" action="/form">
-                <rux-select id="ruxSelect" label="Best Thing?" name="bestThing">
-                    <rux-option label="Select an option" value=""></rux-option>
-                    <rux-option label="Red" value="red"></rux-option>
-                    <rux-option value="blue" label="Blue"></rux-option>
-                    <rux-option value="green" label="Green"></rux-option>
+            <form id="form" method="POST" action="/form" style="width: 200px">
+                <rux-select
+                    id="ruxSelect"
+                    label="Best Thing?"
+                    name="bestThing"
+                    size="large"
+                >
+                    <rux-option
+                        label="Select an option that is the best thing"
+                        value=""
+                    ></rux-option>
+                    <rux-option
+                        label="Red is definitely the best for sure forever"
+                        value="red"
+                    ></rux-option>
+                    <rux-option
+                        value="blue"
+                        label="Blue is clearly supperior to all others"
+                    ></rux-option>
+                    <rux-option
+                        value="green"
+                        label="green is fine"
+                    ></rux-option>
                 </rux-select>
                 <button id="formSubmitBtn" type="submit">submit</button>
             </form>


### PR DESCRIPTION
## Brief Description

Changed rux-select so that long options no longer fall over the drop down arrow.

## JIRA Link

[ASTRO-4820](https://rocketcom.atlassian.net/browse/ASTRO-4820)

## Related Issue

https://github.com/RocketCommunicationsInc/astro/issues/722

## General Notes

## Motivation and Context

When rux-select contains longer options they could fall over the drop down menu arrow. This fix applies some extra padding to account for the size of the drop down arrow in each size of rux-select. Because rux-select uses box-sizing: border-box it won't change the actual of rux-select itself.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
