### PR TITLE
ci/cd: Add VRTs to github actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,8 +27,7 @@ jobs:
         run: npm ci && npx playwright install --with-deps
         working-directory: ./packages/web-components
       - name: Build
-        run: npm run build.stencil
-        working-directory: ./packages/web-components
+        run: npm run build
   e2e:
     needs: setup
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,8 +26,7 @@ jobs:
         name: Install Dependencies
         run: npm ci && npx playwright install --with-deps
         working-directory: ./packages/web-components
-      - if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-        name: Build
+      - name: Build
         run: npm run build.stencil
         working-directory: ./packages/web-components
   e2e:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,8 +24,7 @@ jobs:
           key: ${{ runner.os }}-setup-${{ hashFiles('./packages/web-components/package-lock.json') }}
       - if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
         name: Install Dependencies
-        run: npm ci && npx playwright install --with-deps
-        working-directory: ./packages/web-components
+        run: npm ci && cd .packages/web-components && npx playwright install --with-deps
       - name: Build
         run: npm run build
   e2e:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   setup:
     runs-on: ubuntu-latest
+    timeout-minutes: 7
     steps:
       - uses: actions/checkout@v2
       - name: Cache node modules
@@ -24,7 +25,7 @@ jobs:
           key: ${{ runner.os }}-setup-${{ hashFiles('./packages/web-components/package-lock.json') }}
       - if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
         name: Install Dependencies
-        run: npm ci && cd .packages/web-components && npx playwright install --with-deps
+        run: npm ci && cd ./packages/web-components && npx playwright install --with-deps
       - name: Build
         run: npm run build
   e2e:
@@ -47,7 +48,7 @@ jobs:
   VRTs:
     needs: setup
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 7
     steps:
       - uses: actions/checkout@v2
       - name: Get Cache

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,31 +10,57 @@ on:
 env:
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 jobs:
-  e2e-tests:
+  setup:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Node
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v3
         with:
-          node-version: 16
-      - name: Install
-        run: npm ci
+          path: |
+            ./packages/web-components/node_modules
+            ./packages/web-components/dist
+          key: ${{ runner.os }}-setup-${{ hashFiles('./packages/web-components/package-lock.json') }}
+      - if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+        name: Install Dependencies
+        run: npm ci && npx playwright install --with-deps
         working-directory: ./packages/web-components
-      # - name: Install Playwright Dependencies
-      #   run: npx playwright install && npx playwright install-deps
-      #   shell: bash
-      #   working-directory: ./packages/web-components
-      - name: Build
+      - if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+        name: Build
         run: npm run build.stencil
         working-directory: ./packages/web-components
-      - name: Run Tests
+  e2e:
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 7
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Cache
+        uses: actions/cache@v3
+        id: get-cache
+        with:
+          path: |
+            ./packages/web-components/node_modules
+            ./packages/web-components/dist
+          key: ${{ runner.os }}-setup-${{ hashFiles('./packages/web-components/package-lock.json') }}
+      - name: e2e Tests
         run: npm run test.ci
         working-directory: ./packages/web-components
-      - uses: actions/upload-artifact@v3
-        if: always()
+  VRTs:
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Cache
+        uses: actions/cache@v3
+        id: get-cache
         with:
-          name: playwright-report
-          path: packages/web-components/playwright-report/
-          retention-days: 30
+          path: |
+            ./packages/web-components/node_modules
+            ./packages/web-components/dist
+          key: ${{ runner.os }}-setup-${{ hashFiles('./packages/web-components/package-lock.json') }}
+      - name: Run VRTs
+        run: npm run test.vrt
+        working-directory: ./packages/web-components

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   setup:
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@v2
       - name: Cache node modules
@@ -23,8 +23,7 @@ jobs:
             ./packages/web-components/node_modules
             ./packages/web-components/dist
           key: ${{ runner.os }}-setup-${{ hashFiles('./packages/web-components/package-lock.json') }}
-      - if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-        name: Install Dependencies
+      - name: Install Dependencies
         run: npm ci && cd ./packages/web-components && npx playwright install --with-deps
       - name: Build
         run: npm run build

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -29,7 +29,7 @@
     "test": "docker run -it --rm --ipc=host -v \"${PWD}:/var/app/\" mcr.microsoft.com/playwright:v1.28.0-focal /bin/bash -c 'cd /var/app; npx playwright install; npx playwright test'",
     "test.server": "serve -p 3334",
     "test.e2e": "npx playwright test --grep-invert @vrt",
-    "test.vrt": "docker run -it --rm --ipc=host -v \"${PWD}:/var/app/\" mcr.microsoft.com/playwright:v1.28.0-focal /bin/bash -c 'cd /var/app; npx playwright install; npx playwright test --grep @vrt'",
+    "test.vrt": "docker run -i --rm --ipc=host -v \"${PWD}:/var/app/\" mcr.microsoft.com/playwright:v1.28.0-focal /bin/bash -c 'cd /var/app; npx playwright install; npx playwright test --grep @vrt'",
     "test.vrt.update": "docker run -i --rm --ipc=host -v \"${PWD}:/var/app/\" mcr.microsoft.com/playwright:v1.28.0-focal /bin/bash -c 'cd /var/app; npx playwright install; npx playwright test --grep @vrt --update-snapshots'",
     "test.ci": "docker run -i --rm --ipc=host -v \"${PWD}:/var/app/\" mcr.microsoft.com/playwright:v1.28.0-focal /bin/bash -c 'cd /var/app; npx playwright install; npx playwright test --grep-invert @vrt'",
     "test.wk": "npx playwright test --project=webkit --grep-invert @vrt",


### PR DESCRIPTION
## Brief Description

This is a ci/cd change only.
Improves GA time with caching of node_modules and build files 
Adds new VRT job 
Splits e2e tests out into own job. 
Adds new (old) setup job. 
The setup job will always run a `npm run build` from root to ensure that the project's packages build with the new code. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-5240

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
