### PR TITLE
fix(clock, monitoring-progress-icon): add tabular nums

### DIFF
--- a/.changeset/mighty-countries-know.md
+++ b/.changeset/mighty-countries-know.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+---
+
+Clock, Monitoring Progress Icon - added tabular-nums for better support when using system fonts

--- a/packages/web-components/src/components/rux-clock/rux-clock.scss
+++ b/packages/web-components/src/components/rux-clock/rux-clock.scss
@@ -33,6 +33,7 @@
     align-items: center;
     color: var(--gsb-color-text);
     font-family: var(--font-monospace-1-font-family);
+    font-variant-numeric: tabular-nums;
     font-weight: var(--font-monospace-1-font-weight);
     font-size: var(--font-monospace-1-font-size);
     letter-spacing: var(--font-monospace-1-letter-spacing);

--- a/packages/web-components/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.scss
+++ b/packages/web-components/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.scss
@@ -140,6 +140,7 @@ svg.rux-status--critical {
     color: var(--color-text-primary);
     font-family: var(--font-monospace-1-font-family);
     font-size: var(--font-body-3-font-size);
+    font-variant-numeric: tabular-nums;
     font-weight: var(--font-monospace-1-font-weight);
     letter-spacing: var(--font-monospace-1-letter-spacing);
     margin-top: -0.125rem;


### PR DESCRIPTION
## Brief Description

adds tabular nums for clock, monitoring progress icon so they don't jitter when using system fonts

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
