### PR TITLE
fix(select): Options within an opt group now sync to select value when slot changes

### DIFF
--- a/.changeset/nine-fishes-carry.md
+++ b/.changeset/nine-fishes-carry.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+---
+
+Fixed an issue where adding or removing rux-options inside a rux-option group didn't allow for the select menu to show them selected by default

--- a/packages/web-components/src/components/rux-select/rux-select.tsx
+++ b/packages/web-components/src/components/rux-select/rux-select.tsx
@@ -125,6 +125,7 @@ export class RuxSelect implements FormFieldInterface {
     @Listen('rux-option-group-changed')
     handleGroupChange() {
         this._syncOptionsToNativeSelect()
+        this._syncOptionsFromValue()
     }
 
     @Listen('rux-option-changed')

--- a/packages/web-components/src/components/rux-select/test/select.spec.ts
+++ b/packages/web-components/src/components/rux-select/test/select.spec.ts
@@ -129,7 +129,7 @@ test.describe('Select', () => {
       `,
         })
         //selected value should be flash
-        const sel = page.locator('rux-select').locator('select')
+        const sel = page.locator('rux-select select')
         await expect(sel).toHaveValue('flash')
         const btn = page.locator('rux-button')
         //click btn to add more options inside opt group

--- a/packages/web-components/src/components/rux-select/test/select.spec.ts
+++ b/packages/web-components/src/components/rux-select/test/select.spec.ts
@@ -78,43 +78,29 @@ test.describe('Select', () => {
         page,
     }) => {
         const template = `
-          <rux-select value="flash">
-          <rux-option value="" label="Select"></rux-option>
-          <rux-option-group label="Group">
-              <rux-option value="flash" label="Flash"></rux-option>
-          </rux-option-group>
-        </rux-select>
-        <rux-button>Add to options</rux-button>
+            <rux-select value="flash">
+                <rux-option value="" label="Select"></rux-option>
+                <rux-option-group label="Group">
+                    <rux-option value="flash" label="Flash"></rux-option>
+                </rux-option-group>
+            </rux-select> 
         `
         await page.setContent(template)
-        await page.addScriptTag({
-            content: `
-              const sel = document.querySelector('rux-select')
-              const optGroup = document.querySelector('rux-option-group')
-              const init = [
-                  { value: 'aquaman', name: 'Aquaman' },
-                  { value: 'batman', name: 'Batman' },
-              ]
-              const btn = document.querySelector('rux-button')
-              btn.addEventListener('click', () => {
-                  init.map((hero) => {
-                      let newOption = document.createElement('rux-option')
-                      newOption.label = hero.name
-                      newOption.value = hero.value
-                      optGroup.appendChild(newOption)
-                  })
+
+        const select = await page.locator('rux-select select')
+        await expect(select).toHaveValue('flash')
+
+        // Add Batman to Option Group
+        const optionGroupEl = await page.locator('rux-option-group')
+        await optionGroupEl.evaluate((el) => {
+            const newOption = document.createElement('rux-option')
+            newOption.label = 'batman'
+            newOption.value = 'batman'
+            el.appendChild(newOption)
         })
-        `,
-        })
-        //selected value should be flash
-        const sel = page.locator('rux-select').locator('select')
-        await expect(sel).toHaveValue('flash')
-        const btn = page.locator('rux-button')
-        //click btn to add more options inside opt group
-        await btn.click()
+
         await page.waitForChanges()
-        //selected value should still be flash
-        await expect(sel).toHaveValue('flash')
+        await expect(select).toHaveValue('flash')
     })
     test('Options that are dynamically removed can be synced to select', async ({
         page,

--- a/packages/web-components/src/components/rux-select/test/select.spec.ts
+++ b/packages/web-components/src/components/rux-select/test/select.spec.ts
@@ -116,6 +116,42 @@ test.describe('Select', () => {
         //selected value should still be flash
         await expect(sel).toHaveValue('flash')
     })
+    test('Options that are dynamically removed can be synced to select', async ({
+        page,
+    }) => {
+        const template = `
+        <rux-select value="flash">
+        <rux-option value="" label="Select"></rux-option>
+        <rux-option-group label="Group">
+            <rux-option value="flash" label="Flash"></rux-option>
+            <rux-option value="batman" label="Batman"></rux-option>
+            <rux-option value="wonder woman" label="Wonder Woman"></rux-option>
+        </rux-option-group>
+      </rux-select>
+      <rux-button>Remove from options</rux-button>
+      `
+        await page.setContent(template)
+        await page.addScriptTag({
+            content: `
+            const sel = document.querySelector('rux-select')
+            const optGroup = document.querySelector('rux-option-group')
+            const btn = document.querySelector('rux-button')
+            btn.addEventListener('click', () => {
+              let options = optGroup.querySelectorAll('rux-option')
+              options[options.length - 1].remove()
+            })
+      `,
+        })
+        //selected value should be flash
+        const sel = page.locator('rux-select').locator('select')
+        await expect(sel).toHaveValue('flash')
+        const btn = page.locator('rux-button')
+        //click btn to add more options inside opt group
+        await btn.click()
+        await page.waitForChanges()
+        //selected value should still be flash
+        await expect(sel).toHaveValue('flash')
+    })
 })
 /**
  * Select in a form

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -19,5 +19,31 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body></body>
+    <body>
+        <rux-select value="flash">
+            <rux-option value="" label="Select"></rux-option>
+            <rux-option-group label="Group">
+                <rux-option value="flash" label="Flash"></rux-option>
+            </rux-option-group>
+        </rux-select>
+
+        <rux-button>Add to options</rux-button>
+        <script>
+            const sel = document.querySelector('rux-select')
+            const optGroup = document.querySelector('rux-option-group')
+            const init = [
+                { value: 'aquaman', name: 'Aquaman' },
+                { value: 'batman', name: 'Batman' },
+            ]
+            const btn = document.querySelector('rux-button')
+            btn.addEventListener('click', () => {
+                init.map((hero) => {
+                    let newOption = document.createElement('rux-option')
+                    newOption.label = hero.name
+                    newOption.value = hero.value
+                    optGroup.appendChild(newOption)
+                })
+            })
+        </script>
+    </body>
 </html>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -19,31 +19,5 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body>
-        <rux-select value="flash">
-            <rux-option value="" label="Select"></rux-option>
-            <rux-option-group label="Group">
-                <rux-option value="flash" label="Flash"></rux-option>
-            </rux-option-group>
-        </rux-select>
-
-        <rux-button>Add to options</rux-button>
-        <script>
-            const sel = document.querySelector('rux-select')
-            const optGroup = document.querySelector('rux-option-group')
-            const init = [
-                { value: 'aquaman', name: 'Aquaman' },
-                { value: 'batman', name: 'Batman' },
-            ]
-            const btn = document.querySelector('rux-button')
-            btn.addEventListener('click', () => {
-                init.map((hero) => {
-                    let newOption = document.createElement('rux-option')
-                    newOption.label = hero.name
-                    newOption.value = hero.value
-                    optGroup.appendChild(newOption)
-                })
-            })
-        </script>
-    </body>
+    <body></body>
 </html>


### PR DESCRIPTION
## Brief Description

When dynamically adding/removing `rux-option`'s from a `rux-option-group`, the value of the `rux-select` would not properly sync to a `rux-option` within the `rux-option` group. 
The method to sync these values wasn't being called when a `rux-option-group` emitted it's changed event.

I left the `src/index` with an example of the fix in action for convenience  of review. Check out the astro-stencil preview to see it. 
Here's a sandbox version of the bug without the fix as well: https://codesandbox.io/s/misty-moon-0c2nfm?file=/index.html
## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-6186

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/1125
## General Notes

Added 2 tests for adding/removing `rux-option`'s from a `rux-option-group` and having the pre-selected value persist. 

## Motivation and Context

Allows for pre-selected values on `rux-select` to persist when changes to `rux-options` within a `rux-option-group` are made.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
