### PR TITLE
chore(starter-kits): update js starter kit to use jsdelivr

### DIFF
--- a/packages/starter-kits/html-js-starter/index.html
+++ b/packages/starter-kits/html-js-starter/index.html
@@ -12,16 +12,17 @@
     />
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
+      href="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
     />
     <script
       type="module"
-      src="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
+      src="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
     ></script>
   </head>
+
   <body>
     <rux-global-status-bar appname="App">
-      <rux-clock aos="1557503698781" los="2019-05-10T16:21:12.000Z"></rux-clock>
+      <rux-clock></rux-clock>
     </rux-global-status-bar>
 
     <div style="width: 40%; margin: 50px auto 0 auto; text-align: center">


### PR DESCRIPTION
## Brief Description

unpkg scripts were broken in the JS starter kit. 

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

https://github.com/RocketCommunicationsInc/astro/issues/1108

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
