### PR TITLE
fix(rux-progress-monitoring-icon) restyle to match rux-monitoring-icon

### DIFF
--- a/.changeset/gold-melons-prove.md
+++ b/.changeset/gold-melons-prove.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": minor
+---
+
+fix(rux-progrress-monitoring-icon) restyle to match rux-monitoring-icon

--- a/packages/web-components/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.scss
+++ b/packages/web-components/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.scss
@@ -35,8 +35,6 @@
 
 rux-status {
     position: absolute;
-    top: -0.25rem;
-    left: -0.25rem;
     margin: 0;
 }
 
@@ -68,12 +66,12 @@ rux-status {
     font-size: var(--font-body-2-font-size);
     font-weight: var(--font-body-2-font-weight);
     letter-spacing: var(--font-body-2-letter-spacing);
+    line-height: var(--line-height-sm);
     text-align: center;
     text-overflow: ellipsis;
     white-space: nowrap;
-    line-height: 1.2;
     overflow: hidden;
-    margin-top: 1rem;
+    margin-top: 0;
     width: 100%;
     max-width: 6.25rem;
 }
@@ -84,11 +82,10 @@ rux-status {
     font-weight: var(--font-body-3-font-weight);
     letter-spacing: var(--font-body-3-letter-spacing);
     color: var(--color-text-primary);
-    opacity: 0.6;
     display: block;
 }
 
-.rux-advanced-status__status rux-status::part(status) {
+.rux-advanced-status__icon-group rux-status::part(status) {
     line-height: 0;
 }
 
@@ -98,8 +95,8 @@ rux-status {
 
 svg {
     margin: 0 auto;
-    width: 3rem;
-    height: 3rem;
+    width: 2.5rem; //40px
+    height: 2.5rem; //40px
 }
 svg.rux-status--off {
     stroke: var(--status-symbol-color-fill-off-on-dark, rgb(158, 167, 173));

--- a/packages/web-components/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.scss
+++ b/packages/web-components/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.scss
@@ -43,12 +43,12 @@ rux-status {
     z-index: 2;
     order: 3;
     position: absolute;
-    bottom: -0.75rem;
-    right: -0.4rem;
-    border: 1px solid rgba(255, 255, 255, 0.6);
+    left: calc(var(--spacing-14) - var(--spacing-050)); //54
+    top: calc(var(--spacing-025) * -5);
+    box-shadow: inset 0 0 0 1px var(--color-text-secondary);
     border-radius: var(--radius-base);
-    padding: 0.65rem 0.25rem;
-    color: #fff;
+    padding: var(--spacing-2) var(--spacing-1); //8px 4px
+    color: var(--color-palette-neutral-000);
     font-family: var(--font-body-3-font-family);
     font-size: var(--font-body-3-font-size);
     font-weight: var(--font-body-3-font-weight);

--- a/packages/web-components/src/components/rux-monitoring-progress-icon/test/index.html
+++ b/packages/web-components/src/components/rux-monitoring-progress-icon/test/index.html
@@ -83,25 +83,37 @@
                 top: 3rem;
             }
         </style>
-        <div style="position: relative; padding: 3rem" class="absolute">
-            <rux-monitoring-icon
-                icon="antenna-receive"
-                label="Label"
-                sublabel="Sub"
-                notifications="10"
-                status="caution"
-            >
-            </rux-monitoring-icon>
-            <rux-monitoring-progress-icon
-                progress="64"
-                label="Label"
-                sublabel="Sub"
-            ></rux-monitoring-progress-icon>
-        </div>
-
-        <div style="width: 40%; margin: 50px auto 0 auto; text-align: center">
-            <h1>Monitoring Icon vs Progress Monitoring Icon</h1>
-        </div>
+        <section style="padding: 3rem">
+            <h2>Overlap Test</h2>
+            <p>
+                This is like a figma visual test except figma doesn't have
+                rux-monitoring-progress-icon yet so I just wanted to make sure
+                that the wording, badge, and status icon have the same
+                positioning.
+            </p>
+            <div style="position: relative; padding: 3rem" class="absolute">
+                <rux-monitoring-icon
+                    icon="antenna-receive"
+                    label="Label"
+                    sublabel="Sub"
+                    notifications="10"
+                    status="caution"
+                >
+                </rux-monitoring-icon>
+                <rux-monitoring-progress-icon
+                    progress="64"
+                    label="Label"
+                    sublabel="Sub"
+                    notifications="10"
+                ></rux-monitoring-progress-icon>
+            </div>
+        </section>
+        <rux-monitoring-progress-icon
+            progress="64"
+            label="Label"
+            sublabel="Sub"
+            notifications="10"
+        ></rux-monitoring-progress-icon>
         <rux-monitoring-progress-icon></rux-monitoring-progress-icon>
     </body>
 </html>

--- a/packages/web-components/src/components/rux-monitoring-progress-icon/test/index.html
+++ b/packages/web-components/src/components/rux-monitoring-progress-icon/test/index.html
@@ -74,6 +74,7 @@
                     progress="80"
                     label="Styled"
                     sublabel="Sub"
+                    notifications="1000"
                 ></rux-monitoring-progress-icon>
             </div>
         </rux-global-status-bar>

--- a/packages/web-components/src/components/rux-monitoring-progress-icon/test/index.html
+++ b/packages/web-components/src/components/rux-monitoring-progress-icon/test/index.html
@@ -25,6 +25,83 @@
         />
     </head>
     <body>
+        <rux-global-status-bar
+            include-icon
+            app-domain="GSB"
+            app-state="App State"
+            app-name="Demo"
+            username="Kiley"
+        >
+            <div
+                style="
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                    gap: 0.5rem;
+                "
+            >
+                <rux-monitoring-icon
+                    icon="antenna-receive"
+                    label="Label"
+                    sublabel="Sub"
+                    notifications="10"
+                    status="normal"
+                >
+                </rux-monitoring-icon>
+                <rux-monitoring-progress-icon
+                    progress="40"
+                    label="Label"
+                    sublabel="Sub"
+                ></rux-monitoring-progress-icon>
+                <rux-monitoring-progress-icon
+                    progress="64"
+                    label="Caution"
+                ></rux-monitoring-progress-icon>
+                <rux-monitoring-progress-icon
+                    progress="80"
+                    label="Styled"
+                    sublabel="Sub"
+                    id="styled"
+                ></rux-monitoring-progress-icon>
+                <rux-monitoring-icon
+                    label="Label"
+                    sublabel="Sub"
+                    icon="antenna-transmit"
+                    notifications="2"
+                    status="critical"
+                ></rux-monitoring-icon>
+                <rux-monitoring-progress-icon
+                    progress="80"
+                    label="Styled"
+                    sublabel="Sub"
+                ></rux-monitoring-progress-icon>
+            </div>
+        </rux-global-status-bar>
+        <style>
+            .absolute > * {
+                position: absolute;
+                top: 3rem;
+            }
+        </style>
+        <div style="position: relative; padding: 3rem" class="absolute">
+            <rux-monitoring-icon
+                icon="antenna-receive"
+                label="Label"
+                sublabel="Sub"
+                notifications="10"
+                status="caution"
+            >
+            </rux-monitoring-icon>
+            <rux-monitoring-progress-icon
+                progress="64"
+                label="Label"
+                sublabel="Sub"
+            ></rux-monitoring-progress-icon>
+        </div>
+
+        <div style="width: 40%; margin: 50px auto 0 auto; text-align: center">
+            <h1>Monitoring Icon vs Progress Monitoring Icon</h1>
+        </div>
         <rux-monitoring-progress-icon></rux-monitoring-progress-icon>
     </body>
 </html>


### PR DESCRIPTION
## Brief Description

This is a restyle of rux-progress-monitoring-icon web component to bring the styles inline with rux-monitoring-icon. The two were styles quite differently which made them look odd next to each other in the GSB. The [GRM Dashboard](https://www.astrouxds.com/grm-service-ux-design/grm-dashboard/) is a sample of where they might be seen together in the GSB.

## JIRA Link

[ASTRO-5105](https://rocketcom.atlassian.net/browse/ASTRO-5150)

## Related Issue

## General Notes

## Motivation and Context

Oddly there is no figma example of rux-progress-monitoring-icon so its styles were never (as far as I know) created by design. This is a draft PR to show design what it would look like if it matched rux-monitoring-icon

## Issues and Limitations

This is a draft until it gets approved by design. :)

## Types of changes

- [x] Bug fix
- [ ] New feature
- [x] Breaking change - it does pretty significantly change the style of rux-progress-monitoring-icon although it should not change the overall footprint/size.

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
