### PR TITLE
feat: import injection 

### DIFF
--- a/.changeset/green-rules-knock.md
+++ b/.changeset/green-rules-knock.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+---
+
+Added Vite and similar bundler support.

--- a/.changeset/green-rules-knock.md
+++ b/.changeset/green-rules-knock.md
@@ -5,4 +5,4 @@
 "angular-workspace": patch
 ---
 
-Added Vite and similar bundler support.
+Added Vite and similar bundler support. Fixes an issue that prevented users from using lazy-loaded components in Vue when using Vite

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,15 @@
 {
-  "name": "@astrouxds/react",
-  "version": "7.9.1",
+  "name": "@rocket_micah/react",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@astrouxds/react",
-      "version": "7.9.1",
+      "name": "@rocket_micah/react",
+      "version": "0.0.1",
+      "dependencies": {
+        "@rocket_micah/astro-web-components": "^0.0.1"
+      },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.1.5",
@@ -539,6 +542,19 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg=="
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.12.tgz",
+      "integrity": "sha512-HeG/wHoa2laUHlDX3xkzqlUqliAfa+zqV04LaKIwNCmCNaW2p0fQi4/Kd0LB4GdFoJ2UllLFq5gWnXAd67lg7w==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.4"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1202,6 +1218,17 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@rocket_micah/astro-web-components": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@rocket_micah/astro-web-components/-/astro-web-components-0.0.1.tgz",
+      "integrity": "sha512-Uhncnio2sGd9kwd2PId/CCwIlyH1rO/d8uzfRE4fHzyR3AL+siZ2oNphnFsad/yiWvwmMzLUDvrBFRpJtM5Dyg==",
+      "dependencies": {
+        "@floating-ui/dom": "~1.0.6",
+        "@stencil/core": "~2.18.1",
+        "date-fns": "~2.21.3",
+        "date-fns-tz": "~1.3.7"
+      }
+    },
     "node_modules/@samverschueren/stream-to-observable": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
@@ -1247,6 +1274,18 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@stencil/core": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.1.tgz",
+      "integrity": "sha512-/fXkh1lwZ+X9JQCw50mPjhBogzEHOBvVC5pLoDLZqodVYK0DGWILM2YLV4dcIUBNEK8/HMDpO/Rq81/rS3mNOw==",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=12.10.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -2706,6 +2745,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
+      "integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.8.tgz",
+      "integrity": "sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/debug": {
@@ -10009,6 +10068,19 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@floating-ui/core": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg=="
+    },
+    "@floating-ui/dom": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.12.tgz",
+      "integrity": "sha512-HeG/wHoa2laUHlDX3xkzqlUqliAfa+zqV04LaKIwNCmCNaW2p0fQi4/Kd0LB4GdFoJ2UllLFq5gWnXAd67lg7w==",
+      "requires": {
+        "@floating-ui/core": "^1.0.4"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -10512,6 +10584,17 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@rocket_micah/astro-web-components": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@rocket_micah/astro-web-components/-/astro-web-components-0.0.1.tgz",
+      "integrity": "sha512-Uhncnio2sGd9kwd2PId/CCwIlyH1rO/d8uzfRE4fHzyR3AL+siZ2oNphnFsad/yiWvwmMzLUDvrBFRpJtM5Dyg==",
+      "requires": {
+        "@floating-ui/dom": "~1.0.6",
+        "@stencil/core": "~2.18.1",
+        "date-fns": "~2.21.3",
+        "date-fns-tz": "~1.3.7"
+      }
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
@@ -10544,6 +10627,11 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "@stencil/core": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.1.tgz",
+      "integrity": "sha512-/fXkh1lwZ+X9JQCw50mPjhBogzEHOBvVC5pLoDLZqodVYK0DGWILM2YLV4dcIUBNEK8/HMDpO/Rq81/rS3mNOw=="
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -11698,6 +11786,17 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
+      "integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw=="
+    },
+    "date-fns-tz": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.8.tgz",
+      "integrity": "sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==",
+      "requires": {}
     },
     "debug": {
       "version": "4.3.4",

--- a/packages/web-components/src/stories/astro-uxds/welcome/vue.stories.mdx
+++ b/packages/web-components/src/stories/astro-uxds/welcome/vue.stories.mdx
@@ -17,8 +17,6 @@ You have two options for importing Astro Web Components: Lazy Loading and Cherry
 
 Astro Web Components make use of Stencil's automatic lazy loader which only loads components that are actually used on the page.
 
-> NOTE: Lazy loading is currently NOT supported if you're using Vite. Instead, use the cherry picking method below.
-
 ```js
 // main.js
 import { createApp } from 'vue'

--- a/packages/web-components/stencil.config.ts
+++ b/packages/web-components/stencil.config.ts
@@ -65,6 +65,7 @@ export const config: Config = {
     enableCache: true,
     extras: {
         appendChildSlotFix: true,
+        experimentalImportInjection: true,
     },
     testing: { modulePathIgnorePatterns: ['tests/'] },
 }


### PR DESCRIPTION
## Brief Description

Adds the `experimentalImportInjection` flag to `stencil.config`. This allows for our components to work in other bundlers like Vite. 

The flag above has been deprecated in Stencil 3.2, and was just renamed to ` enableImportInjection` so we'll need to update that when we upgrade Stencil.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-6072

## Related Issues
https://github.com/RocketCommunicationsInc/astro/issues/1097
https://github.com/RocketCommunicationsInc/astro/discussions/1112

## General Notes

This increases our overall bundle size, but allows for our components (specifically our React wrapper) to work in Vite and other bundler environments like it. 

## Motivation and Context

Vite support 

## Issues and Limitations

Increases bundle size. 

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
