### PR TITLE
Mj 4867 pop up overflow

### DIFF
--- a/.changeset/flat-cups-sit.md
+++ b/.changeset/flat-cups-sit.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+---
+
+Fixed an issue where the `strategy` prop of `rux-pop-up` was not applying correctly.

--- a/packages/web-components/src/components/rux-pop-up/rux-pop-up.tsx
+++ b/packages/web-components/src/components/rux-pop-up/rux-pop-up.tsx
@@ -172,6 +172,7 @@ export class RuxPopUp {
             Object.assign(this.content.style, {
                 left: `${x}px`,
                 top: `${y}px`,
+                position: `${this.strategy}`,
             })
 
             //@ts-ignore


### PR DESCRIPTION
## Brief Description

The `strategy` prop on rux-pop-up was not being applied correctly. This now applies the correct `position: ` to the pop-up. 
This fixes an issue where a pop-up inside a parent that had `position: absolute; overflow: hidden` would hide the pop-up. 


## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4867

## Related Issue

## General Notes

## Motivation and Context

Pop-up was being hidden when the above conditions where being met. 

## Issues and Limitations

This still does not fix an issue where a `transform` on a parent will still hide some or all of the pop-up. This is due to `transform` creating it's own stacking context, and thus the pop-up gets rendered behind it. 

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
