### PR TITLE
docs(react): fix/update docs

### DIFF
--- a/packages/web-components/src/stories/astro-uxds/welcome/react.stories.mdx
+++ b/packages/web-components/src/stories/astro-uxds/welcome/react.stories.mdx
@@ -54,12 +54,12 @@ const MyComp = () => {
 ```
 ## Using our CSS Variables (Design Tokens).
 
-While our components may solve 60% of your UI needs, you will inevitably find yourself needing to 
-create your own custom UI in the style of Astro. 
+While our components may solve 60% of your UI needs, you will inevitably find yourself needing to
+create your own custom UI in the style of Astro.
 
-Our Astro Web Components are powered by our Design Tokens under the hood. These are imported 
-and made available to you when you import `astro-web-components.css` in the form of CSS Custom Properties. 
-Our Design Tokens include everything from our color palette to our spacing system. 
+Our Astro Web Components are powered by our Design Tokens under the hood. These are imported
+and made available to you when you import `astro-web-components.css` in the form of CSS Custom Properties.
+Our Design Tokens include everything from our color palette to our spacing system.
 
 We also provide our tokens in other formats (SASS, json) for your convienence. For more information,
 check out our [Design Tokens](https://www.astrouxds.com/design-tokens/installation/) page for a list
@@ -366,9 +366,9 @@ React also has syntactic sugar for two way data binding, which can be found [her
 
 #### Overview
 
-[React Testing Library](https://testing-library.com/docs/react-testing-library/intro) is built for testing React components and supports the native HTML elements such as `<input>`. 
+[React Testing Library](https://testing-library.com/docs/react-testing-library/intro) is built for testing React components and supports the native HTML elements such as `<input>`.
 Because our Astro components are web-components, some adaptations must be made to make testing with React Testing Library possible.
-[testing-library__dom](https://www.npmjs.com/package/testing-library__dom) is an adpatation of the DOM testing library for use with 
+[testing-library__dom](https://www.npmjs.com/package/testing-library__dom) is an adpatation of the DOM testing library for use with
 shadow dom. It is still in an early beta stage, however we will show some examples on how to make use of it below.
 
 > For a complete list of the React Testing Library API, read their [docs](https://testing-library.com/docs/react-testing-library/api).
@@ -397,42 +397,43 @@ test('Can find and click a rux-button', async () => {
     const { getByTestId } = render(<Comp handleClick={mockClick}/>)
     let btn = getByTestId('btn')
     expect(btn).not.toBeNull()
-    
+
     fireEvent.click(btn);
     expect(mockClick).toHaveBeenCalledTimes(1)
 })
 ```
 #### User input
 
-Handling user input can be done through `fireEvent` or `userEvent`. According to [the docs](https://testing-library.com/docs/ecosystem-user-event), `userEvent` is more true to 
+Handling user input can be done through `fireEvent` or `userEvent`. According to [the docs](https://testing-library.com/docs/ecosystem-user-event), `userEvent` is more true to
 how the dom would behave with actual user interaction. However, there may be some hiccups with `userEvent` and shadow dom.
 
 Here's an example using both `fireEvent` and `userEvent` to handle user input.
 
 ```jsx
 // MyForm.tsx
-import { useState } from "react"
-import { RuxInput } from "@astrouxds/react"
+import { useState } from "react";
+import { RuxInput } from "@astrouxds/react";
 
 function RuxInputTest() {
-    const [input, setInput] = useState("")
-    
-    return(
-        <div>
-            <RuxInput
-                label="Rux Input"
-                type="text"
-                data-testid="rux-input-test"
-                value={input}
-                setInput={(e: CustomEvent<HTMLRuxInputElement>) => {
-                    const target = e.target as HTMLInputElement;
-                    setRuxInput(target.value);
-                }}
-            />
-        </div>
-    )
+  const [input, setInput] = useState("");
 
+  return (
+    <div>
+      <RuxInput
+        label="Rux Input"
+        type="text"
+        data-testid="rux-input-test"
+        value={input}
+        onRuxinput={(e: CustomEvent<HTMLRuxInputElement>) => {
+          const target = e.target as HTMLInputElement;
+          setInput(target.value);
+        }}
+      />
+    </div>
+  );
 }
+
+export default RuxInputTest;
 ```
 ```jsx
 //input.test.tsx
@@ -462,4 +463,7 @@ describe('RuxInput', () => {
 })
 ```
 
-For more React testing examples, see our React repo [here](https://github.com/RocketCommunicationsInc/astro/tree/main/packages/react).
+Depending on your enviornment, you may also need to update the test command. For example, in a create-react-app you might need to change the test script to be: `test: "react-scripts test --transformIgnorePatterns=\"node_modules/(?!@astrouxds/react)/\" --env=jsdom"`,
+or otherwise configure Jest to use jsdom and set the `--transformIgnorePatterns` inside `jest.config`. More info can be found at [Jest's documentation](https://jestjs.io/docs/configuration#transformignorepatterns-arraystring).
+
+For more React testing examples, see our React repo [here](https://github.com/RocketCommunicationsInc/astro/tree/v7.7.0/packages/react/test-app).


### PR DESCRIPTION
## Brief Description

Our React docs had an incorrect example in the testing section. Also, the link to the test app repo at the bottom of the React docs page in now incorrect since that test repo has been removed in recent versions. The link now points to 7.7, which has the test repo. 

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/1114

## General Notes

We'll need to do a SB publish for this to go live. 

## Motivation and Context

User noticed syntax error in code examples. 
Test app repo couldn't be easily found.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
