### PR TITLE
add pointer to close icon on rux-notification

### DIFF
--- a/.changeset/itchy-cows-travel.md
+++ b/.changeset/itchy-cows-travel.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+fix(rux-notification) add cursor:pointer to default close icon

--- a/packages/web-components/src/components/rux-notification/rux-notification.scss
+++ b/packages/web-components/src/components/rux-notification/rux-notification.scss
@@ -85,6 +85,10 @@
     display: flex;
 }
 
+.rux-notification-banner__close {
+    cursor: pointer;
+}
+
 /* ----- Large ----- */
 .rux-notification-banner--large {
     border: 1px solid var(--notification-banner-color-border-outer-default);

--- a/packages/web-components/src/components/rux-notification/rux-notification.tsx
+++ b/packages/web-components/src/components/rux-notification/rux-notification.tsx
@@ -194,6 +194,7 @@ export class RuxNotification {
                                         icon="clear"
                                         size={this.small ? '24px' : '32px'}
                                         exportparts="icon"
+                                        class="rux-notification-banner__close"
                                     ></rux-icon>
                                 </slot>
                             </div>


### PR DESCRIPTION
## Brief Description

The default close button on rux-notification did not have a hand pointer when hovered to indicate that it can be activated. It should, so one was added.

## JIRA Link

[ASTRO-5069](https://rocketcom.atlassian.net/browse/ASTRO-5069)

## Related Issue

## General Notes

## Motivation and Context



## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
