### PR TITLE
add focus state for close button/keyboard control

### DIFF
--- a/packages/web-components/src/components/rux-notification/rux-notification.scss
+++ b/packages/web-components/src/components/rux-notification/rux-notification.scss
@@ -84,6 +84,13 @@
     margin-left: auto;
     display: flex;
 }
+.rux-notification-banner__close {
+    &:focus-visible {
+        border-radius: var(--focus-radius);
+        outline: var(--focus-outline);
+        outline-offset: var(--focus-offset);
+    }
+}
 
 /* ----- Large ----- */
 .rux-notification-banner--large {
@@ -121,7 +128,7 @@
 
 /* ---- truncated/wrapped --- */
 .rux-notification-banner__content {
-    overflow: hidden;
+    overflow-x: hidden; //because of this focus doesn't show. need refactor.
     white-space: nowrap;
     text-overflow: ellipsis;
 }

--- a/packages/web-components/src/components/rux-notification/rux-notification.tsx
+++ b/packages/web-components/src/components/rux-notification/rux-notification.tsx
@@ -100,6 +100,12 @@ export class RuxNotification {
         this.open = false
     }
 
+    private _onKeyPress(e: KeyboardEvent) {
+        if (e.key === 'Enter') {
+            this._onClick()
+        }
+    }
+
     get _closeAfter() {
         //* as long as it's less than 1000, they put in seconds. Convert that here.
         if (this.closeAfter && this.closeAfter <= 999) {
@@ -190,7 +196,10 @@ export class RuxNotification {
                                 <slot name="actions">
                                     <rux-icon
                                         role="button"
+                                        tabindex="1"
+                                        class="rux-notification-banner__close"
                                         onClick={() => this._onClick()}
+                                        onKeyDown={(e) => this._onKeyPress(e)}
                                         icon="clear"
                                         size={this.small ? '24px' : '32px'}
                                         exportparts="icon"


### PR DESCRIPTION
## Brief Description

Rux-notification could not be focused since it did not have a tab index. Added that and keyboard controls and then our focus outline state.

## JIRA Link

[ASTRO-5078](https://rocketcom.atlassian.net/browse/ASTRO-5078)

## Related Issue

## General Notes

## Motivation and Context

Focus state general tweaking

## Issues and Limitations

We need to revisit some of our components that use overflow:hidden in any way. Sometimes this cuts off focus state which isn't great. In notification specifically we should revisit the idea that notifications should be truncated with no way to see the rest of the notification.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
