### PR TITLE
(fix): monitoring-icon and monitoring-progress-icon display grid issue and push button cursor issue

### DIFF
--- a/.changeset/eighty-actors-behave.md
+++ b/.changeset/eighty-actors-behave.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": minor
+---
+
+Fixing an issue where wrapping rux-monitoring-icon and rux-monitoring-progress-icon in display: grid was causing layout shift, along with an issue where the cursor: pointer attribute on rux-push-button was misplaced."

--- a/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
+++ b/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
@@ -1,5 +1,5 @@
 :host {
-    display: inline-flex;
+    display: inline-block;
     padding: 0;
     min-height: 5.188rem; //83px;
     min-width: 4.938rem; //79px;

--- a/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
+++ b/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
@@ -1,5 +1,5 @@
 :host {
-    display: inline-block;
+    display: inline-flex;
     padding: 0;
     min-height: 5.188rem; //83px;
     min-width: 4.938rem; //79px;

--- a/packages/web-components/src/components/rux-monitoring-icon/test/index.html
+++ b/packages/web-components/src/components/rux-monitoring-icon/test/index.html
@@ -22,7 +22,6 @@
             src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
         ></script> -->
     </head>
-
     <body>
         <rux-monitoring-icon
             icon="mission"

--- a/packages/web-components/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.scss
+++ b/packages/web-components/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.scss
@@ -1,5 +1,5 @@
 :host {
-    display: inline-flex;
+    display: inline-block;
     padding: 0;
 }
 

--- a/packages/web-components/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.scss
+++ b/packages/web-components/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.scss
@@ -1,5 +1,5 @@
 :host {
-    display: inline-block;
+    display: inline-flex;
     padding: 0;
 }
 

--- a/packages/web-components/src/components/rux-push-button/rux-push-button.scss
+++ b/packages/web-components/src/components/rux-push-button/rux-push-button.scss
@@ -1,5 +1,4 @@
 :host {
-    cursor: pointer;
     display: block;
     margin: (--spacing-0) (--spacing-050);
     -webkit-user-select: none;
@@ -28,6 +27,7 @@
 
     .rux-push-button {
         &__button {
+            cursor: pointer;
             font-family: var(--font-control-body-1-font-family);
             font-size: var(--font-control-body-1-font-size);
             font-weight: var(--font-control-body-1-font-weight);

--- a/packages/web-components/src/components/rux-push-button/test/index.html
+++ b/packages/web-components/src/components/rux-push-button/test/index.html
@@ -19,7 +19,6 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
         <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
     </head>
-
     <body class="dark-theme">
         <div style="padding: 10%; display: flex; justify-content: center">
             <form id="form">


### PR DESCRIPTION
## Brief Description

An issue was discovered wherein if `rux-monitoring-icon` or `rux-monitoring-progress-icon` were wrapping in `display: grid` the icons pieces and the label pieces of the component would not be aligned. This PR fixes that issue. Another issue was discovered in `rux-push-button` that has been fixed as well where the cursor turning to pointer would fall outside of the bounds of the button itself if a specific width was set on the component.

## JIRA Link

[ASTRO-4875](https://rocketcom.atlassian.net/browse/ASTRO-4875)

## Related Issue

## General Notes

## Motivation and Context

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
