### PR TITLE
rux-pop-up keyboard control fixes

### DIFF
--- a/packages/web-components/src/components/rux-pop-up/rux-pop-up.scss
+++ b/packages/web-components/src/components/rux-pop-up/rux-pop-up.scss
@@ -14,6 +14,11 @@
 ::slotted(*[slot='trigger']) {
     cursor: pointer;
 }
+::slotted(*[slot='trigger']:focus-visible) {
+    border-radius: var(--focus-radius);
+    outline: var(--focus-outline);
+    outline-offset: var(--focus-offset);
+}
 
 .rux-popup {
     font-family: var(--font-body-1-font-family);

--- a/packages/web-components/src/components/rux-pop-up/rux-pop-up.tsx
+++ b/packages/web-components/src/components/rux-pop-up/rux-pop-up.tsx
@@ -86,7 +86,6 @@ export class RuxPopUp {
 
     @Watch('open')
     handleOpen() {
-        console.log('handled')
         if (this.open) {
             this.content.style.display = 'block'
             this._startPositioner()

--- a/packages/web-components/src/components/rux-pop-up/rux-pop-up.tsx
+++ b/packages/web-components/src/components/rux-pop-up/rux-pop-up.tsx
@@ -86,6 +86,7 @@ export class RuxPopUp {
 
     @Watch('open')
     handleOpen() {
+        console.log('handled')
         if (this.open) {
             this.content.style.display = 'block'
             this._startPositioner()
@@ -127,7 +128,13 @@ export class RuxPopUp {
 
     connectedCallback() {
         this._handleTriggerClick = this._handleTriggerClick.bind(this)
+        this._handleTriggerKeyPress = this._handleTriggerKeyPress.bind(this)
         this._handleOutsideClick = this._handleOutsideClick.bind(this)
+        this._setTriggerTabIndex = this._setTriggerTabIndex.bind(this)
+    }
+
+    componentWillLoad() {
+        this._setTriggerTabIndex()
     }
 
     componentDidRender() {
@@ -136,8 +143,18 @@ export class RuxPopUp {
         }
     }
 
-    private async _handleTriggerClick() {
-        this.open = !this.open
+    private async _handleTriggerClick(event: MouseEvent) {
+        //excludes synthetic keyboard events such as Enter on a button behaving as a click
+        if (event.detail > 0) {
+            this.open = !this.open
+        }
+    }
+
+    //part of focus + accessible keyboard events
+    private async _handleTriggerKeyPress(event: KeyboardEvent) {
+        if (event.key === 'Enter') {
+            this.open = !this.open
+        }
     }
 
     private _position() {
@@ -194,6 +211,16 @@ export class RuxPopUp {
             })
         })
         this._setArrowPosition()
+    }
+
+    //set a tabindex if the trigger element does not have one, necessary for items that can not natively receive focus
+    private _setTriggerTabIndex() {
+        const triggerEl = this.el.querySelector(
+            `[slot='trigger']`
+        ) as HTMLElement
+        triggerEl.hasAttribute('tabindex')
+            ? null
+            : triggerEl.setAttribute('tabindex', '0')
     }
 
     private _startPositioner() {
@@ -300,6 +327,7 @@ export class RuxPopUp {
                 <div class="rux-popup" part="container">
                     <div
                         onClick={this._handleTriggerClick}
+                        onKeyPress={this._handleTriggerKeyPress}
                         class="rux-popup__trigger"
                         ref={(el) => (this.trigger = el!)}
                         part="trigger-container"

--- a/packages/web-components/src/components/rux-pop-up/test/index.html
+++ b/packages/web-components/src/components/rux-pop-up/test/index.html
@@ -27,6 +27,23 @@
     </head>
 
     <body>
+        <div style="padding: 10% 5%; display: flex">
+            <rux-pop-up disable-auto-update placement="top-start" id="top">
+                <rux-icon icon="star" slot="trigger">Top</rux-icon>
+                <rux-menu>
+                    <rux-menu-item value="1" selected
+                        >Pop up menu option test</rux-menu-item
+                    >
+                    <rux-menu-item-divider></rux-menu-item-divider>
+                    <rux-menu-item value="2"
+                        >Pop up menu option test</rux-menu-item
+                    >
+                    <rux-menu-item value="3"
+                        >Pop up menu option test</rux-menu-item
+                    >
+                </rux-menu>
+            </rux-pop-up>
+        </div>
         <!-- Top -->
         <div style="padding: 10% 5%; display: flex">
             <rux-pop-up disable-auto-update placement="top-start" id="top">

--- a/packages/web-components/src/components/rux-pop-up/test/pop-up.spec.ts
+++ b/packages/web-components/src/components/rux-pop-up/test/pop-up.spec.ts
@@ -85,6 +85,61 @@ test.describe('Pop up', async () => {
             toggleBtn.click(),
         ])
     })
+    //keyboard tests
+    test('it opens/closes on Enter', async ({ page }) => {
+        const template = `    
+        <rux-pop-up placement="top-start" id="top">
+        <rux-button slot="trigger" id="toggle-btn">Top</rux-button>
+        <rux-menu>
+            <rux-menu-item value="1" selected>Pop up menu option test</rux-menu-item>
+            <rux-menu-item-divider></rux-menu-item-divider>
+            <rux-menu-item value="2">Pop up menu option test</rux-menu-item>
+            <rux-menu-item value="3">Pop up menu option test</rux-menu-item>
+        </rux-menu>
+        </rux-pop-up>`
+        await page.setContent(template)
+        const toggleBtn = await page.locator('#toggle-btn')
+        const popUp = await page.locator('rux-pop-up')
+
+        //Assert
+        await expect(popUp).not.toHaveAttribute('open', '')
+
+        //Act
+        await toggleBtn.focus()
+        await page.keyboard.press('Enter')
+
+        //Assert
+        await expect(popUp).toHaveAttribute('open', '')
+
+        //Act
+        await toggleBtn.focus()
+        await page.keyboard.press('Enter')
+
+        //Assert
+        await expect(popUp).not.toHaveAttribute('open', '')
+    })
+    test('icon trigger can have focus', async ({ page }) => {
+        const template = `    
+        <rux-pop-up placement="top-start" id="top">
+        <rux-icon slot="trigger" icon="star" id="toggle-btn"></rux-icon>
+        <rux-menu>
+            <rux-menu-item value="1" selected>Pop up menu option test</rux-menu-item>
+            <rux-menu-item-divider></rux-menu-item-divider>
+            <rux-menu-item value="2">Pop up menu option test</rux-menu-item>
+            <rux-menu-item value="3">Pop up menu option test</rux-menu-item>
+        </rux-menu>
+        </rux-pop-up>`
+        await page.setContent(template)
+        const toggleBtn = await page.locator('#toggle-btn')
+        const popUp = await page.locator('rux-pop-up')
+
+        //Assert
+        await expect(popUp).not.toHaveAttribute('open', '')
+
+        //Act
+        await page.keyboard.press('Tab')
+        await expect(toggleBtn).toBeFocused()
+    })
     /**
      * Need to test:
      *  - Open and close?


### PR DESCRIPTION
## Brief Description

Added tabindexing to trigger slot items in rux-pop-up
Also added keyboard functionality (IE hitting Enter when the trigger is focused will open and close the popup)

## JIRA Link

[ASTRO-4953](https://rocketcom.atlassian.net/browse/ASTRO-4953)

## Related Issue
Part of the Astro focus state initiative!

## General Notes

## Motivation and Context

Previously, elements that were used as a trigger for rux-pop-up that could not normally be focused were unable to be focused via tabbing. This is a problem because it meant that keyboard users could not focus the element to activate the popup.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
