### PR TITLE
Km 5076 pop up storybook changes - focus state

### DIFF
--- a/packages/web-components/src/stories/popup.stories.mdx
+++ b/packages/web-components/src/stories/popup.stories.mdx
@@ -35,9 +35,9 @@ export const Default = (args) => {
     <rux-pop-up open=${args.open}>
         <rux-icon icon="apps" slot="trigger"></rux-icon>
         <rux-menu>
-            <rux-menu-item value="1">Menu Item 1</rux-menu-item>
-            <rux-menu-item value="2">Menu Item 2</rux-menu-item>
-            <rux-menu-item value="3">Menu Item 3</rux-menu-item>
+            <rux-menu-item href="#">Menu Item 1</rux-menu-item>
+            <rux-menu-item href="#">Menu Item 2</rux-menu-item>
+            <rux-menu-item href="#">Menu Item 3</rux-menu-item>
         </rux-menu>
     </rux-pop-up>
 </div>
@@ -77,9 +77,9 @@ export const Placements = (args) => {
     <rux-pop-up placement="top" open>
         <rux-button slot="trigger">Top</rux-button>
         <rux-menu>
-            <rux-menu-item value="1">Menu Item 1</rux-menu-item>
-            <rux-menu-item value="2">Menu Item 2</rux-menu-item>
-            <rux-menu-item value="3">Menu Item 3</rux-menu-item>
+            <rux-menu-item href="#">Menu Item 1</rux-menu-item>
+            <rux-menu-item href="#">Menu Item 2</rux-menu-item>
+            <rux-menu-item href="#">Menu Item 3</rux-menu-item>
         </rux-menu>
     </rux-pop-up>
 </div>
@@ -87,9 +87,9 @@ export const Placements = (args) => {
     <rux-pop-up placement="right" open>
         <rux-button slot="trigger">Right</rux-button>
         <rux-menu>
-            <rux-menu-item value="1">Menu Item 1</rux-menu-item>
-            <rux-menu-item value="2">Menu Item 2</rux-menu-item>
-            <rux-menu-item value="3">Menu Item 3</rux-menu-item>
+            <rux-menu-item href="#">Menu Item 1</rux-menu-item>
+            <rux-menu-item href="#">Menu Item 2</rux-menu-item>
+            <rux-menu-item href="#">Menu Item 3</rux-menu-item>
         </rux-menu>
     </rux-pop-up>
 </div>
@@ -97,9 +97,9 @@ export const Placements = (args) => {
     <rux-pop-up placement="bottom" open>
         <rux-button slot="trigger">Bottom</rux-button>
         <rux-menu>
-            <rux-menu-item value="1">Menu Item 1</rux-menu-item>
-            <rux-menu-item value="2">Menu Item 2</rux-menu-item>
-            <rux-menu-item value="3">Menu Item 3</rux-menu-item>
+            <rux-menu-item href="#">Menu Item 1</rux-menu-item>
+            <rux-menu-item href="#">Menu Item 2</rux-menu-item>
+            <rux-menu-item href="#">Menu Item 3</rux-menu-item>
         </rux-menu>
     </rux-pop-up>
 </div>
@@ -107,9 +107,9 @@ export const Placements = (args) => {
     <rux-pop-up placement="left" open>
         <rux-button slot="trigger">Left</rux-button>
         <rux-menu>
-            <rux-menu-item value="1">Menu Item 1</rux-menu-item>
-            <rux-menu-item value="2">Menu Item 2</rux-menu-item>
-            <rux-menu-item value="3">Menu Item 3</rux-menu-item>
+            <rux-menu-item href="#">Menu Item 1</rux-menu-item>
+            <rux-menu-item href="#">Menu Item 2</rux-menu-item>
+            <rux-menu-item href="#">Menu Item 3</rux-menu-item>
         </rux-menu>
     </rux-pop-up>
 </div>


### PR DESCRIPTION
## Brief Description

Changes pop-up storybook entry to make the menu items within pop-up interactive. This way they can take on focus state when tabbed into.

## JIRA Link

[ASTRO-5067](https://rocketcom.atlassian.net/browse/ASTRO-5076)

## Related Issue

## General Notes

## Motivation and Context

Part of the Astro focus state initiative!

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] This PR changes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
