### PR TITLE
Add post-install diffs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,23 +6,6 @@ Interested in contributing to Astro? We would love to have you. Here's everythin
 
 **Requirements:** Node v16+, Docker
 
-**M1 USERS ONLY:** Chromium needs to be installed manually
-
-1. Install chromium with Homebrew
-
-```bash
-brew install chromium --no-quarantine
-```
-
-2. Modify your .zshrc file and add the following 2 lines of code at the bottom:
-
-```bash
-export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-export PUPPETEER_EXECUTABLE_PATH=`which chromium`
-```
-
-3. Restart your terminal and proceed to the next step.
-
 Clone this repo and run
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build.tests": "lerna run --scope '{@astrouxds/astro-web-components,@astrouxds/react}' build",
     "build.web-comps": "lerna run --scope '@astrouxds/astro-web-components' build",
     "build.react": "lerna run --scope '@astrouxds/react' build",
+    "postbuild": "npx pretty-quick",
     "test": "lerna run --ignore @astrouxds/angular test",
     "release": "node ./.scripts/release.js && changeset publish",
     "test.web-comps.unit": "lerna run --scope '@astrouxds/astro-web-components' test.unit",

--- a/packages/angular-workspace/package-lock.json
+++ b/packages/angular-workspace/package-lock.json
@@ -16,7 +16,6 @@
         "@angular/platform-browser": "~13.2.7",
         "@angular/platform-browser-dynamic": "~13.2.7",
         "@angular/router": "~13.2.7",
-        "@astrouxds/astro-web-components": "^7.3.0",
         "rxjs": "~7.5.7",
         "tslib": "^2.4.1",
         "zone.js": "~0.11.8"
@@ -639,17 +638,6 @@
       "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.10.1.tgz",
       "integrity": "sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==",
       "dev": true
-    },
-    "node_modules/@astrouxds/astro-web-components": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-7.3.0.tgz",
-      "integrity": "sha512-D5ISu4oWsnu6HS9jFTNX+MOLsbsD3FEXZK6o+Xd6Elu6n3q8vqyRmZnpJC68tn4R1yiimBgBOYQ9U/st+wy83A==",
-      "dependencies": {
-        "@floating-ui/dom": "~1.0.1",
-        "@stencil/core": "~2.18.0",
-        "date-fns": "~2.21.1",
-        "date-fns-tz": "~1.3.3"
-      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -2480,19 +2468,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.2.tgz",
-      "integrity": "sha512-Skfy0YS3NJ5nV9us0uuPN0HDk1Q4edljaOhRBJGDWs9EBa7ZVMYBHRFlhLvvmwEoaIM9BlH6QJFn9/uZg0bACg=="
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.6.tgz",
-      "integrity": "sha512-kt/tg1oip9OAH1xjCTcx1OpcUpu9rjDw3GKJ/rEhUqhO7QyJWfrHU0DpLTNsH67+JyFL5Kv9X1utsXwKFVtyEQ==",
-      "dependencies": {
-        "@floating-ui/core": "^1.0.2"
-      }
-    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -2814,18 +2789,6 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
       "dev": true
-    },
-    "node_modules/@stencil/core": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.1.tgz",
-      "integrity": "sha512-/fXkh1lwZ+X9JQCw50mPjhBogzEHOBvVC5pLoDLZqodVYK0DGWILM2YLV4dcIUBNEK8/HMDpO/Rq81/rS3mNOw==",
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
-      }
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -4713,26 +4676,6 @@
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true
-    },
-    "node_modules/date-fns": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
-      "integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw==",
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
-    },
-    "node_modules/date-fns-tz": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.7.tgz",
-      "integrity": "sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==",
-      "peerDependencies": {
-        "date-fns": ">=2.0.0"
-      }
     },
     "node_modules/date-format": {
       "version": "4.0.14",
@@ -12684,17 +12627,6 @@
       "integrity": "sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==",
       "dev": true
     },
-    "@astrouxds/astro-web-components": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-7.3.0.tgz",
-      "integrity": "sha512-D5ISu4oWsnu6HS9jFTNX+MOLsbsD3FEXZK6o+Xd6Elu6n3q8vqyRmZnpJC68tn4R1yiimBgBOYQ9U/st+wy83A==",
-      "requires": {
-        "@floating-ui/dom": "~1.0.1",
-        "@stencil/core": "~2.18.0",
-        "date-fns": "~2.21.1",
-        "date-fns-tz": "~1.3.3"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
@@ -13996,19 +13928,6 @@
       "integrity": "sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==",
       "dev": true
     },
-    "@floating-ui/core": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.2.tgz",
-      "integrity": "sha512-Skfy0YS3NJ5nV9us0uuPN0HDk1Q4edljaOhRBJGDWs9EBa7ZVMYBHRFlhLvvmwEoaIM9BlH6QJFn9/uZg0bACg=="
-    },
-    "@floating-ui/dom": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.6.tgz",
-      "integrity": "sha512-kt/tg1oip9OAH1xjCTcx1OpcUpu9rjDw3GKJ/rEhUqhO7QyJWfrHU0DpLTNsH67+JyFL5Kv9X1utsXwKFVtyEQ==",
-      "requires": {
-        "@floating-ui/core": "^1.0.2"
-      }
-    },
     "@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -14262,11 +14181,6 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
       "dev": true
-    },
-    "@stencil/core": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.1.tgz",
-      "integrity": "sha512-/fXkh1lwZ+X9JQCw50mPjhBogzEHOBvVC5pLoDLZqodVYK0DGWILM2YLV4dcIUBNEK8/HMDpO/Rq81/rS3mNOw=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -15750,17 +15664,6 @@
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true
-    },
-    "date-fns": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
-      "integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw=="
-    },
-    "date-fns-tz": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.7.tgz",
-      "integrity": "sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==",
-      "requires": {}
     },
     "date-format": {
       "version": "4.0.14",

--- a/packages/angular-workspace/projects/angular/package-lock.json
+++ b/packages/angular-workspace/projects/angular/package-lock.json
@@ -9,7 +9,6 @@
       "version": "7.3.0",
       "license": "MIT",
       "dependencies": {
-        "@astrouxds/astro-web-components": "^7.3.0",
         "tslib": "^2.4.1"
       },
       "peerDependencies": {
@@ -47,62 +46,6 @@
       "peerDependencies": {
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.11.4 || ~0.12.0"
-      }
-    },
-    "node_modules/@astrouxds/astro-web-components": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-7.3.0.tgz",
-      "integrity": "sha512-D5ISu4oWsnu6HS9jFTNX+MOLsbsD3FEXZK6o+Xd6Elu6n3q8vqyRmZnpJC68tn4R1yiimBgBOYQ9U/st+wy83A==",
-      "dependencies": {
-        "@floating-ui/dom": "~1.0.1",
-        "@stencil/core": "~2.18.0",
-        "date-fns": "~2.21.1",
-        "date-fns-tz": "~1.3.3"
-      }
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.2.tgz",
-      "integrity": "sha512-Skfy0YS3NJ5nV9us0uuPN0HDk1Q4edljaOhRBJGDWs9EBa7ZVMYBHRFlhLvvmwEoaIM9BlH6QJFn9/uZg0bACg=="
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.6.tgz",
-      "integrity": "sha512-kt/tg1oip9OAH1xjCTcx1OpcUpu9rjDw3GKJ/rEhUqhO7QyJWfrHU0DpLTNsH67+JyFL5Kv9X1utsXwKFVtyEQ==",
-      "dependencies": {
-        "@floating-ui/core": "^1.0.2"
-      }
-    },
-    "node_modules/@stencil/core": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.1.tgz",
-      "integrity": "sha512-/fXkh1lwZ+X9JQCw50mPjhBogzEHOBvVC5pLoDLZqodVYK0DGWILM2YLV4dcIUBNEK8/HMDpO/Rq81/rS3mNOw==",
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
-      "integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw==",
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
-    },
-    "node_modules/date-fns-tz": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.7.tgz",
-      "integrity": "sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==",
-      "peerDependencies": {
-        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/rxjs": {
@@ -147,46 +90,6 @@
       "requires": {
         "tslib": "^2.3.0"
       }
-    },
-    "@astrouxds/astro-web-components": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-7.3.0.tgz",
-      "integrity": "sha512-D5ISu4oWsnu6HS9jFTNX+MOLsbsD3FEXZK6o+Xd6Elu6n3q8vqyRmZnpJC68tn4R1yiimBgBOYQ9U/st+wy83A==",
-      "requires": {
-        "@floating-ui/dom": "~1.0.1",
-        "@stencil/core": "~2.18.0",
-        "date-fns": "~2.21.1",
-        "date-fns-tz": "~1.3.3"
-      }
-    },
-    "@floating-ui/core": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.2.tgz",
-      "integrity": "sha512-Skfy0YS3NJ5nV9us0uuPN0HDk1Q4edljaOhRBJGDWs9EBa7ZVMYBHRFlhLvvmwEoaIM9BlH6QJFn9/uZg0bACg=="
-    },
-    "@floating-ui/dom": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.6.tgz",
-      "integrity": "sha512-kt/tg1oip9OAH1xjCTcx1OpcUpu9rjDw3GKJ/rEhUqhO7QyJWfrHU0DpLTNsH67+JyFL5Kv9X1utsXwKFVtyEQ==",
-      "requires": {
-        "@floating-ui/core": "^1.0.2"
-      }
-    },
-    "@stencil/core": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.1.tgz",
-      "integrity": "sha512-/fXkh1lwZ+X9JQCw50mPjhBogzEHOBvVC5pLoDLZqodVYK0DGWILM2YLV4dcIUBNEK8/HMDpO/Rq81/rS3mNOw=="
-    },
-    "date-fns": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
-      "integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw=="
-    },
-    "date-fns-tz": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.7.tgz",
-      "integrity": "sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==",
-      "requires": {}
     },
     "rxjs": {
       "version": "7.5.7",

--- a/packages/angular-workspace/projects/angular/src/directives/proxies-list.ts
+++ b/packages/angular-workspace/projects/angular/src/directives/proxies-list.ts
@@ -1,19 +1,4 @@
 //@ts-nocheck
-//@ts-nocheck
-//@ts-nocheck
-//@ts-nocheck
-//@ts-nocheck
-//@ts-nocheck
-//@ts-nocheck
-//@ts-nocheck
-//@ts-nocheck
-//@ts-nocheck
-//@ts-nocheck
-//@ts-nocheck
-//@ts-nocheck
-//@ts-nocheck
-//@ts-nocheck
-//@ts-nocheck
 
 import * as d from './proxies';
 

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "@astrouxds/react",
       "version": "7.3.0",
-      "dependencies": {
-        "@astrouxds/astro-web-components": "^7.3.0"
-      },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.1.5",
@@ -49,37 +46,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@astrouxds/astro-web-components": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-7.3.0.tgz",
-      "integrity": "sha512-D5ISu4oWsnu6HS9jFTNX+MOLsbsD3FEXZK6o+Xd6Elu6n3q8vqyRmZnpJC68tn4R1yiimBgBOYQ9U/st+wy83A==",
-      "dependencies": {
-        "@floating-ui/dom": "~1.0.1",
-        "@stencil/core": "~2.18.0",
-        "date-fns": "~2.21.1",
-        "date-fns-tz": "~1.3.3"
-      }
-    },
-    "node_modules/@astrouxds/astro-web-components/node_modules/date-fns": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
-      "integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw==",
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
-    },
-    "node_modules/@astrouxds/astro-web-components/node_modules/date-fns-tz": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.7.tgz",
-      "integrity": "sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==",
-      "peerDependencies": {
-        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -572,19 +538,6 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.2.tgz",
-      "integrity": "sha512-Skfy0YS3NJ5nV9us0uuPN0HDk1Q4edljaOhRBJGDWs9EBa7ZVMYBHRFlhLvvmwEoaIM9BlH6QJFn9/uZg0bACg=="
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.6.tgz",
-      "integrity": "sha512-kt/tg1oip9OAH1xjCTcx1OpcUpu9rjDw3GKJ/rEhUqhO7QyJWfrHU0DpLTNsH67+JyFL5Kv9X1utsXwKFVtyEQ==",
-      "dependencies": {
-        "@floating-ui/core": "^1.0.2"
-      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1293,18 +1246,6 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/@stencil/core": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.1.tgz",
-      "integrity": "sha512-/fXkh1lwZ+X9JQCw50mPjhBogzEHOBvVC5pLoDLZqodVYK0DGWILM2YLV4dcIUBNEK8/HMDpO/Rq81/rS3mNOw==",
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -9606,30 +9547,6 @@
         "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
-    "@astrouxds/astro-web-components": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-7.3.0.tgz",
-      "integrity": "sha512-D5ISu4oWsnu6HS9jFTNX+MOLsbsD3FEXZK6o+Xd6Elu6n3q8vqyRmZnpJC68tn4R1yiimBgBOYQ9U/st+wy83A==",
-      "requires": {
-        "@floating-ui/dom": "~1.0.1",
-        "@stencil/core": "~2.18.0",
-        "date-fns": "~2.21.1",
-        "date-fns-tz": "~1.3.3"
-      },
-      "dependencies": {
-        "date-fns": {
-          "version": "2.21.3",
-          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
-          "integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw=="
-        },
-        "date-fns-tz": {
-          "version": "1.3.7",
-          "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.7.tgz",
-          "integrity": "sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==",
-          "requires": {}
-        }
-      }
-    },
     "@babel/code-frame": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
@@ -9995,19 +9912,6 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
-    },
-    "@floating-ui/core": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.2.tgz",
-      "integrity": "sha512-Skfy0YS3NJ5nV9us0uuPN0HDk1Q4edljaOhRBJGDWs9EBa7ZVMYBHRFlhLvvmwEoaIM9BlH6QJFn9/uZg0bACg=="
-    },
-    "@floating-ui/dom": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.6.tgz",
-      "integrity": "sha512-kt/tg1oip9OAH1xjCTcx1OpcUpu9rjDw3GKJ/rEhUqhO7QyJWfrHU0DpLTNsH67+JyFL5Kv9X1utsXwKFVtyEQ==",
-      "requires": {
-        "@floating-ui/core": "^1.0.2"
-      }
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -10544,11 +10448,6 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
-    },
-    "@stencil/core": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.1.tgz",
-      "integrity": "sha512-/fXkh1lwZ+X9JQCw50mPjhBogzEHOBvVC5pLoDLZqodVYK0DGWILM2YLV4dcIUBNEK8/HMDpO/Rq81/rS3mNOw=="
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",


### PR DESCRIPTION
## Brief Description

This adds any remaining changes on a clean install of the project.

- Update package-lock.json files.
- Clear excess `//@ts-nocheck` from `proxies-list.ts`. The underlying issue can be solved at some later point.
- Remove special Apple Silicon instructions for `puppeteer`, which was removed in a previous commit.
- Prevent unexpected file diffs after `npm run build` by running `npx pretty-quick` during `postbuild`.

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
