### PR TITLE
style(clock): fixed height no longer applies to hide-label version

### DIFF
--- a/.changeset/wild-pandas-walk.md
+++ b/.changeset/wild-pandas-walk.md
@@ -1,0 +1,8 @@
+---
+"angular-workspace": minor
+"@astrouxds/angular": minor
+"@astrouxds/react": minor
+"@astrouxds/astro-web-components": minor
+---
+
+Clock: Removed the fixed height on a hide-labels version of clock

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -29,7 +29,7 @@
     "test": "docker run -it --rm --ipc=host -v \"${PWD}:/var/app/\" mcr.microsoft.com/playwright:focal /bin/bash -c 'cd /var/app; npx playwright install; npx playwright test'",
     "test.server": "serve -p 3334",
     "test.e2e": "npx playwright test --grep-invert @vrt",
-    "test.vrt": "docker run -it --rm --ipc=host -v \"${PWD}:/var/app/\" mcr.microsoft.com/playwright:v1.28.0-focal /bin/bash -c 'cd /var/app; npx playwright install; npx playwright test --grep @vrt'",
+    "test.vrt": "docker run -it --rm --ipc=host -v \"${PWD}:/var/app/\" mcr.microsoft.com/playwright:focal /bin/bash -c 'cd /var/app; npx playwright install; npx playwright test --grep @vrt'",
     "test.vrt.update": "docker run -i --rm --ipc=host -v \"${PWD}:/var/app/\" mcr.microsoft.com/playwright:focal /bin/bash -c 'cd /var/app; npx playwright install; npx playwright test --grep @vrt --update-snapshots'",
     "test.ci": "docker run -i --rm --ipc=host -v \"${PWD}:/var/app/\" mcr.microsoft.com/playwright:focal /bin/bash -c 'cd /var/app; npx playwright install; npx playwright test --grep-invert @vrt'",
     "test.wk": "npx playwright test --project=webkit --grep-invert @vrt",

--- a/packages/web-components/src/components/rux-clock/rux-clock.scss
+++ b/packages/web-components/src/components/rux-clock/rux-clock.scss
@@ -6,18 +6,20 @@
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
-    height: calc(var(--spacing-8) * 2); //64px
 }
 
 :host([hidden]) {
     display: none;
 }
 
+:host(:not([hide-labels])) {
+    height: calc(var(--spacing-8) * 2); //64px
+}
+
 .rux-clock {
     display: flex;
     user-select: none;
     color: var(--clock-text-color);
-    height: calc(var(--spacing-8) * 2); //64px
 }
 
 .rux-clock__segment {
@@ -45,7 +47,6 @@
 
 :host([small]) .rux-clock__segment__value {
     height: var(--spacing-10);
-    padding: var(--spacing-0) var(--spacing-3);
     padding: var(--spacing-1) var(--spacing-3);
     font-size: 1.15rem;
     font-weight: var(--font-weight-medium);


### PR DESCRIPTION
## Brief Description

Updates the `hide-labels` version of clock to not include a fixed height. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-5103

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
