### PR TITLE
revert button reflection temporarily

### DIFF
--- a/.changeset/serious-pans-sell.md
+++ b/.changeset/serious-pans-sell.md
@@ -1,8 +1,0 @@
----
-"@astrouxds/astro-web-components": minor
-"angular-workspace": minor
-"@astrouxds/angular": minor
-"@astrouxds/react": minor
----
-
-Button - the `secondary`, `borderless`, and `type` properties now reflect as attributes

--- a/packages/web-components/src/components/rux-button/rux-button.tsx
+++ b/packages/web-components/src/components/rux-button/rux-button.tsx
@@ -30,7 +30,7 @@ export class RuxButton {
     /**
      * Changes button style from solid to secondary by setting the rux-button--secondary class
      */
-    @Prop({ reflect: true }) secondary: boolean = false
+    @Prop() secondary: boolean = false
     /**
      * Toggles disabled attribute on the button
      */
@@ -39,7 +39,7 @@ export class RuxButton {
     /**
      * Changes button style from solid to borderless by setting the rux-button--borderless class
      */
-    @Prop({ reflect: true }) borderless: boolean = false
+    @Prop() borderless: boolean = false
 
     /**
      * Changes size of a button from medium to small or large by setting sizing classes
@@ -51,7 +51,7 @@ export class RuxButton {
     /**
      * The button type. Use 'submit' to submit native form data.
      */
-    @Prop({ reflect: true }) type: 'submit' | 'button' = 'button'
+    @Prop() type: 'submit' | 'button' = 'button'
 
     /**
      * Creates and appends a native <button> if used within a form

--- a/packages/web-components/src/components/rux-button/test/button.spec.ts
+++ b/packages/web-components/src/components/rux-button/test/button.spec.ts
@@ -1,111 +1,111 @@
-import { test, expect } from '../../../../tests/utils/_astro-fixtures'
-test.describe('Button reflection', () => {
-    test.beforeEach(async ({ page }) => {
-        const template = `
-			<rux-button>Submit</rux-button>
-		`
-        await page.setContent(template)
-    })
+// import { test, expect } from '../../../../tests/utils/_astro-fixtures'
+// test.describe('Button reflection', () => {
+//     test.beforeEach(async ({ page }) => {
+//         const template = `
+// 			<rux-button>Submit</rux-button>
+// 		`
+//         await page.setContent(template)
+//     })
 
-    test('the icon property reflects to an attribute', async ({ page }) => {
-        const el = page.locator('rux-button')
-        await el.evaluate((buttonEl) => {
-            ;(buttonEl as HTMLRuxButtonElement).icon = 'apps'
-        })
+//     test('the icon property reflects to an attribute', async ({ page }) => {
+//         const el = page.locator('rux-button')
+//         await el.evaluate((buttonEl) => {
+//             ;(buttonEl as HTMLRuxButtonElement).icon = 'apps'
+//         })
 
-        await page.waitForChanges()
+//         await page.waitForChanges()
 
-        const attr = await el.evaluate((buttonEl) => {
-            return buttonEl.getAttribute('icon')
-        })
-        expect(attr).toBe('apps')
-    })
+//         const attr = await el.evaluate((buttonEl) => {
+//             return buttonEl.getAttribute('icon')
+//         })
+//         expect(attr).toBe('apps')
+//     })
 
-    test('the iconOnly property reflects to an attribute', async ({ page }) => {
-        const el = page.locator('rux-button')
-        await el.evaluate((buttonEl) => {
-            ;(buttonEl as HTMLRuxButtonElement).iconOnly = true
-        })
+//     test('the iconOnly property reflects to an attribute', async ({ page }) => {
+//         const el = page.locator('rux-button')
+//         await el.evaluate((buttonEl) => {
+//             ;(buttonEl as HTMLRuxButtonElement).iconOnly = true
+//         })
 
-        await page.waitForChanges()
+//         await page.waitForChanges()
 
-        const attr = await el.evaluate((buttonEl) => {
-            return buttonEl.getAttribute('icon-only')
-        })
-        expect(attr).not.toBeNull()
-    })
+//         const attr = await el.evaluate((buttonEl) => {
+//             return buttonEl.getAttribute('icon-only')
+//         })
+//         expect(attr).not.toBeNull()
+//     })
 
-    test('the secondary property reflects to an attribute', async ({
-        page,
-    }) => {
-        const el = page.locator('rux-button')
-        await el.evaluate((buttonEl) => {
-            ;(buttonEl as HTMLRuxButtonElement).secondary = true
-        })
+//     test('the secondary property reflects to an attribute', async ({
+//         page,
+//     }) => {
+//         const el = page.locator('rux-button')
+//         await el.evaluate((buttonEl) => {
+//             ;(buttonEl as HTMLRuxButtonElement).secondary = true
+//         })
 
-        await page.waitForChanges()
+//         await page.waitForChanges()
 
-        const attr = await el.evaluate((buttonEl) => {
-            return buttonEl.getAttribute('secondary')
-        })
-        expect(attr).not.toBeNull()
-    })
+//         const attr = await el.evaluate((buttonEl) => {
+//             return buttonEl.getAttribute('secondary')
+//         })
+//         expect(attr).not.toBeNull()
+//     })
 
-    test('the disabled property reflects to an attribute', async ({ page }) => {
-        const el = page.locator('rux-button')
-        await el.evaluate((buttonEl) => {
-            ;(buttonEl as HTMLRuxButtonElement).disabled = true
-        })
+//     test('the disabled property reflects to an attribute', async ({ page }) => {
+//         const el = page.locator('rux-button')
+//         await el.evaluate((buttonEl) => {
+//             ;(buttonEl as HTMLRuxButtonElement).disabled = true
+//         })
 
-        await page.waitForChanges()
+//         await page.waitForChanges()
 
-        const attr = await el.evaluate((buttonEl) => {
-            return buttonEl.getAttribute('disabled')
-        })
-        expect(attr).not.toBeNull()
-    })
+//         const attr = await el.evaluate((buttonEl) => {
+//             return buttonEl.getAttribute('disabled')
+//         })
+//         expect(attr).not.toBeNull()
+//     })
 
-    test('the borderless property reflects to an attribute', async ({
-        page,
-    }) => {
-        const el = page.locator('rux-button')
-        await el.evaluate((buttonEl) => {
-            ;(buttonEl as HTMLRuxButtonElement).borderless = true
-        })
+//     test('the borderless property reflects to an attribute', async ({
+//         page,
+//     }) => {
+//         const el = page.locator('rux-button')
+//         await el.evaluate((buttonEl) => {
+//             ;(buttonEl as HTMLRuxButtonElement).borderless = true
+//         })
 
-        await page.waitForChanges()
+//         await page.waitForChanges()
 
-        const attr = await el.evaluate((buttonEl) => {
-            return buttonEl.getAttribute('borderless')
-        })
-        expect(attr).not.toBeNull()
-    })
+//         const attr = await el.evaluate((buttonEl) => {
+//             return buttonEl.getAttribute('borderless')
+//         })
+//         expect(attr).not.toBeNull()
+//     })
 
-    test('the size property reflects to an attribute', async ({ page }) => {
-        const el = page.locator('rux-button')
-        await el.evaluate((buttonEl) => {
-            ;(buttonEl as HTMLRuxButtonElement).size = 'small'
-        })
+//     test('the size property reflects to an attribute', async ({ page }) => {
+//         const el = page.locator('rux-button')
+//         await el.evaluate((buttonEl) => {
+//             ;(buttonEl as HTMLRuxButtonElement).size = 'small'
+//         })
 
-        await page.waitForChanges()
+//         await page.waitForChanges()
 
-        const attr = await el.evaluate((buttonEl) => {
-            return buttonEl.getAttribute('size')
-        })
-        expect(attr).toBe('small')
-    })
+//         const attr = await el.evaluate((buttonEl) => {
+//             return buttonEl.getAttribute('size')
+//         })
+//         expect(attr).toBe('small')
+//     })
 
-    test('the type property reflects to an attribute', async ({ page }) => {
-        const el = page.locator('rux-button')
-        await el.evaluate((buttonEl) => {
-            ;(buttonEl as HTMLRuxButtonElement).type = 'submit'
-        })
+//     test('the type property reflects to an attribute', async ({ page }) => {
+//         const el = page.locator('rux-button')
+//         await el.evaluate((buttonEl) => {
+//             ;(buttonEl as HTMLRuxButtonElement).type = 'submit'
+//         })
 
-        await page.waitForChanges()
+//         await page.waitForChanges()
 
-        const attr = await el.evaluate((buttonEl) => {
-            return buttonEl.getAttribute('type')
-        })
-        expect(attr).toBe('submit')
-    })
-})
+//         const attr = await el.evaluate((buttonEl) => {
+//             return buttonEl.getAttribute('type')
+//         })
+//         expect(attr).toBe('submit')
+//     })
+// })


### PR DESCRIPTION
## Brief Description

reverts button reflection feature temporarily to make 7.9.1 easier to release

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
