### PR TITLE
fix(rux-timeline): added left/right/both border to selected partial events

### DIFF
--- a/packages/web-components/src/components/rux-timeline/rux-time-region/rux-time-region.scss
+++ b/packages/web-components/src/components/rux-timeline/rux-time-region/rux-time-region.scss
@@ -41,6 +41,18 @@
     border: 1px solid var(--color-background-interactive-default);
     --status-symbols: var(--status-symbols-light);
     color: var(--color-text-inverse);
+
+    &.rux-time-region--partial-start {
+        border-color: var(--color-palette-neutral-1000);
+        border-left-style: dashed;
+        border-left-width: 2px;
+    }
+
+    &.rux-time-region--partial-end {
+        border-color: var(--color-palette-neutral-1000);
+        border-right-width: 2px;
+        border-right-style: dashed;
+    }
 }
 
 .rux-time-region--normal:not(.rux-time-region--selected) {


### PR DESCRIPTION
## Brief Description

Added borders to partial events even when selected. The borders are color/palette/neutral/1000 as they appear on the figma specs. This allows users to know that selected partial events are still partial events. 

## JIRA Link

[ASTRO-4844](https://rocketcom.atlassian.net/browse/ASTRO-4844)

## Related Issue

## General Notes

## Motivation and Context

Previously, when a partial timeline event was selected it would lose the dashed left/right border which indicated it as a partial event. Adding them back in a neutral color when selected, brings back the visual queue.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
