### PR TITLE
test(ga): always run build as part of test setup

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,7 +31,6 @@ jobs:
       - run: npm run web-comps.install
         if: steps.cache-node-modules.outputs.cache-hit != 'true' || steps.changed-files.outputs.any_changed == 'true'
       - run: npm run build.web-comps
-        if: steps.cache-node-modules.outputs.cache-hit != 'true' || steps.changed-files.outputs.any_changed == 'true'
   e2e-tests:
     needs: setup
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Brief Description

Previously, our github action e2e tests would only run a stencil build if the package.json file had changed. 
This has been changed to run a build on every PR.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4842

## Related Issue

## General Notes

## Motivation and Context

GA will no longer pass if there are any build errors. 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
