### PR TITLE
style(seg-btn): added pointer cursor

### DIFF
--- a/.changeset/warm-rice-divide.md
+++ b/.changeset/warm-rice-divide.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+---
+
+Added a `cursor: pointer` to an enabled rux-segmented-button.

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
@@ -93,6 +93,7 @@
         // Defaults to medium
         height: calc(var(--spacing-8) + var(--spacing-1)); //36px
         padding: var(--spacing-2) var(--spacing-4); //8px 16px
+        cursor: pointer;
 
         &--small {
             height: calc(var(--spacing-6) + var(--spacing-1)); //28px


### PR DESCRIPTION
## Brief Description

Adds `cursor: pointer` to an enabled rux-segmented-button.

I wanted to also add `pointer: not-allowed` to a disabled seg button, but because we're setting `pointer-events: none` on `:host[disabled]`, it doesn't work. We'd have add a wrapper or something and set that to `cursor: not-allowed`. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4877

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
