### PR TITLE
fix(rux-option): added watch to disabled prop

### DIFF
--- a/packages/web-components/src/components/rux-option/rux-option.tsx
+++ b/packages/web-components/src/components/rux-option/rux-option.tsx
@@ -27,10 +27,10 @@ export class RuxOption {
     /**
      * The option value
      */
-    @Prop() value!: string
+    @Prop({ reflect: true }) value!: string
 
     /** The option label */
-    @Prop() label!: string
+    @Prop({ reflect: true }) label!: string
 
     /** Sets the option as disabled */
     @Prop() disabled: boolean = false

--- a/packages/web-components/src/components/rux-option/rux-option.tsx
+++ b/packages/web-components/src/components/rux-option/rux-option.tsx
@@ -41,6 +41,7 @@ export class RuxOption {
 
     @Watch('value')
     @Watch('label')
+    @Watch('disabled')
     handleValueChange() {
         this.optionChanged.emit()
     }

--- a/packages/web-components/src/components/rux-select/test/select.spec.ts
+++ b/packages/web-components/src/components/rux-select/test/select.spec.ts
@@ -162,20 +162,69 @@ test.describe('Options can dynamically add/remove props', () => {
         const template = `
         <rux-select id="ruxSelect" label="Best Thing?" name="bestThing">
             <rux-option label="Select an option" value=""></rux-option>
-            <rux-option label="Red" value="red"></rux-option>
-            <rux-option value="blue" label="Blue"></rux-option>
+            <rux-option label="Red" value="red" id="red"></rux-option>
+            <rux-option value="blue" label="Blue" id="blue"></rux-option>
             <rux-option value="green" label="Green" id="green"></rux-option>
         </rux-select>
         <rux-button id="dis-green">Disabled Green Option</rux-button>
+        <rux-button id="change-label">Change Label</rux-button>
+        <rux-button id="change-value">Change Value</rux-button>
+        <script>
+          const green = document.getElementById('green')
+          const blue = document.getElementById('blue')
+          const red = document.getElementById('red')
+
+          const disGreen = document.getElementById('dis-green')
+          const changeLabel = document.getElementById('change-label')
+          const changeValue = document.getElementById('change-value')
+
+          disGreen.addEventListener('click', () => {
+              green.disabled = !green.disabled
+          })
+          changeLabel.addEventListener('click', () => {
+            blue.label = "new label"
+          })
+          changeValue.addEventListener('click', () => {
+            red.value = "new value"
+          })
+        </script>
       `
         await page.setContent(template)
     })
-    test('it should dynamically disable an option', async ({ page }) => {
-        const disGreen = await page.locator('#dis-green')
-        const select = await page.locator('#ruxSelect')
-        const greenOption = await page.locator('#green')
+    test('it should be abel to dynamically disable an option', async ({
+        page,
+    }) => {
+        const disGreen = page.locator('#dis-green')
+        const shadowSelect = page.locator('#ruxSelect').locator('select')
+        const greenOption = shadowSelect.locator('option').last()
 
-        // await page.click(greenOption)
+        await page.click('#ruxSelect')
+        await shadowSelect.selectOption('green')
+        await expect(shadowSelect).toHaveValue('green')
+        await disGreen.click()
+        await expect(greenOption).toBeDisabled()
+    })
+    test('it should be able to dynamically change option label', async ({
+        page,
+    }) => {
+        const changeLabel = page.locator('#change-label')
+        const shadowSelect = page.locator('#ruxSelect').locator('select')
+        const blueOption = shadowSelect.locator('option').nth(2)
+
+        await expect(blueOption).toHaveText('Blue')
+        await changeLabel.click()
+        await expect(blueOption).toHaveText('new label')
+    })
+    test('it should be able to dynamically change option value', async ({
+        page,
+    }) => {
+        const changeValue = page.locator('#change-value')
+        const shadowSelect = page.locator('#ruxSelect').locator('select')
+        const redOption = shadowSelect.locator('option').nth(1)
+
+        await expect(redOption).toHaveAttribute('value', 'red')
+        await changeValue.click()
+        await expect(redOption).toHaveAttribute('value', 'new value')
     })
 })
 // test.describe('Emits events', () => {

--- a/packages/web-components/src/components/rux-select/test/select.spec.ts
+++ b/packages/web-components/src/components/rux-select/test/select.spec.ts
@@ -70,7 +70,7 @@ test.describe('Select in a form', () => {
                 <rux-option value="blue" label="Blue"></rux-option>
                 <rux-option value="green" label="Green"></rux-option>
             </rux-select>
-            <!--- Multi Select ---> 
+            <!--- Multi Select --->
             <rux-select
                 id="ruxMultiSelect"
                 label="Best Thing?"
@@ -157,25 +157,46 @@ test.describe('Select in a form', () => {
         await expect(log).toContainText('multBestThing:redmultBestThing:blue')
     })
 })
-test.describe('Emits events', () => {
+test.describe('Options can dynamically add/remove props', () => {
     test.beforeEach(async ({ page }) => {
         const template = `
         <rux-select id="ruxSelect" label="Best Thing?" name="bestThing">
             <rux-option label="Select an option" value=""></rux-option>
             <rux-option label="Red" value="red"></rux-option>
             <rux-option value="blue" label="Blue"></rux-option>
-            <rux-option value="green" label="Green"></rux-option>
+            <rux-option value="green" label="Green" id="green"></rux-option>
         </rux-select>
-        `
+        <rux-button id="dis-green">Disabled Green Option</rux-button>
+      `
         await page.setContent(template)
     })
-    //TODO: Get this working
-    // test('it emits change event', async ({ page }) => {
-    //     const select = page.locator('rux-select')
-    //     const option = select.locator('rux-option').nth(1)
-    //     const changeEvent = await page.spyOnEvent('ruxchange')
-    //     await select.click()
-    //     await option.click({ force: true })
-    //     await expect(changeEvent).toHaveReceivedEventTimes(1)
-    // })
+    test('it should dynamically disable an option', async ({ page }) => {
+        const disGreen = await page.locator('#dis-green')
+        const select = await page.locator('#ruxSelect')
+        const greenOption = await page.locator('#green')
+
+        // await page.click(greenOption)
+    })
 })
+// test.describe('Emits events', () => {
+//     test.beforeEach(async ({ page }) => {
+//         const template = `
+//         <rux-select id="ruxSelect" label="Best Thing?" name="bestThing">
+//             <rux-option label="Select an option" value=""></rux-option>
+//             <rux-option label="Red" value="red"></rux-option>
+//             <rux-option value="blue" label="Blue"></rux-option>
+//             <rux-option value="green" label="Green"></rux-option>
+//         </rux-select>
+//         `
+//         await page.setContent(template)
+//     })
+//TODO: Get this working
+// test('it emits change event', async ({ page }) => {
+//     const select = page.locator('rux-select')
+//     const option = select.locator('rux-option').nth(1)
+//     const changeEvent = await page.spyOnEvent('ruxchange')
+//     await select.click()
+//     await option.click({ force: true })
+//     await expect(changeEvent).toHaveReceivedEventTimes(1)
+// })
+// })

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -20,22 +20,33 @@
     </head>
 
     <body>
-        <div style="width: 300px; margin: 2rem">
-            <rux-select id="ruxSelect" label="Best Thing?" name="bestThing">
-                <rux-option label="Select an option" value=""></rux-option>
-                <rux-option label="Red" value="red"></rux-option>
-                <rux-option value="blue" label="Blue"></rux-option>
-                <rux-option value="green" label="Green" id="green"></rux-option>
-            </rux-select>
-        </div>
+        <rux-select id="ruxSelect" label="Best Thing?" name="bestThing">
+            <rux-option label="Select an option" value=""></rux-option>
+            <rux-option label="Red" value="red" id="red"></rux-option>
+            <rux-option value="blue" label="Blue" id="blue"></rux-option>
+            <rux-option value="green" label="Green" id="green"></rux-option>
+        </rux-select>
         <rux-button id="dis-green">Disabled Green Option</rux-button>
-
+        <rux-button id="change-label">Change Label</rux-button>
+        <rux-button id="change-value">Change Value</rux-button>
         <script>
-            const opt3 = document.getElementById('green')
-            const btn = document.querySelector('rux-button')
+            const green = document.getElementById('green')
+            const blue = document.getElementById('blue')
+            const red = document.getElementById('red')
 
-            btn.addEventListener('click', () => {
-                opt3.disabled = !opt3.disabled
+            const disGreen = document.getElementById('dis-green')
+            const changeLabel = document.getElementById('change-label')
+            const changeValue = document.getElementById('change-value')
+
+            disGreen.addEventListener('click', () => {
+                green.disabled = !green.disabled
+            })
+            changeLabel.addEventListener('click', () => {
+                blue.label = 'new label'
+            })
+            changeValue.addEventListener('click', () => {
+                console.log(red.value)
+                red.value = 'new value'
             })
         </script>
     </body>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -21,16 +21,17 @@
 
     <body>
         <div style="width: 300px; margin: 2rem">
-            <rux-select>
-                <rux-option label="option 1" value="opt1"></rux-option>
-                <rux-option label="option 2" value="opt2"></rux-option>
-                <rux-option label="option 3" value="opt3" id="3"></rux-option>
+            <rux-select id="ruxSelect" label="Best Thing?" name="bestThing">
+                <rux-option label="Select an option" value=""></rux-option>
+                <rux-option label="Red" value="red"></rux-option>
+                <rux-option value="blue" label="Blue"></rux-option>
+                <rux-option value="green" label="Green" id="green"></rux-option>
             </rux-select>
         </div>
-        <rux-button style="margin: 2rem">Disable Option 3</rux-button>
+        <rux-button id="dis-green">Disabled Green Option</rux-button>
 
         <script>
-            const opt3 = document.getElementById('3')
+            const opt3 = document.getElementById('green')
             const btn = document.querySelector('rux-button')
 
             btn.addEventListener('click', () => {

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -19,5 +19,23 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body></body>
+    <body>
+        <div style="width: 300px; margin: 2rem">
+            <rux-select>
+                <rux-option label="option 1" value="opt1"></rux-option>
+                <rux-option label="option 2" value="opt2"></rux-option>
+                <rux-option label="option 3" value="opt3" id="3"></rux-option>
+            </rux-select>
+        </div>
+        <rux-button style="margin: 2rem">Disable Option 3</rux-button>
+
+        <script>
+            const opt3 = document.getElementById('3')
+            const btn = document.querySelector('rux-button')
+
+            btn.addEventListener('click', () => {
+                opt3.disabled = !opt3.disabled
+            })
+        </script>
+    </body>
 </html>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -19,35 +19,5 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body>
-        <rux-select id="ruxSelect" label="Best Thing?" name="bestThing">
-            <rux-option label="Select an option" value=""></rux-option>
-            <rux-option label="Red" value="red" id="red"></rux-option>
-            <rux-option value="blue" label="Blue" id="blue"></rux-option>
-            <rux-option value="green" label="Green" id="green"></rux-option>
-        </rux-select>
-        <rux-button id="dis-green">Disabled Green Option</rux-button>
-        <rux-button id="change-label">Change Label</rux-button>
-        <rux-button id="change-value">Change Value</rux-button>
-        <script>
-            const green = document.getElementById('green')
-            const blue = document.getElementById('blue')
-            const red = document.getElementById('red')
-
-            const disGreen = document.getElementById('dis-green')
-            const changeLabel = document.getElementById('change-label')
-            const changeValue = document.getElementById('change-value')
-
-            disGreen.addEventListener('click', () => {
-                green.disabled = !green.disabled
-            })
-            changeLabel.addEventListener('click', () => {
-                blue.label = 'new label'
-            })
-            changeValue.addEventListener('click', () => {
-                console.log(red.value)
-                red.value = 'new value'
-            })
-        </script>
-    </body>
+    <body></body>
 </html>


### PR DESCRIPTION
## Brief Description

Fixes an issue where the rux-option wouldn't update on select when the disabled prop was dynamically changed.
I left some code in the `src/index.html` to help the review process. Checkout the astro-stencil deploy preview to see that. I'll remove it before merge. 

Adds tests to cover the dynamic addition of label, value and disabled props to rux-option. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-5699

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/1075
## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
