### PR TITLE
docs: add homepage and repository field for web-components

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -2,6 +2,7 @@
   "name": "@astrouxds/astro-web-components",
   "version": "7.8.0",
   "description": "Astro Web Components",
+  "homepage": "https://github.com/RocketCommunicationsInc/astro",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "es2015": "dist/esm/index.mjs",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -2,7 +2,11 @@
   "name": "@astrouxds/astro-web-components",
   "version": "7.8.0",
   "description": "Astro Web Components",
-  "homepage": "https://github.com/RocketCommunicationsInc/astro",
+  "homepage": "https://astro-components.netlify.app/?path=/story/astro-uxds-welcome-start-here--page",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RocketCommunicationsInc/astro"
+  },
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "es2015": "dist/esm/index.mjs",


### PR DESCRIPTION
## Brief Description

Adds the homepage and repository fields to `package.json` on `web-components`
I put the homepage as our storybook, since that's the most dev related homepage. If we want to change that to astrouxds.com that's fine too 

## JIRA Link

Was noticed by Sasha and brought up during dev bookclub meeting

## Related Issue

## General Notes

## Motivation and Context

Allows for our npm page to have links to our SB and github repo

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
