### PR TITLE
emulate changes micah made to rux-dialog

### DIFF
--- a/.changeset/heavy-kings-smell.md
+++ b/.changeset/heavy-kings-smell.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+rux-notification: fix but where message prop was not showing if another slot was slotted in the component

--- a/.changeset/heavy-kings-smell.md
+++ b/.changeset/heavy-kings-smell.md
@@ -2,4 +2,4 @@
 "@astrouxds/astro-web-components": patch
 ---
 
-rux-notification: fix but where message prop was not showing if another slot was slotted in the component
+rux-notification: fix a bug where message prop was not showing if another slot was slotted in the component

--- a/packages/web-components/src/components/rux-notification/rux-notification.tsx
+++ b/packages/web-components/src/components/rux-notification/rux-notification.tsx
@@ -32,6 +32,7 @@ export class RuxNotification {
     @Element() el!: HTMLRuxNotificationElement
 
     @State() hasPrefixSlot = false
+    @State() hasMessageSlot = false
     /**
      *  Set to true to display the Banner and begin countdown to close (if a close-after Number value is provided).
      */
@@ -81,6 +82,7 @@ export class RuxNotification {
     connectedCallback() {
         this._handleSlotChange = this._handleSlotChange.bind(this)
         this._updated()
+        this.hasMessageSlot = hasSlot(this.el)
     }
 
     private _updated() {
@@ -118,6 +120,7 @@ export class RuxNotification {
 
     private _handleSlotChange() {
         this.hasPrefixSlot = hasSlot(this.el, 'prefix')
+        this.hasMessageSlot = hasSlot(this.el)
     }
 
     render() {
@@ -176,7 +179,10 @@ export class RuxNotification {
                             }}
                             part="message"
                         >
-                            <slot>{this.message}</slot>
+                            <slot onSlotchange={this._handleSlotChange}></slot>
+                            {!this.hasMessageSlot && this.message ? (
+                                <span>{this.message}</span>
+                            ) : null}
                         </div>
 
                         {!this.hideClose ? (

--- a/packages/web-components/tests/notification.spec.ts
+++ b/packages/web-components/tests/notification.spec.ts
@@ -129,6 +129,21 @@ test.describe('Notification', () => {
             closeBtn.click(),
         ])
     })
+
+    test('it renders the message prop text when used with slots', async ({
+        page,
+    }) => {
+        await setBodyContent(
+            page,
+            `
+            <rux-notification open message="Message Prop">
+                <span slot="prefix">Slot Prefix</span>
+            </rux-notification>
+        `
+        )
+        const messageContainer = page.locator('.rux-notification-banner__content')
+        await expect(messageContainer).toContainText('Message Prop')
+    })
 })
 /*
     Need to test: 


### PR DESCRIPTION
## Brief Description

This is a followup to the rux-notification issue [#854](https://github.com/RocketCommunicationsInc/astro/pull/854) while I still believe that the ultimate solution is to remove the message prop, @micahjones13 has come up with a brilliant interim solution that is not a breaking change and does fix the issue. I've basically taken his work on rux-dialog and emulated it here. :) 

## JIRA Link

[ASTRO-4780](https://rocketcom.atlassian.net/browse/ASTRO-4780)

## Related Issue
[#904](https://github.com/RocketCommunicationsInc/astro/pull/904)

## General Notes

Thanks Micah!

## Motivation and Context

This will allow the message prop to render if the default slot isn't filled. EVEN if there is another slot inside the component that is being used.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
