### PR TITLE
remove conditional rendering of slot for rux-tag

### DIFF
--- a/.changeset/itchy-humans-leave.md
+++ b/.changeset/itchy-humans-leave.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+rux-tag fixed an issue with default slot and conditional rendering

--- a/packages/web-components/src/components/rux-tag/rux-tag.tsx
+++ b/packages/web-components/src/components/rux-tag/rux-tag.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Element } from '@stencil/core'
+import { Component, Host, h, Prop, Element, State } from '@stencil/core'
 import { StatusTags } from '../../common/commonTypes.module'
 import { hasSlot } from '../../utils/utils'
 
@@ -26,6 +26,17 @@ export class RuxTag {
 
     @Element() el!: HTMLRuxTagElement
 
+    @State() hasSlot: boolean = false
+
+    connectedCallback() {
+        this._handleSlotChange = this._handleSlotChange.bind(this)
+        this.hasSlot = hasSlot(this.el)
+    }
+
+    private _handleSlotChange() {
+        this.hasSlot = hasSlot(this.el)
+    }
+
     private _getValidStatus() {
         if (this.status) {
             //if it is a valid status, return it
@@ -47,7 +58,8 @@ export class RuxTag {
                 }}
             >
                 <div part="container">
-                    {hasSlot(this.el) ? <slot></slot> : this._getValidStatus()}
+                    <slot onSlotchange={this._handleSlotChange}></slot>
+                    {!this.hasSlot ? this._getValidStatus() : null}
                 </div>
             </Host>
         )

--- a/packages/web-components/src/components/rux-tag/test/index.html
+++ b/packages/web-components/src/components/rux-tag/test/index.html
@@ -48,5 +48,18 @@
         <div style="padding: 10px 5%; width: 100px">
             <rux-tag status="standby" id="invalid-status"></rux-tag>
         </div>
+        <section>
+            <h2>Slot testing</h2>
+            <rux-tag status="pass" id="noslot"></rux-tag>
+            <p><rux-button id="toggle">Toggle Slot</rux-button></p>
+        </section>
+        <script>
+            const tag = document.getElementById('noslot')
+            const button = document.getElementById('toggle')
+            button.addEventListener('click', () => {
+                console.log(tag.innerHTML)
+                tag.innerHTML = '<em>slot</em>!'
+            })
+        </script>
     </body>
 </html>


### PR DESCRIPTION
## Brief Description

I tested rux-tag to see if the conditional rendering of the default slot would break if a slot was added programmatically after first render. It did, so I solved this in a similar way to rux-notification. I added a slot change handler, and a new state which holds whether or not rux-tag has a slot. It then conditionally renders the Status prop string.

As an added benefit, these changes bring the code more inline with our other components.

## JIRA Link

[ASTRO-4890](https://rocketcom.atlassian.net/browse/ASTRO-4890)

## Related Issue

## General Notes

I know that we are going to be looking at rux-tag against soon these changes may also help with the future enhancements.

## Motivation and Context

When a slot was added after the component had initially been rendered it would not appear properly. This has to do with the nature of conditionally rendering slots in Stencil (you can't).

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
