### PR TITLE
fix(notification): accomodate text focus styles

### DIFF
--- a/packages/web-components/src/components/rux-notification/rux-notification.scss
+++ b/packages/web-components/src/components/rux-notification/rux-notification.scss
@@ -11,7 +11,7 @@
     --notification-banner-radius-outer: var(--radius-base);
     --notification-banner-radius-inner: calc(var(--radius-base) / 3 * 2);
     --notification-banner-border-width-large: var(--spacing-1); //4
-    --notification-banner-padding: 12px var(--spacing-2) 12px var(--spacing-4); //0 8px 0 16px
+    --notification-banner-padding: 0 var(--spacing-2) 0 var(--spacing-4); //0 8px 0 16px
     --notification-banner-border-width-small: var(--spacing-050); //2
 
     //for the 1px outer border on light theme
@@ -100,6 +100,9 @@
     }
 }
 
+.rux-notification-banner__content {
+    padding: 2px 3px 2px 0px;
+}
 .rux-notification-banner--large .rux-notification-banner__content {
     font-family: var(--font-heading-5-font-family);
     font-size: var(--font-heading-5-font-size);

--- a/packages/web-components/src/components/rux-notification/test/basic/index.html
+++ b/packages/web-components/src/components/rux-notification/test/basic/index.html
@@ -127,6 +127,11 @@
                 </rux-notification>
             </div>
             <div class="wrapper">
+                <rux-notification open small>
+                    Default Slot Small <a href="#">Link here</a>
+                </rux-notification>
+            </div>
+            <div class="wrapper">
                 <rux-notification open>
                     <rux-button slot="actions">Confirm</rux-button>
                     Action Slot


### PR DESCRIPTION
## Brief Description

adjusts padding on notification to allow for focus state when links are slotted

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
