### PR TITLE
make segmented buttons ttab-able and add focus

### DIFF
--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
@@ -45,6 +45,14 @@
     margin: var(--spacing-0);
     padding: var(--spacing-0);
 
+    //mimic the border radius of the interior button
+    &:first-child {
+        border-radius: var(--radius-base) 0 0 var(--radius-base);
+    }
+    &:last-child {
+        border-radius: 0 var(--radius-base) var(--radius-base) 0;
+    }
+
     //omit the right border on next sibling to avoid double borders
     + .rux-segmented-button__segment {
         label {
@@ -59,6 +67,12 @@
                 border-left-color: var(--color-background-interactive-hover);
             }
         }
+    }
+    //apply focus state when input within in selected and raise so that full outline is visible
+    &:focus-within {
+        outline: var(--focus-outline);
+        outline-offset: var(--focus-offset);
+        z-index: 1;
     }
 
     label {
@@ -107,7 +121,9 @@
     }
 
     input {
-        display: none !important;
+        //allow normal radio keyboard functionality while hiding the input from view
+        position: absolute;
+        opacity: 0;
 
         &:checked + label {
             background-color: var(--color-background-surface-selected);

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -33,7 +33,7 @@
     --focus-ring-color: var(--color-palette-pink-200);
     --focus-ring-width: var(--spacing-025);
     --focus-offset: var(--spacing-050);
-    --focus-radius: 3px;
+    --focus-radius: var(--radius-base);
     --focus-outline: var(--focus-ring-width) solid var(--focus-ring-color);
     --focus-shadow: 0px 0px 0px 3px rgba(218, 156, 231, 0.5); //Cannot use design token because opacity is needed.. not currently in use
 }


### PR DESCRIPTION
## Brief Description

This is the PR for segmented buttons. I had to make them tab enabled. in order to accomplish this I changed <input> from display: none to absolutely positioned within the button with an opacity of 0. This way it can still be tabbed into and the proper button segment takes on the focus state.

## Motivation and Context

Part of focus state first sweep

## Issues and Limitations

One problem I'm seeing is that tabbing between segmented buttons does not work. The internals work fine, arrow keys will determine which button is selected and you can tab back to the one that you had selected.

That said, if you have two segmented buttons in a row you cannot tab from one to the next. HOWEVER, if you have two segmented buttons that are separated by something else with a tab index then you can tab between all items.