### PR TITLE
fix(storybook) remove duplicate google analytics tags

### DIFF
--- a/packages/web-components/.storybook/preview-head.html
+++ b/packages/web-components/.storybook/preview-head.html
@@ -1,17 +1,3 @@
-<!-- Google tag (gtag.js) -->
-<script
-    async
-    src="https://www.googletagmanager.com/gtag/js?id=G-TLB26KX41Q"
-></script>
-<script>
-    window.dataLayer = window.dataLayer || []
-    function gtag() {
-        dataLayer.push(arguments)
-    }
-    gtag('js', new Date())
-
-    gtag('config', 'G-TLB26KX41Q')
-</script>
 <link rel="preconnect" href="https://fonts.gstatic.com" />
 <script>
     window.addEventListener('DOMContentLoaded', (event) => {
@@ -21,6 +7,7 @@
             previewFrame.classList.add('dark-theme')
         }
     })
+    console.log(window)
 </script>
 <link
     href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@100;300;400&family=Roboto:wght@100;300;400;500;700;900&display=swap"


### PR DESCRIPTION
## Brief Description

Removed the additional google analytics tag from storybook in the preview box.

## JIRA Link

[ASTRO-3582](https://rocketcom.atlassian.net/browse/ASTRO-5382)
[ASTRO-5391](https://rocketcom.atlassian.net/browse/ASTRO-5391)

## Related Issue

## General Notes

## Motivation and Context

Storybook analytics are polluted with a bunch of 'Webpack App' hits. It turns out that because content on each page is generated in an iFrame and that iFrame had the title "Webpack App" and also an additional google analytics tag, it was generating an extra hit for every page view. It was also generating extra hits because the tag carries over onto all storybook previews on Astrouxds.com

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
