### PR TITLE
Mj 4868 dialog msg

### DIFF
--- a/.changeset/nasty-oranges-greet.md
+++ b/.changeset/nasty-oranges-greet.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+---
+
+Fixed an issue where the `message` prop of `rux-dialog` would not appear if being used with slots for header or footer.

--- a/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
+++ b/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
@@ -236,9 +236,15 @@ export class RuxDialog {
                                     }}
                                     part="message"
                                 >
-                                    <slot onSlotchange={this._handleSlotChange}>
-                                        {message}
-                                    </slot>
+                                    {this.hasMessage ? (
+                                        <slot
+                                            onSlotchange={
+                                                this._handleSlotChange
+                                            }
+                                        ></slot>
+                                    ) : (
+                                        <div>{message}</div>
+                                    )}
                                 </div>
                             </div>
                             <footer


### PR DESCRIPTION
## Brief Description

Fixed an issue where the message prop on rux-dialog would not show if being used with slots for header or footer.
This was due to an issue where even though the message(default) slot was empty, it was taking in whitespace and therefore thinking it wasn't empty. This fix conditionally renders the slot based on if a default slot is being used.

This relates to @kiley-mitti 's PR of https://github.com/RocketCommunicationsInc/astro/pull/854. I think it's the exact same issue that the default message slot on notification is having. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4868

## Related Issue
https://github.com/RocketCommunicationsInc/astro/pull/854
## General Notes

## Motivation and Context

Message prop can now be used on dialog at any point.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
