### PR TITLE
(fix rux-icon): Removing incorrect label prop from rux-icon storybook

### DIFF
--- a/.changeset/clever-hounds-watch.md
+++ b/.changeset/clever-hounds-watch.md
@@ -1,0 +1,7 @@
+---
+"@astrouxds/angular": minor
+"@astrouxds/react": minor
+"@astrouxds/astro-web-components": minor
+---
+
+Fixing rux-icon in Storybook incorrectly displaying a label prop.

--- a/.changeset/clever-hounds-watch.md
+++ b/.changeset/clever-hounds-watch.md
@@ -1,7 +1,0 @@
----
-"@astrouxds/angular": minor
-"@astrouxds/react": minor
-"@astrouxds/astro-web-components": minor
----
-
-Fixing rux-icon in Storybook incorrectly displaying a label prop.

--- a/packages/angular-workspace/projects/angular/src/directives/proxies-list.ts
+++ b/packages/angular-workspace/projects/angular/src/directives/proxies-list.ts
@@ -12,6 +12,7 @@
 //@ts-nocheck
 //@ts-nocheck
 //@ts-nocheck
+//@ts-nocheck
 
 import * as d from './proxies';
 

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@astrouxds/astro-web-components",
-    "version": "7.1.1",
+    "version": "7.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@astrouxds/astro-web-components",
-            "version": "7.1.1",
+            "version": "7.2.0",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "~1.0.1",

--- a/packages/web-components/src/stories/icon-and-symbols.stories.mdx
+++ b/packages/web-components/src/stories/icon-and-symbols.stories.mdx
@@ -19,7 +19,6 @@ export const Default = (args) => {
         <rux-icon
             icon="${args.icon}"
             size="${args.size}"
-            label="${args.label}"
         ></rux-icon>
     `
 }
@@ -28,8 +27,7 @@ export const Default = (args) => {
     <Story
         args={{
             icon: 'satellite-transmit',
-            size: 'normal',
-            label: ""
+            size: 'normal'
         }}
         parameters={{
             docs: {
@@ -188,8 +186,7 @@ export const AllIcons = (args) => {
         }}
         argTypes={{
             size: { table: { disable: true } },
-            icon: { table: { disable: true } },
-            label: { table: { disable: true } }
+            icon: { table: { disable: true } }
         }}
         name="All Icons"
     >


### PR DESCRIPTION
## Brief Description

The Storybook story for `rux-icon` was incorrectly showing that it had a label prop. This has been removed from its story.

## JIRA Link

[ASTRO-4872](https://rocketcom.atlassian.net/browse/ASTRO-4872)

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/907
## General Notes

## Motivation and Context

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
