### PR TITLE
Loosen package.json restrictions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test.react": "lerna run --scope '@astrouxds/react' test"
   },
   "engines": {
-    "node": "^16",
-    "npm": "~8.5"
+    "node": "^16 || ^18",
+    "npm": "^8.5"
   }
 }


### PR DESCRIPTION
## Brief Description

Loosens the restrictions in `package.json` so that both Node v16 and Node v18 are usable. It also allows all versions `npm` v8 in both Node v16 and Node v18.

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
