### PR TITLE
fix(rux-pop-up)

### DIFF
--- a/.changeset/lemon-buckets-leave.md
+++ b/.changeset/lemon-buckets-leave.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+fix(rux-pop-up) move aria-hidden to describe the pop up itself rather than the whole web component

--- a/packages/web-components/src/components/rux-pop-up/rux-pop-up.tsx
+++ b/packages/web-components/src/components/rux-pop-up/rux-pop-up.tsx
@@ -296,7 +296,7 @@ export class RuxPopUp {
 
     render() {
         return (
-            <Host aria-hidden={this.open ? 'false' : 'true'}>
+            <Host>
                 <div class="rux-popup" part="container">
                     <div
                         onClick={this._handleTriggerClick}
@@ -321,6 +321,7 @@ export class RuxPopUp {
                             'rux-popup__content--menu': this.hasMenu,
                             hidden: this.open === false,
                         }}
+                        aria-hidden={this.open ? 'false' : 'true'}
                         part="popup-content"
                         ref={(el) => (this.content = el!)}
                     >


### PR DESCRIPTION
## Brief Description

Moved aria-hidden on rux-pop-up to describe the pop up itself rather than the entire component.

## JIRA Link

[ASTRO-4908](https://rocketcom.atlassian.net/browse/ASTRO-4908)

## Related Issue

## General Notes

## Motivation and Context

When the pop-up container was hidden on rux-pop-up aria-hidden = true was being applied to the entire component which made it impossible for keyboard users to tab into the button/trigger for the pop up. Effectively this made the component inaccessible to keyboard users indefinitely.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
