### PR TITLE
Update cherry picking docs

### DIFF
--- a/packages/web-components/src/stories/accordion-item.stories.mdx
+++ b/packages/web-components/src/stories/accordion-item.stories.mdx
@@ -142,6 +142,6 @@ export const IconSlotted = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxAccordionItem from '@astrouxds/astro-web-components/dist/components/rux-accordion-item'
+import { RuxAccordionItem } from '@astrouxds/astro-web-components/dist/components/rux-accordion-item'
 customElements.define('rux-accordion-item', RuxAccordionItem)
 ```

--- a/packages/web-components/src/stories/accordion.stories.mdx
+++ b/packages/web-components/src/stories/accordion.stories.mdx
@@ -184,8 +184,8 @@ export const Truncate = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxAccordion from '@astrouxds/astro-web-components/dist/components/rux-accordion'
-import RuxAccordionItem from '@astrouxds/astro-web-components/dist/components/rux-accordion-item'
+import { RuxAccordion } from '@astrouxds/astro-web-components/dist/components/rux-accordion'
+import { RuxAccordionItem } from '@astrouxds/astro-web-components/dist/components/rux-accordion-item'
 customElements.define('rux-accordion', RuxAccordion)
 customElements.define('rux-accordion-item', RuxAccordionItem)
 ```

--- a/packages/web-components/src/stories/button-group.stories.mdx
+++ b/packages/web-components/src/stories/button-group.stories.mdx
@@ -70,9 +70,9 @@ export const Default = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxButtonGroup from '@astrouxds/astro-web-components/dist/components/rux-button-group.js'
-import RuxButton from '@astrouxds/astro-web-components/dist/components/rux-button.js'
-import RuxIcon from '@astrouxds/astro-web-components/dist/components/rux-icon.js'
+import { RuxButtonGroup } from '@astrouxds/astro-web-components/dist/components/rux-button-group.js'
+import { RuxButton } from '@astrouxds/astro-web-components/dist/components/rux-button.js'
+import { RuxIcon } from '@astrouxds/astro-web-components/dist/components/rux-icon.js'
 customElements.define('rux-button', RuxButton)
 customElements.define('rux-icon', RuxIcon)
 customElements.define('rux-button-group', RuxButtonGroup)

--- a/packages/web-components/src/stories/checkbox-group.stories.mdx
+++ b/packages/web-components/src/stories/checkbox-group.stories.mdx
@@ -252,8 +252,8 @@ export const HorizontalLabel = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxCheckbox from '@astrouxds/astro-web-components/dist/components/rux-checkbox.js'
-import RuxCheckboxGroup from '@astrouxds/astro-web-components/dist/components/rux-checkbox-group.js'
+import { RuxCheckbox } from '@astrouxds/astro-web-components/dist/components/rux-checkbox.js'
+import { RuxCheckboxGroup } from '@astrouxds/astro-web-components/dist/components/rux-checkbox-group.js'
 customElements.define('rux-checkbox', RuxCheckbox)
 customElements.define('rux-checkbox-group', RuxCheckboxGroup)
 ```

--- a/packages/web-components/src/stories/checkbox.stories.mdx
+++ b/packages/web-components/src/stories/checkbox.stories.mdx
@@ -212,6 +212,6 @@ export const WithHelpText = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxCheckbox from '@astrouxds/astro-web-components/dist/components/rux-checkbox.js'
+import { RuxCheckbox } from '@astrouxds/astro-web-components/dist/components/rux-checkbox.js'
 customElements.define('rux-checkbox', RuxCheckbox)
 ```

--- a/packages/web-components/src/stories/datetime.stories.mdx
+++ b/packages/web-components/src/stories/datetime.stories.mdx
@@ -72,6 +72,6 @@ export const Default = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxDatetime from '@astrouxds/astro-web-components/dist/components/rux-datetime.js'
+import { RuxDatetime } from '@astrouxds/astro-web-components/dist/components/rux-datetime.js'
 customElements.define('rux-datetime', RuxDatetime)
 ```

--- a/packages/web-components/src/stories/indeterminate-progress.stories.mdx
+++ b/packages/web-components/src/stories/indeterminate-progress.stories.mdx
@@ -51,6 +51,6 @@ rux-indeterminate-progress {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxIndeterminateProgress from '@astrouxds/astro-web-components/dist/components/rux-indeterminate-progress.js'
+import { RuxIndeterminateProgress } from '@astrouxds/astro-web-components/dist/components/rux-indeterminate-progress.js'
 customElements.define('rux-indeterminate-progress', RuxIndeterminateProgress)
 ```

--- a/packages/web-components/src/stories/input.stories.mdx
+++ b/packages/web-components/src/stories/input.stories.mdx
@@ -666,6 +666,6 @@ export const HorizontalLabel = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxInput from '@astrouxds/astro-web-components/dist/components/rux-input.js'
+import { RuxInput } from '@astrouxds/astro-web-components/dist/components/rux-input.js'
 customElements.define('rux-input', RuxInput)
 ```

--- a/packages/web-components/src/stories/menu-item-divider.stories.mdx
+++ b/packages/web-components/src/stories/menu-item-divider.stories.mdx
@@ -30,6 +30,6 @@ export const Default = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxMenuItemDivider from '@astrouxds/astro-web-components/dist/components/rux-menu-item-divider'
+import { RuxMenuItemDivider } from '@astrouxds/astro-web-components/dist/components/rux-menu-item-divider'
 customElements.define('rux-menu-item-divider', RuxMenuItemDivider)
 ```

--- a/packages/web-components/src/stories/menu-item.stories.mdx
+++ b/packages/web-components/src/stories/menu-item.stories.mdx
@@ -89,6 +89,6 @@ export const Disabled = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxMenuItem from '@astrouxds/astro-web-components/dist/components/rux-menu-item'
+import { RuxMenuItem } from '@astrouxds/astro-web-components/dist/components/rux-menu-item'
 customElements.define('rux-menu-item', RuxMenuItem)
 ```

--- a/packages/web-components/src/stories/menu.stories.mdx
+++ b/packages/web-components/src/stories/menu.stories.mdx
@@ -49,6 +49,6 @@ export const Default = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxMenu from '@astrouxds/astro-web-components/dist/components/rux-menu'
+import { RuxMenu } from '@astrouxds/astro-web-components/dist/components/rux-menu'
 customElements.define('rux-menu', RuxMenu)
 ```

--- a/packages/web-components/src/stories/popup.stories.mdx
+++ b/packages/web-components/src/stories/popup.stories.mdx
@@ -134,10 +134,10 @@ export const Placements = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxPopUp from '@astrouxds/astro-web-components/dist/components/rux-pop-up.js'
-import RuxMenu from '@astrouxds/astro-web-components/dist/components/rux-menu.js'
-import RuxMenuItem from '@astrouxds/astro-web-components/dist/components/rux-menu-item.js'
-import RuxMenuItemDivider from '@astrouxds/astro-web-components/dist/components/rux-menu-item-divider.js'
+import { RuxPopUp } from '@astrouxds/astro-web-components/dist/components/rux-pop-up.js'
+import { RuxMenu } from '@astrouxds/astro-web-components/dist/components/rux-menu.js'
+import { RuxMenuItem } from '@astrouxds/astro-web-components/dist/components/rux-menu-item.js'
+import { RuxMenuItemDivider } from '@astrouxds/astro-web-components/dist/components/rux-menu-item-divider.js'
 
 customElements.define('rux-pop-up', RuxPopUp)
 customElements.define('rux-menu', RuxMenu)

--- a/packages/web-components/src/stories/radio-group.stories.mdx
+++ b/packages/web-components/src/stories/radio-group.stories.mdx
@@ -272,8 +272,8 @@ export const HorizontalLabel = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxRadio from '@astrouxds/astro-web-components/dist/components/rux-radio.js'
-import RuxRadioGroup from '@astrouxds/astro-web-components/dist/components/rux-radio-group.js'
+import { RuxRadio } from '@astrouxds/astro-web-components/dist/components/rux-radio.js'
+import { RuxRadioGroup } from '@astrouxds/astro-web-components/dist/components/rux-radio-group.js'
 customElements.define('rux-radio', RuxRadio)
 customElements.define('rux-radio-group', RuxRadioGroup)
 ```

--- a/packages/web-components/src/stories/radio.stories.mdx
+++ b/packages/web-components/src/stories/radio.stories.mdx
@@ -126,8 +126,8 @@ export const Disabled = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxRadio from '@astrouxds/astro-web-components/dist/components/rux-radio.js'
-import RuxRadioGroup from '@astrouxds/astro-web-components/dist/components/rux-radio-group.js'
+import { RuxRadio } from '@astrouxds/astro-web-components/dist/components/rux-radio.js'
+import { RuxRadioGroup } from '@astrouxds/astro-web-components/dist/components/rux-radio-group.js'
 customElements.define('rux-radio', RuxRadio)
 customElements.define('rux-radio-group', RuxRadioGroup)
 ```

--- a/packages/web-components/src/stories/segmented-button.stories.mdx
+++ b/packages/web-components/src/stories/segmented-button.stories.mdx
@@ -191,6 +191,6 @@ Pass an array of segments via the `data` attribute on the Segmented Button custo
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxSegmentedButton from '@astrouxds/astro-web-components/dist/components/rux-segmented-button.js'
+import { RuxSegmentedButton } from '@astrouxds/astro-web-components/dist/components/rux-segmented-button.js'
 customElements.define('rux-segmented-button', RuxSegmentedButton)
 ```

--- a/packages/web-components/src/stories/slider.stories.mdx
+++ b/packages/web-components/src/stories/slider.stories.mdx
@@ -291,6 +291,6 @@ export const HorizontalLabel = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxSlider from '@astrouxds/astro-web-components/dist/components/rux-slider.js'
+import { RuxSlider } from '@astrouxds/astro-web-components/dist/components/rux-slider.js'
 customElements.define('rux-slider', RuxSlider)
 ```

--- a/packages/web-components/src/stories/table.stories.mdx
+++ b/packages/web-components/src/stories/table.stories.mdx
@@ -219,13 +219,13 @@ export const WithSelectedRow = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxTable from '@astrouxds/astro-web-components/dist/components/rux-table'
-import RuxTableHeader from '@astrouxds/astro-web-components/dist/components/rux-table-header'
-import RuxTableHeaderRow from '@astrouxds/astro-web-components/dist/components/rux-table-header-row'
-import RuxTableHeaderCell from '@astrouxds/astro-web-components/dist/components/rux-table-header-cell'
-import RuxTableBody from '@astrouxds/astro-web-components/dist/components/rux-table-body'
-import RuxTableRow from '@astrouxds/astro-web-components/dist/components/rux-table-row'
-import RuxTableCell from '@astrouxds/astro-web-components/dist/components/rux-table-cell'
+import { RuxTable } from '@astrouxds/astro-web-components/dist/components/rux-table'
+import { RuxTableHeader } from '@astrouxds/astro-web-components/dist/components/rux-table-header'
+import { RuxTableHeaderRow } from '@astrouxds/astro-web-components/dist/components/rux-table-header-row'
+import { RuxTableHeaderCell } from '@astrouxds/astro-web-components/dist/components/rux-table-header-cell'
+import { RuxTableBody } from '@astrouxds/astro-web-components/dist/components/rux-table-body'
+import { RuxTableRow } from '@astrouxds/astro-web-components/dist/components/rux-table-row'
+import { RuxTableCell } from '@astrouxds/astro-web-components/dist/components/rux-table-cell'
 
 customElements.define('rux-table', RuxTable)
 customElements.define('rux-table-header', RuxTableHeader)

--- a/packages/web-components/src/stories/tag.stories.mdx
+++ b/packages/web-components/src/stories/tag.stories.mdx
@@ -90,6 +90,6 @@ export const Variants = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxTag from '@astrouxds/astro-web-components/dist/components/rux-tag.js'
+import { RuxTag } from '@astrouxds/astro-web-components/dist/components/rux-tag.js'
 customElements.define('rux-tag', RuxTag)
 ```

--- a/packages/web-components/src/stories/textarea.stories.mdx
+++ b/packages/web-components/src/stories/textarea.stories.mdx
@@ -443,6 +443,6 @@ export const HorizontalLabel = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxTextarea from '@astrouxds/astro-web-components/dist/components/rux-textarea.js'
+import { RuxTextarea } from '@astrouxds/astro-web-components/dist/components/rux-textarea.js'
 customElements.define('rux-textarea', RuxTextarea)
 ```

--- a/packages/web-components/src/stories/tree-node.stories.mdx
+++ b/packages/web-components/src/stories/tree-node.stories.mdx
@@ -109,6 +109,6 @@ export const Expanded = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxTreeNode from '@astrouxds/astro-web-components/dist/components/rux-tree-node.js'
+import { RuxTreeNode } from '@astrouxds/astro-web-components/dist/components/rux-tree-node.js'
 customElements.define('rux-tree-node', RuxTreeNode)
 ```

--- a/packages/web-components/src/stories/tree.stories.mdx
+++ b/packages/web-components/src/stories/tree.stories.mdx
@@ -366,6 +366,6 @@ export const WrapText = (args) => {
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
 
 ```js
-import RuxTree from '@astrouxds/astro-web-components/dist/components/rux-tree.js'
+import { RuxTree } from '@astrouxds/astro-web-components/dist/components/rux-tree.js'
 customElements.define('rux-tree', RuxTree)
 ```


### PR DESCRIPTION
Update default imports to named imports since that's what the files actually export (at least in 6.x, haven't updated to 7.x yet)