### PR TITLE
fix(rux-segmented-button) programmatically select segments

### DIFF
--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astrouxds/astro-web-components",
-  "version": "7.9.3",
+  "version": "7.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@astrouxds/astro-web-components",
-      "version": "7.9.3",
+      "version": "7.10.0",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "~1.0.6",

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
@@ -46,6 +46,12 @@ export class RuxSegmentedButton {
     @Event({ eventName: 'ruxchange' })
     ruxChange!: EventEmitter
 
+    @Watch('selected')
+    onSelectedChange(newValue: string) {
+        //if 'selected' is changed programatically rather than on click, set new selected value
+        this._setSelected(newValue)
+    }
+
     @Watch('data')
     onDataChange(newValue: string) {
         if (newValue) {

--- a/packages/web-components/src/components/rux-segmented-button/test/index.html
+++ b/packages/web-components/src/components/rux-segmented-button/test/index.html
@@ -28,11 +28,22 @@
 
     <body>
         <div style="padding: 2.5% 5%">
-            <rux-segmented-button></rux-segmented-button>
+            <rux-segmented-button id="changeTest"></rux-segmented-button>
         </div>
+        <section>
+            <select
+                id="segSelect"
+                style="width: 200px; margin: 20px 80px; padding: 8px 12px"
+            >
+                <option value="First segment">1</option>
+                <option value="Second segment" selected>2</option>
+                <option value="Third segment">3</option>
+            </select>
+        </section>
         <div style="padding: 2.5% 5%">
             <rux-segmented-button size="small"></rux-segmented-button>
         </div>
+
         <div style="padding: 2.5% 5%">
             <rux-segmented-button size="medium"></rux-segmented-button>
         </div>
@@ -67,6 +78,13 @@
             })
             disabled.addEventListener('ruxchange', () => {
                 console.log('disabled --- heard change')
+            })
+
+            const testSeg = document.getElementById('changeTest')
+            const select = document.getElementById('segSelect')
+
+            select.addEventListener('change', (e) => {
+                testSeg.selected = e.target.value
             })
         </script>
 

--- a/packages/web-components/src/components/rux-segmented-button/test/segmented-button.spec.ts
+++ b/packages/web-components/src/components/rux-segmented-button/test/segmented-button.spec.ts
@@ -113,6 +113,41 @@ test.describe('Segmented-button', () => {
         await expect(changeEvent).toHaveReceivedEventTimes(1)
         await expect(changeEvent).toHaveReceivedEventDetail('Second segment')
     })
+    test('it properly reselects a pre-selected segment', async ({ page }) => {
+        const template = `
+        <div style="padding: 2.5% 5%">
+            <rux-segmented-button></rux-segmented-button>
+        </div>
+        `
+        await page.setContent(template)
+        await page.addScriptTag({
+            //first is selected by default
+            content: `
+            const segmented = document.querySelector('rux-segmented-button')
+            const data = [
+                { label: 'First segment' },
+                { label: 'Second segment' },
+                { label: 'Third segment' },
+            ]
+            segmented.data = data
+        `,
+        })
+        const segmentedButton = page.locator('rux-segmented-button')
+        const segButton1Segment = segmentedButton.locator('li').nth(1)
+        const segButton2Segment = segmentedButton.locator('li').nth(2)
+        const segButton1Input = segButton1Segment.locator('input')
+        //click second button
+        await segButton2Segment.click()
+        //make sure it changed
+        await expect(segButton2Segment.locator('input')).toBeChecked
+
+        //then programatically go back to first
+        await segmentedButton.evaluate((e) =>
+            e.setAttribute('selected', 'First segment')
+        )
+        //and make sure it gets checked
+        await expect(segButton1Input).toBeChecked
+    })
 })
 /*
     Need to test: 


### PR DESCRIPTION
## Brief Description

Segmented button had an issue when trying to programmatically select a segment using rux-segmented-button's 'selected' attribute. It would select any item that was not initially selected.

## JIRA Link

[ASTRO-6212](https://rocketcom.atlassian.net/browse/ASTRO-6212)

## Related Issue

## General Notes

I put a listener on 'selected' and updated the input check when it changes.

## Motivation and Context

This use case is likely small but it was making the component act strangely with the controls in Storybook and Playground.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
