### PR TITLE
Mj 4879 select curosr

### DIFF
--- a/.changeset/popular-ladybugs-jam.md
+++ b/.changeset/popular-ladybugs-jam.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+---
+
+Fixed some styling issues on rux-select where the border color would still change on hover when rux-select was disabled. Added correct curors to rux-select.

--- a/packages/web-components/src/components/rux-select/rux-select.scss
+++ b/packages/web-components/src/components/rux-select/rux-select.scss
@@ -101,7 +101,7 @@ label {
                 var(--color-background-base-default) var(--spacing-8)
             );
     }
-    &:hover {
+    &:hover:not(:disabled) {
         cursor: pointer;
     }
 }
@@ -140,6 +140,12 @@ label {
     &--multiple {
         background: var(--color-background-base-default);
         padding: 0;
+        &:disabled {
+            cursor: not-allowed;
+            option:hover {
+                cursor: not-allowed;
+            }
+        }
         option {
             padding: calc(var(--spacing-2) - 1px) var(--spacing-0)
                 calc(var(--spacing-2) - 1px) var(--spacing-4); // 7px 0px 7px 16px
@@ -164,12 +170,10 @@ label {
                             var(--spacing-8),
                         var(--color-background-base-default) var(--spacing-8)
                     );
+                    cursor: not-allowed;
                 }
             }
         }
-    }
-    &--invalid {
-        border: 1px solid var(--color-text-error);
     }
 
     &:hover {
@@ -186,6 +190,10 @@ label {
         cursor: not-allowed;
         &:hover {
             border: 1px solid var(--color-border-interactive-muted);
+            option {
+                background: var(--color-background-base-default);
+                color: var(--color-background-interactive-default);
+            }
         }
     }
 
@@ -225,5 +233,18 @@ label {
         font-weight: var(--font-body-1-font-weight);
         letter-spacing: var(--font-body-1-letter-spacing);
         font-style: normal;
+    }
+}
+
+//no hover border color change when invalid and disabled
+.rux-select.rux-select--invalid {
+    border: 1px solid var(--color-text-error);
+    &:disabled {
+        &:hover {
+            border: 1px solid var(--color-text-error);
+        }
+    }
+    &:hover {
+        border: 1px solid var(--color-background-interactive-hover);
     }
 }


### PR DESCRIPTION
## Brief Description

Fixes some minor styling issues found in rux-select. 
- No more interactive hover states when rux-select or options are disabled. 
- cursor: pointer and not-allowed have been added where appropriate 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-4879

## Related Issue

## General Notes

## Motivation and Context

Consistent styling 

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
