### PR TITLE
feat(card) add part: container to the outer container

### DIFF
--- a/.changeset/good-toes-think.md
+++ b/.changeset/good-toes-think.md
@@ -1,0 +1,8 @@
+---
+"angular-workspace": minor
+"@astrouxds/angular": minor
+"@astrouxds/astro-web-components": minor
+"@astrouxds/react": minor
+---
+
+Card - Added `container` CSS Shadow Part

--- a/packages/web-components/src/components/rux-card/rux-card.tsx
+++ b/packages/web-components/src/components/rux-card/rux-card.tsx
@@ -3,6 +3,7 @@ import { hasSlot } from '../../utils/utils'
 /**
  * @slot (default) - The card's content
  * @slot header - The card's header
+ * @part container - The card's outtermost container
  * @part header - The card's outside header element
  * @part body - The card's outside body element
  * @part footer - The card's outside footer element
@@ -34,7 +35,7 @@ export class RuxCard {
     render() {
         return (
             <Host>
-                <div class="rux-card">
+                <div class="rux-card" part="container">
                     <div
                         class={{
                             'rux-card__header': true,


### PR DESCRIPTION
## Brief Description

Added a new part: container to run-card. This part is on the div with class 'rux-card'

## JIRA Link

[ASTRO-5893](https://rocketcom.atlassian.net/browse/ASTRO-5893)

## Related Issue

## General Notes

## Motivation and Context

developers were previously unable to remove the box-shadow from card because it was placed on an element without a part. Now they can remove the box shadow if they wish.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
