### PR TITLE
fix(select): options now reflect title attr

### DIFF
--- a/.changeset/chilled-goats-argue.md
+++ b/.changeset/chilled-goats-argue.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+---
+
+`rux-option` and `rux-option-group` now reflect the `title` attribute if it is provided.

--- a/packages/web-components/src/components/rux-select/rux-select.tsx
+++ b/packages/web-components/src/components/rux-select/rux-select.tsx
@@ -199,7 +199,8 @@ export class RuxSelect implements FormFieldInterface {
                     ] as HTMLRuxOptionElement[]
                     this._appendOptGroupToNativeSelect(
                         option.label ? option.label : 'Group',
-                        children
+                        children,
+                        option.title
                     )
                 }
             })
@@ -209,10 +210,12 @@ export class RuxSelect implements FormFieldInterface {
 
     private _appendOptGroupToNativeSelect(
         groupName: string,
-        children: HTMLRuxOptionElement[]
+        children: HTMLRuxOptionElement[],
+        title?: string
     ) {
         const group = Object.assign(document.createElement('optgroup'), {
             label: groupName,
+            title: title,
         })
 
         children.map((option: any) => {
@@ -220,7 +223,8 @@ export class RuxSelect implements FormFieldInterface {
                 option.label,
                 option.value,
                 option.disabled,
-                group
+                group,
+                option.title
             )
             this.selectEl.appendChild(group)
         })

--- a/packages/web-components/src/components/rux-select/rux-select.tsx
+++ b/packages/web-components/src/components/rux-select/rux-select.tsx
@@ -188,7 +188,8 @@ export class RuxSelect implements FormFieldInterface {
                         option.label,
                         option.value,
                         option.disabled,
-                        this.selectEl
+                        this.selectEl,
+                        option.title
                     )
                 }
 
@@ -231,12 +232,14 @@ export class RuxSelect implements FormFieldInterface {
         label: string,
         value: string,
         disabled: boolean,
-        target: HTMLSelectElement | HTMLOptGroupElement
+        target: HTMLSelectElement | HTMLOptGroupElement,
+        title?: string
     ) {
         const item = Object.assign(document.createElement('option'), {
             innerHTML: label ? label : '',
             value: value,
             disabled: disabled,
+            title: title,
         })
         target.appendChild(item)
     }


### PR DESCRIPTION
## Brief Description

Adds `title` attribute reflection to `rux-option` and `rux-option-group`. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4892

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/930
## General Notes

This does not add any new props, but simply reflects the `title` attribute if it exists. 

## Motivation and Context

Github issue 

## Issues and Limitations

Title attributes should be avoided if possible, but there is no other way to get a tooltip on our rux-select. 
Does not work using microsoft edge. 

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
