### PR TITLE
Fix keyboard functionality for rux-tabs

### DIFF
--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
@@ -14,12 +14,12 @@
     &:hover {
         color: var(--color-background-interactive-hover);
     }
+    cursor: pointer;
     &:focus-visible {
-        border-radius: var(--focus-radius);
         outline: var(--focus-outline);
         outline-offset: var(--focus-offset);
+        border-radius: var(--focus-radius);
     }
-    cursor: pointer;
 }
 
 :host([hidden]) {

--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.tsx
@@ -55,7 +55,7 @@ export class RuxTab {
                         'rux-tab--large': !this.small,
                         'rux-tab--disabled': this.disabled,
                     }}
-                    tabindex={this.disabled ? '-1' : '0'}
+                    tabindex={this.disabled || !this.selected ? '-1' : '0'}
                 >
                     <slot></slot>
                 </div>

--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.tsx
@@ -29,8 +29,6 @@ export class RuxTab {
     @Element() el!: HTMLRuxTabElement
 
     connectedCallback() {
-        this.el.setAttribute('role', 'tab')
-
         //handle small on init
         if (this.el?.parentElement?.getAttributeNode('small')) {
             this.el.setAttribute('small', '')
@@ -55,6 +53,7 @@ export class RuxTab {
                         'rux-tab--large': !this.small,
                         'rux-tab--disabled': this.disabled,
                     }}
+                    role="tab"
                     tabindex={this.disabled || !this.selected ? '-1' : '0'}
                 >
                     <slot></slot>

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
@@ -55,6 +55,44 @@ export class RuxTabs {
         }
     }
 
+    @Listen('keydown', { target: 'document' })
+    onKeydown(e: any) {
+        if (e.target && !this.el.contains(e.target)) {
+            return
+        }
+
+        // Get all tabs inside of the radio group and then
+        // filter out disabled radios since we need to skip those
+        const tabs = this._tabs.filter((tab) => !tab.disabled)
+
+        // Only move the radio if the current focus is in the radio group
+        if (e.target && tabs.includes(e.target)) {
+            const index = tabs.findIndex((tab) => tab === e.target)
+
+            let next
+
+            // If hitting arrow down or arrow right, move to the next radio
+            // If we're on the last radio, move to the first radio
+            if (['ArrowDown', 'ArrowRight'].includes(e.code)) {
+                next = index === tabs.length - 1 ? tabs[0] : tabs[index + 1]
+            }
+
+            // If hitting arrow up or arrow left, move to the previous radio
+            // If we're on the first radio, move to the last radio
+            if (['ArrowUp', 'ArrowLeft'].includes(e.code)) {
+                next = index === 0 ? tabs[tabs.length - 1] : tabs[index - 1]
+            }
+
+            if (next && tabs.includes(next)) {
+                console.log(next)
+                const nextFocus = next.shadowRoot?.querySelector(
+                    '.rux-tab'
+                ) as HTMLElement
+                nextFocus.focus()
+            }
+        }
+    }
+
     /**
      * Fires whenever a new tab is selected, and emits the selected tab on the event.detail.
      */
@@ -66,6 +104,7 @@ export class RuxTabs {
 
     private _addTabs() {
         this._tabs = Array.from(this.el.querySelectorAll('rux-tab'))
+        console.log(this._tabs)
     }
 
     private _registerPanels(e: CustomEvent) {

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
@@ -84,7 +84,6 @@ export class RuxTabs {
             }
 
             if (next && tabs.includes(next)) {
-                console.log(next)
                 const nextFocus = next.shadowRoot?.querySelector(
                     '.rux-tab'
                 ) as HTMLElement

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
@@ -67,14 +67,14 @@ export class RuxTabs {
 
             let next
 
-            // If hitting arrow down or arrow right, move to the next radio
-            // If we're on the last radio, move to the first radio
+            // If hitting arrow down or arrow right, move to the next tab
+            // If we're on the last tab, move to the first tab
             if (['ArrowDown', 'ArrowRight'].includes(e.code)) {
                 next = index === tabs.length - 1 ? tabs[0] : tabs[index + 1]
             }
 
-            // If hitting arrow up or arrow left, move to the previous radio
-            // If we're on the first radio, move to the last radio
+            // If hitting arrow up or arrow left, move to the previous tab
+            // If we're on the first tab, move to the last tab
             if (['ArrowUp', 'ArrowLeft'].includes(e.code)) {
                 next = index === 0 ? tabs[tabs.length - 1] : tabs[index - 1]
             }

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
@@ -103,7 +103,6 @@ export class RuxTabs {
 
     private _addTabs() {
         this._tabs = Array.from(this.el.querySelectorAll('rux-tab'))
-        console.log(this._tabs)
     }
 
     private _registerPanels(e: CustomEvent) {

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
@@ -81,8 +81,14 @@ export class RuxTabs {
         this._setTab(selectedTab)
     }
 
-    private _onClick(e: MouseEvent) {
-        const tab = e.target as HTMLRuxTabElement
+    private _onPress(e: KeyboardEvent) {
+        e.key === 'Enter' ? this._onClick(e) : null
+    }
+
+    private _onClick(e: KeyboardEvent | MouseEvent) {
+        const target = e.target as HTMLElement
+        //get the tab in case complex html is nested inside rux-tab
+        const tab = target.closest('rux-tab') as HTMLRuxTabElement
         this.ruxSelected.emit(tab)
         if (
             tab.getAttribute('role') === 'tab' &&
@@ -123,7 +129,11 @@ export class RuxTabs {
 
     render() {
         return (
-            <Host onClick={(e: MouseEvent) => this._onClick(e)}>
+            <Host
+                onClick={(e: MouseEvent) => this._onClick(e)}
+                onKeyPress={(e: KeyboardEvent) => this._onPress(e)}
+                role="tablist"
+            >
                 <slot></slot>
             </Host>
         )

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
@@ -55,17 +55,13 @@ export class RuxTabs {
         }
     }
 
-    @Listen('keydown', { target: 'document' })
+    @Listen('keydown')
     onKeydown(e: any) {
-        if (e.target && !this.el.contains(e.target)) {
-            return
-        }
-
-        // Get all tabs inside of the radio group and then
-        // filter out disabled radios since we need to skip those
+        // Get all tabs inside of the tab group and then
+        // filter out disabled tabs since we need to skip those
         const tabs = this._tabs.filter((tab) => !tab.disabled)
 
-        // Only move the radio if the current focus is in the radio group
+        // Only move the tab if the current focus is in the tab group
         if (e.target && tabs.includes(e.target)) {
             const index = tabs.findIndex((tab) => tab === e.target)
 
@@ -127,10 +123,7 @@ export class RuxTabs {
         //get the tab in case complex html is nested inside rux-tab
         const tab = target.closest('rux-tab') as HTMLRuxTabElement
         this.ruxSelected.emit(tab)
-        if (
-            tab.getAttribute('role') === 'tab' &&
-            tab.getAttribute('disabled') === null
-        ) {
+        if (tab.getAttribute('disabled') === null) {
             this._setTab(tab)
         }
     }

--- a/packages/web-components/src/components/rux-tabs/test/index.html
+++ b/packages/web-components/src/components/rux-tabs/test/index.html
@@ -147,7 +147,7 @@
         >
             <rux-tabs id="tabs-spacing-styling" small>
                 <rux-tab id="spacing-small-id-1">Tab One</rux-tab>
-                <rux-tab id="spacing-small-id-2">Tab Two</rux-tab>
+                <rux-tab id="spacing-small-id-2" disabled>Tab Two</rux-tab>
                 <rux-tab id="spacing-small-id-3">Tab Three</rux-tab>
             </rux-tabs>
             <rux-tab-panels aria-labelledby="tabs-spacing-styling">

--- a/packages/web-components/src/components/rux-tabs/test/index.html
+++ b/packages/web-components/src/components/rux-tabs/test/index.html
@@ -28,7 +28,7 @@
         <!--Previous Tests-->
         <div style="display: flex; flex-flow: column">
             <rux-tabs id="tab-set-id-1">
-                <rux-tab id="tab-id-1">Tab 1</rux-tab>
+                <rux-tab id="tab-id-1"><span>Tab 1</span></rux-tab>
                 <rux-tab id="tab-id-2">Tab 2</rux-tab>
                 <rux-tab id="tab-id-3">Tab 3</rux-tab>
             </rux-tabs>

--- a/packages/web-components/src/components/rux-tabs/test/tabs.spec.ts
+++ b/packages/web-components/src/components/rux-tabs/test/tabs.spec.ts
@@ -370,7 +370,6 @@ test.describe('Tab Keyboard Navigation', () => {
         const tab1Child = tab1.locator('.rux-tab')
         const tab2Child = tab2.locator('.rux-tab')
         const tab3Child = tab3.locator('.rux-tab')
-        const button = page.locator('#button')
 
         //Act
         await tab1Child.focus()
@@ -396,12 +395,6 @@ test.describe('Tab Keyboard Navigation', () => {
 
         //Assert
         await expect(tab1Child).toBeFocused()
-
-        //Act
-        page.keyboard.press('Tab')
-
-        //Assert
-        await expect(button).toBeFocused()
     })
     test('tabs to next focusable element on Tab key', async ({ page }) => {
         //Arrange

--- a/packages/web-components/src/components/rux-tabs/test/tabs.spec.ts
+++ b/packages/web-components/src/components/rux-tabs/test/tabs.spec.ts
@@ -410,6 +410,59 @@ test.describe('Tab Keyboard Navigation', () => {
         await expect(button).toBeFocused()
     })
 })
+
+test.describe('Tab Keyboard Disabled Navigation', () => {
+    test.beforeEach(async ({ page }) => {
+        const template = `
+            <div style="display: flex; flex-flow: column">
+                <rux-tabs id="tab-set-id-1">
+                    <rux-tab id="tab-id-1">Tab 1</rux-tab>
+                    <rux-tab id="tab-id-2" disabled >Tab 2</rux-tab>
+                    <rux-tab id="tab-id-3">Tab 3</rux-tab>
+                </rux-tabs>
+                <rux-tab-panels aria-labelledby="tab-set-id-1">
+                    <rux-tab-panel aria-labelledby="tab-id-1">
+                    Content 1 
+                    </rux-tab-panel>
+                    <rux-tab-panel aria-labelledby="tab-id-2">
+                    Content 2 
+                    </rux-tab-panel>
+                    <rux-tab-panel aria-labelledby="tab-id-3">
+                    Content 3 
+                    </rux-tab-panel>
+                </rux-tab-panels>
+            </div>
+            <button id="button">Hi!</button>
+        `
+
+        await page.setContent(template)
+    })
+
+    test('skips disabled tab(s)', async ({ page }) => {
+        //Arrange
+        const tab1 = await page.locator('#tab-id-1')
+        const tab2 = await page.locator('#tab-id-2')
+        const tab3 = await page.locator('#tab-id-3')
+        const tab1Child = tab1.locator('.rux-tab')
+        const tab2Child = tab2.locator('.rux-tab')
+        const tab3Child = tab3.locator('.rux-tab')
+
+        //Act
+        await tab1Child.focus()
+        page.keyboard.press('ArrowRight')
+
+        //Assert
+        await expect(tab2Child).not.toBeFocused()
+        await expect(tab3Child).toBeFocused()
+
+        //Act
+        page.keyboard.press('ArrowLeft')
+
+        //Assert
+        await expect(tab2Child).not.toBeFocused()
+        await expect(tab1Child).toBeFocused()
+    })
+})
 /*
     Need to test: 
     

--- a/packages/web-components/src/components/rux-tabs/test/tabs.spec.ts
+++ b/packages/web-components/src/components/rux-tabs/test/tabs.spec.ts
@@ -60,6 +60,28 @@ test.describe('Tabs', () => {
         //Assert
         await expect(tab1).toHaveAttribute('selected', '')
     })
+    test('selects tab when user hits enter', async ({ page }) => {
+        //Arrange
+        const tab1 = await page.locator('#tab-id-1')
+        const tab2 = await page.locator('#tab-id-2')
+        const tab1Child = tab1.locator('.rux-tab')
+        const tab2Child = tab2.locator('.rux-tab')
+
+        //Act
+        await tab2Child.focus()
+        await page.keyboard.press('Enter')
+
+        //Assert
+        await expect(tab2).toHaveAttribute('selected', '')
+        await expect(tab1).not.toHaveAttribute('selected', '')
+
+        //Act
+        await tab1Child.focus()
+        await page.keyboard.press('Enter')
+
+        //Assert
+        await expect(tab1).toHaveAttribute('selected', '')
+    })
     test('shows correct panel when its tab is clicked', async ({ page }) => {
         //Arrange
         const ruxTabPanel1 = await page.locator('rux-tab-panel').nth(0)
@@ -310,6 +332,111 @@ test.describe('Multiple tabs on same page', () => {
             .then((e) => {
                 expect(e).toBeFalsy()
             })
+    })
+})
+
+test.describe('Tab Keyboard Navigation', () => {
+    test.beforeEach(async ({ page }) => {
+        const template = `
+            <div style="display: flex; flex-flow: column">
+                <rux-tabs id="tab-set-id-1">
+                    <rux-tab id="tab-id-1">Tab 1</rux-tab>
+                    <rux-tab id="tab-id-2">Tab 2</rux-tab>
+                    <rux-tab id="tab-id-3">Tab 3</rux-tab>
+                </rux-tabs>
+                <rux-tab-panels aria-labelledby="tab-set-id-1">
+                    <rux-tab-panel aria-labelledby="tab-id-1">
+                    Content 1 
+                    </rux-tab-panel>
+                    <rux-tab-panel aria-labelledby="tab-id-2">
+                    Content 2 
+                    </rux-tab-panel>
+                    <rux-tab-panel aria-labelledby="tab-id-3">
+                    Content 3 
+                    </rux-tab-panel>
+                </rux-tab-panels>
+            </div>
+            <button id="button">Hi!</button>
+        `
+
+        await page.setContent(template)
+    })
+
+    test('selects tab when user hits enter', async ({ page }) => {
+        //Arrange
+        const tab1 = await page.locator('#tab-id-1')
+        const tab2 = await page.locator('#tab-id-2')
+        const tab1Child = tab1.locator('.rux-tab')
+        const tab2Child = tab2.locator('.rux-tab')
+
+        //Act
+        await tab2Child.focus()
+        await page.keyboard.press('Enter')
+
+        //Assert
+        await expect(tab2).toHaveAttribute('selected', '')
+        await expect(tab1).not.toHaveAttribute('selected', '')
+
+        //Act
+        await tab1Child.focus()
+        await page.keyboard.press('Enter')
+
+        //Assert
+        await expect(tab1).toHaveAttribute('selected', '')
+    })
+    test('moves between tabs with arrow keys', async ({ page }) => {
+        //Arrange
+        const tab1 = await page.locator('#tab-id-1')
+        const tab2 = await page.locator('#tab-id-2')
+        const tab3 = await page.locator('#tab-id-3')
+        const tab1Child = tab1.locator('.rux-tab')
+        const tab2Child = tab2.locator('.rux-tab')
+        const tab3Child = tab3.locator('.rux-tab')
+        const button = page.locator('#button')
+
+        //Act
+        await tab1Child.focus()
+        page.keyboard.press('ArrowRight')
+
+        //Assert
+        await expect(tab2Child).toBeFocused()
+
+        //Act
+        page.keyboard.press('ArrowRight')
+
+        //Assert
+        await expect(tab3Child).toBeFocused()
+
+        //Act
+        page.keyboard.press('ArrowLeft')
+
+        //Assert
+        await expect(tab2Child).toBeFocused()
+
+        //Act
+        page.keyboard.press('ArrowLeft')
+
+        //Assert
+        await expect(tab1Child).toBeFocused()
+
+        //Act
+        page.keyboard.press('Tab')
+
+        //Assert
+        await expect(button).toBeFocused()
+    })
+    test('tabs to next focusable element on Tab key', async ({ page }) => {
+        //Arrange
+        const tab1 = await page.locator('#tab-id-1')
+        const tab1Child = tab1.locator('.rux-tab')
+        const button = page.locator('#button')
+
+        //Act
+        await tab1Child.focus()
+        page.keyboard.press('Tab')
+
+        //Assert
+        await expect(button).toBeFocused()
     })
 })
 /*

--- a/packages/web-components/src/components/rux-tabs/test/tabs.spec.ts
+++ b/packages/web-components/src/components/rux-tabs/test/tabs.spec.ts
@@ -60,28 +60,6 @@ test.describe('Tabs', () => {
         //Assert
         await expect(tab1).toHaveAttribute('selected', '')
     })
-    test('selects tab when user hits enter', async ({ page }) => {
-        //Arrange
-        const tab1 = await page.locator('#tab-id-1')
-        const tab2 = await page.locator('#tab-id-2')
-        const tab1Child = tab1.locator('.rux-tab')
-        const tab2Child = tab2.locator('.rux-tab')
-
-        //Act
-        await tab2Child.focus()
-        await page.keyboard.press('Enter')
-
-        //Assert
-        await expect(tab2).toHaveAttribute('selected', '')
-        await expect(tab1).not.toHaveAttribute('selected', '')
-
-        //Act
-        await tab1Child.focus()
-        await page.keyboard.press('Enter')
-
-        //Assert
-        await expect(tab1).toHaveAttribute('selected', '')
-    })
     test('shows correct panel when its tab is clicked', async ({ page }) => {
         //Arrange
         const ruxTabPanel1 = await page.locator('rux-tab-panel').nth(0)


### PR DESCRIPTION
## Brief Description

Borrowed some code from Mark for the keyboard functionality of tabs, and then inserted my own roving tab index logic. Now tabs work as they should. They currently do not automatically activate on focus but a keyboard user can use the arrow keys to select the appropriate tab and hit enter to activate it.

## JIRA Link

[ASTRO-4952](https://rocketcom.atlassian.net/browse/ASTRO-4952)

## Related Issue
Part of focus state work.

## General Notes

## Motivation and Context

tab keyboard control didn't work as one would expect. now it does.

## Issues and Limitations
I am sick. please look at code and critique my potato brain.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
