### PR TITLE
fix(focus) Remove :has selector from components that were previously using :focus-within

### DIFF
--- a/.changeset/chatty-avocados-exist.md
+++ b/.changeset/chatty-avocados-exist.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+---
+
+feat(rux-checkbox) add ruxfocus event to rux-checkbox on focus

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.scss
@@ -49,19 +49,12 @@ label {
             margin-right: var(--spacing-0);
         }
     }
-    &:has(input:focus-visible) {
-        border-radius: var(--focus-radius);
-        outline: var(--focus-outline);
-        outline-offset: var(--focus-offset);
-    }
 }
-//firefox does not support :has selector so :focus-within instead
-@supports (-moz-appearance: none) {
-    .rux-checkbox:focus-within {
-        border-radius: var(--focus-radius);
-        outline: var(--focus-outline);
-        outline-offset: var(--focus-offset);
-    }
+
+.rux-checkbox--focused {
+    border-radius: var(--focus-radius);
+    outline: var(--focus-outline);
+    outline-offset: var(--focus-offset);
 }
 
 .rux-checkbox__control {

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
@@ -96,7 +96,7 @@ export class RuxCheckbox implements FormFieldInterface {
     @Event({ eventName: 'ruxinput' }) ruxInput!: EventEmitter
 
     /**
-     * Fired when an element has gained focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)
+     * Fired when an element has gained focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)
      */
     @Event({ eventName: 'ruxfocus' }) ruxFocus!: EventEmitter
 
@@ -209,7 +209,7 @@ export class RuxCheckbox implements FormFieldInterface {
                             onChange={_onClick}
                             onInput={_onInput}
                             onBlur={_onBlur}
-                            onFocusin={_onFocus}
+                            onFocus={_onFocus}
                             ref={(el) => (this._inputEl = el)}
                         />
                         <div class="rux-checkbox__control">

--- a/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
+++ b/packages/web-components/src/components/rux-checkbox/rux-checkbox.tsx
@@ -35,6 +35,7 @@ export class RuxCheckbox implements FormFieldInterface {
 
     @State() hasLabelSlot = false
     @State() hasHelpSlot = false
+    @State() isFocused = false
 
     /**
      * The help or explanation text
@@ -95,6 +96,11 @@ export class RuxCheckbox implements FormFieldInterface {
     @Event({ eventName: 'ruxinput' }) ruxInput!: EventEmitter
 
     /**
+     * Fired when an element has gained focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)
+     */
+    @Event({ eventName: 'ruxfocus' }) ruxFocus!: EventEmitter
+
+    /**
      * Fired when an element has lost focus - [HTMLElement/blur_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)
      */
     @Event({ eventName: 'ruxblur' }) ruxBlur!: EventEmitter
@@ -141,13 +147,20 @@ export class RuxCheckbox implements FormFieldInterface {
     }
 
     private _onBlur = () => {
+        this.isFocused = false
         this.ruxBlur.emit()
+    }
+
+    private _onFocus = () => {
+        this.isFocused = this._inputEl?.matches(':focus-visible') ? true : false
+        this.ruxFocus.emit()
     }
 
     render() {
         const {
             _handleSlotChange,
             _onBlur,
+            _onFocus,
             _onClick,
             _onInput,
             checkboxId,
@@ -160,6 +173,7 @@ export class RuxCheckbox implements FormFieldInterface {
             value,
             indeterminate,
             label,
+            isFocused,
             hasLabel,
             hasLabelSlot,
         } = this
@@ -175,6 +189,7 @@ export class RuxCheckbox implements FormFieldInterface {
                         class={{
                             'rux-checkbox': true,
                             'rux-checkbox--disabled': disabled,
+                            'rux-checkbox--focused': isFocused,
                         }}
                         htmlFor={checkboxId}
                     >
@@ -194,6 +209,7 @@ export class RuxCheckbox implements FormFieldInterface {
                             onChange={_onClick}
                             onInput={_onInput}
                             onBlur={_onBlur}
+                            onFocusin={_onFocus}
                             ref={(el) => (this._inputEl = el)}
                         />
                         <div class="rux-checkbox__control">

--- a/packages/web-components/src/components/rux-checkbox/test/checkbox.spec.ts
+++ b/packages/web-components/src/components/rux-checkbox/test/checkbox.spec.ts
@@ -197,4 +197,12 @@ test.describe('Checkbox events', () => {
 
         expect(blurEvent).toHaveReceivedEventTimes(1)
     })
+    test('Should emit ruxfocus event once when focused', async ({ page }) => {
+        const focusEvent = await page.spyOnEvent('ruxfocus')
+
+        await page.click('#blur-trigger')
+        await page.click('#checkbox')
+
+        expect(focusEvent).toHaveReceivedEventTimes(1)
+    })
 })

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
@@ -154,11 +154,3 @@
         }
     }
 }
-//firefox does not support :has selector so :focus-within instead
-@supports (-moz-appearance: none) {
-    .rux-segmented-button__segment:focus-within {
-        outline: var(--focus-outline);
-        outline-offset: var(--focus-offset);
-        z-index: 1;
-    }
-}

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.scss
@@ -69,7 +69,7 @@
         }
     }
     //apply focus state when input within in selected and raise so that full outline is visible
-    &:has(input:focus-visible) {
+    &.--focused {
         outline: var(--focus-outline);
         outline-offset: var(--focus-offset);
         z-index: 1;

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
@@ -109,6 +109,18 @@ export class RuxSegmentedButton {
         return false
     }
 
+    private _handleFocus(e: Event) {
+        const target = e.currentTarget as HTMLInputElement
+        target.matches(':focus-visible')
+            ? target.closest('li')?.classList.add('--focused')
+            : null
+    }
+
+    private _handleBlur(e: Event) {
+        const target = e.currentTarget as HTMLInputElement
+        target.closest('li')?.classList.remove('--focused')
+    }
+
     render() {
         return (
             <ul
@@ -129,6 +141,8 @@ export class RuxSegmentedButton {
                             data-label={item.label}
                             onChange={this._handleChange}
                             disabled={this.disabled}
+                            onFocus={this._handleFocus}
+                            onBlur={this._handleBlur}
                         />
                         <label
                             htmlFor={this._slugify(item.label)}


### PR DESCRIPTION
## Brief Description

We had a couple of elements that were using :focus-within to display focus originally. However, that sometimes displayed focus when none was intended to be displayed.

So, in a previous quick-fix we changed the selector to :has(element:focus-within). That worked well, except that not all browsers support the :has selector yet. (Firefox does not, for example).

In this fix, I removed the :has selector from rux-segmented-button and rux-checkbox in favor of a small onFocus and onBlur script that programmatically adds a focused state to the elements that require focus styling. 

## JIRA Link

[ASTRO-5268](https://rocketcom.atlassian.net/browse/ASTRO-5268)

## Related Issue

## General Notes

I had to apply similar but different solutions to checkbox and segmented button. The theory is the same but in segmented button I had to select the correct segment and programmatically add the --focused class. Checkbox has a 'isFocused' state that adds/removes the class on the checkbox.

**One question: I needed to add onFocus and onBlur to input fields on segmented button. Should I emit those events?** 

## Motivation and Context

This solution is compatible with all browsers.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
