### PR TITLE
refactor: src/index deploy previews

### DIFF
--- a/packages/web-components/netlify.toml
+++ b/packages/web-components/netlify.toml
@@ -1,4 +1,0 @@
-[build]
-
-publish = "storybook-static/"
-command = "npm run build.stencil && npm run build.storybook"


### PR DESCRIPTION
## Brief Description


This PR makes it possible for the `astro-stencil` netlify deploy preview to show our `src/index.html`. This way we can view sample code without having to pull down the branch.
To accomplish this, I remove the `netlify.toml` and changed the params of each deploy preview on the netlify site. This `.toml` was way out of date anyway. The astro preview (the storybook one) remains unchanged.

In the future, I want this to show all the `component/test/basic` pages, but that'll require some more work. This is more of a quick win. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-5226

## Related Issue

## General Notes

## Motivation and Context
Allows for quick previews of example code.
## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
