### PR TITLE
remove menu icon since it was not interactive

### DIFF
--- a/packages/web-components/src/stories/card.stories.mdx
+++ b/packages/web-components/src/stories/card.stories.mdx
@@ -83,7 +83,6 @@ export const FullExample = (args) => {
 			<div slot="header" style="display: flex; align-items: center;">
 				<rux-icon icon="star" size="26px" style="margin-right: 10px;"></rux-icon>
 				Card Title
-				<rux-icon icon="menu" size="26px" style="margin-left: auto;"></rux-icon>
 			</div>
 			<div style="padding-top: 20px; padding-bottom: 20px; display: flex; justify-content: center;">
 				<svg width="140" height="140" viewBox="0 0 140 140" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Brief Description

Update storybook for rux-card to remove the hamburger icon in full example.

## JIRA Link

[ASTRO-5084](https://rocketcom.atlassian.net/browse/ASTRO-5084)

## Related Issue

## General Notes

## Motivation and Context

The hamburger icon wasn't interactive though, because of the nature of hamburger icons it seemed like it should be. Adding interactive code to it would have made the sample annoyingly long so I removed the icon instead.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] This PR changes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
