### PR TITLE
test(dialog): added waitForChanges to prevent dialog flake

### DIFF
--- a/packages/web-components/src/components/rux-dialog/test/dialog.spec.ts
+++ b/packages/web-components/src/components/rux-dialog/test/dialog.spec.ts
@@ -138,6 +138,7 @@ test.describe('Dialog', () => {
         const closeEvent = await page.spyOnEvent('ruxdialogclosed')
 
         await page.keyboard.press('Enter')
+        await page.waitForChanges()
         expect(closeEvent).toHaveReceivedEventDetail(true)
     })
     test('it should trigger deny button when escape is pressed and emit false', async ({
@@ -150,6 +151,8 @@ test.describe('Dialog', () => {
         const closeEvent = await page.spyOnEvent('ruxdialogclosed')
 
         await page.keyboard.press('Escape')
+        await page.waitForChanges()
+
         expect(closeEvent).toHaveReceivedEventDetail(false)
     })
 })


### PR DESCRIPTION
## Brief Description

adds `page.waitForChanges` to two dialog tests that would sometimes fail. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-5329

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
