### PR TITLE
Km 5331 add container part to rux-container

### DIFF
--- a/.changeset/proud-wolves-divide.md
+++ b/.changeset/proud-wolves-divide.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+feat(rux-container) add container part to the encompassing div to allow for extra styling

--- a/.changeset/proud-wolves-divide.md
+++ b/.changeset/proud-wolves-divide.md
@@ -1,5 +1,8 @@
 ---
-"@astrouxds/astro-web-components": patch
+"@astrouxds/astro-web-components": minor
+"angular-workspace": minor
+"@astrouxds/angular": minor
+"@astrouxds/react": minor
 ---
 
-feat(rux-container) add container part to the encompassing div to allow for extra styling
+feat(rux-container) add container part to the encompassing div to allow for extra styling and add scrollbar styling to accomodate scrolling body

--- a/packages/web-components/src/components/rux-container/rux-container.scss
+++ b/packages/web-components/src/components/rux-container/rux-container.scss
@@ -10,6 +10,57 @@
     --body-padding: var(--spacing-4);
     display: block;
 }
+//scrollbar colors
+* {
+    scrollbar-color: var(--color-border-interactive-muted, rgb(43, 101, 155))
+        var(--color-background-surface-default, rgb(27, 45, 62));
+    &::-webkit-scrollbar {
+        width: var(--spacing-4);
+        height: var(--spacing-4);
+        background-color: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background-color: var(
+            --color-border-interactive-muted,
+            rgb(43, 101, 155)
+        );
+        border-radius: 8px;
+        border: 3px solid transparent;
+        background-clip: padding-box;
+    }
+
+    /* visually "centers" because the dark edge of the shadow gives the illusion this is offset */
+    &::-webkit-scrollbar-thumb:vertical {
+        border-left-width: var(--border-width-lg); //4px
+    }
+
+    &::-webkit-scrollbar-thumb:horizontal {
+        border-top-width: var(--border-width-lg); //4px
+    }
+
+    &::-webkit-scrollbar-thumb:active,
+    &::-webkit-scrollbar-thumb:hover {
+        background-color: var(
+            --color-background-interactive-default,
+            rgb(58, 129, 191)
+        );
+    }
+
+    &::-webkit-scrollbar-track,
+    &::-webkit-scrollbar-corner {
+        background-color: var(--color-background-surface-default);
+        box-shadow: var(--scrollbar-shadow-inner-vertical);
+    }
+
+    &::-webkit-scrollbar-track:vertical {
+        box-shadow: var(--scrollbar-shadow-inner-vertical);
+    }
+
+    &::-webkit-scrollbar-track:horizontal {
+        box-shadow: var(--scrollbar-shadow-inner-vertical);
+    }
+}
 
 .hidden,
 :host([hidden]) {

--- a/packages/web-components/src/components/rux-container/rux-container.tsx
+++ b/packages/web-components/src/components/rux-container/rux-container.tsx
@@ -7,6 +7,7 @@ import { hasSlot } from '../../utils/utils'
  * @slot tab-bar - The container's tab bar
  * @slot toolbar - The container's toolbar
  * @slot footer - The container's footer
+ * @part container - The container's outermost element
  * @part header - The container's outside header element
  * @part tab-bar - The container's outside tab bar element
  * @part toolbar - The container's outside toolbar element
@@ -42,7 +43,7 @@ export class RuxContainer {
     render() {
         return (
             <Host>
-                <div class="rux-container">
+                <div class="rux-container" part="container">
                     <div
                         class={{
                             'rux-container__header': true,


### PR DESCRIPTION
## Brief Description

Added a 'container' part to the outermost div of the rux-container. I also added scrollbar stylings.

## JIRA Link

[ASTRO-5331](https://rocketcom.atlassian.net/browse/ASTRO-5331)

## Related Issue

## General Notes

## Motivation and Context

It was brought to our attention by @brikiernan that a very common use case for containers was to hold scrollable content. It was difficult to style the height of rux-container in such a way that would allow the inner parts to align properly and the body to scroll. Adding part='container' to the surrounding div should allow for more flexibility and easier access to change height properties/add Flexbox or grid stylings for layout.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [x] This PR changes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
