### PR TITLE
Fix(rux-monitoring-icon) border chopped off by gsb

### DIFF
--- a/.changeset/stupid-suits-attend.md
+++ b/.changeset/stupid-suits-attend.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+fix(rux-monitoring-icon) fix border being cut off by the gsb when positioned at the edge of visible gsb

--- a/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
+++ b/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
@@ -52,12 +52,11 @@ rux-icon {
     z-index: 2;
     order: 3;
     position: absolute;
-    left: calc(var(--spacing-14) - var(--spacing-025));
+    left: calc(var(--spacing-14) - var(--spacing-050)); //54
     top: calc(var(--spacing-1) * -1);
-    box-shadow: 0 0 0 1px var(--color-text-secondary);
+    box-shadow: inset 0 0 0 1px var(--color-text-secondary);
     border-radius: var(--radius-base);
-    padding: calc(var(--spacing-2) - var(--spacing-025))
-        calc(var(--spacing-025) * 3); //7px 3px
+    padding: var(--spacing-2) var(--spacing-1); //8px 4px
     color: var(--color-palette-neutral-000);
     font-family: var(--font-body-3-font-family);
     font-size: var(--font-body-3-font-size);

--- a/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
+++ b/packages/web-components/src/components/rux-monitoring-icon/rux-monitoring-icon.scss
@@ -53,7 +53,7 @@ rux-icon {
     order: 3;
     position: absolute;
     left: calc(var(--spacing-14) - var(--spacing-050)); //54
-    top: calc(var(--spacing-1) * -1);
+    top: calc(var(--spacing-025) * -5);
     box-shadow: inset 0 0 0 1px var(--color-text-secondary);
     border-radius: var(--radius-base);
     padding: var(--spacing-2) var(--spacing-1); //8px 4px

--- a/packages/web-components/src/components/rux-monitoring-icon/test/index.html
+++ b/packages/web-components/src/components/rux-monitoring-icon/test/index.html
@@ -41,14 +41,24 @@
             notifications="123456789"
         ></rux-monitoring-icon>
         <!-- <h1>Figma VRT</h1>
-    <section>
-        <ftl-belt access-token="" file-id="J77M8jPxzOBoxQeevckKwb">
-            <ftl-holster node="40983:130550">
-                <rux-monitoring-icon icon="antenna-transmit" status="critical" notifications="99" label="Label"
-                    sublabel="Sub">
-                </rux-monitoring-icon>
-            </ftl-holster>
-        </ftl-belt>
-    </section> -->
+        <section>
+            <ftl-belt
+                access-token=""
+                file-id="3tYLyBkvKYOdUysPk6Fu60"
+            >
+                <ftl-holster node="40983:130550">
+                    <div style="padding: 4px 0 0 4px">
+                    <rux-monitoring-icon
+                        icon="antenna-transmit"
+                        status="critical"
+                        notifications="99"
+                        label="Label"
+                        sublabel="Sub"
+                    >
+                </div>
+                    </rux-monitoring-icon>
+                </ftl-holster>
+            </ftl-belt>
+        </section> -->
     </body>
 </html>


### PR DESCRIPTION
## Brief Description

This is a minor tweak to the monitoring icon work Frances did a couple of weeks ago. Despite her excellent efforts, the GSB was still cursing off part of the notifications badge on the monitoring icon.
I changes the border around the monitoring icon from outset to inset so that the calculations used to size the notification badge could take the whole box+border into account. I ran VRTs and adjusted the badge accordingly.c

## JIRA Link

[Astro-5149](https://rocketcom.atlassian.net/browse/ASTRO-5149)

## Related Issue

## General Notes

## Motivation and Context

Makes the GSB and rux-monitoring icon play nice together.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
