### PR TITLE
fix(rux-input) password show/hide button

### DIFF
--- a/.changeset/silver-ducks-rhyme.md
+++ b/.changeset/silver-ducks-rhyme.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+---
+
+fix(rux-input) password show/hide button is no longer visible when type != password

--- a/packages/web-components/src/components/rux-input/rux-input.tsx
+++ b/packages/web-components/src/components/rux-input/rux-input.tsx
@@ -233,7 +233,9 @@ export class RuxInput implements FormFieldInterface {
     }
 
     private _setTogglePassword() {
-        this.type === 'password' ? (this.togglePassword = true) : false
+        this.type === 'password'
+            ? (this.togglePassword = true)
+            : (this.togglePassword = false)
     }
 
     private _handleTogglePassword() {

--- a/packages/web-components/src/components/rux-input/test/index.html
+++ b/packages/web-components/src/components/rux-input/test/index.html
@@ -34,7 +34,7 @@
         <rux-input>
             <div slot="error-text">ERROR SLOT</div>
         </rux-input>
-        <section>
+        <section style="padding-inline: 2rem">
             <h2>Prop/Slot Testing</h2>
             <rux-input id="test-this" label="this the input label"></rux-input>
             <div
@@ -53,6 +53,12 @@
                 <rux-button id="addErrorProp">Add Error Prop</rux-button>
                 <rux-button id="removeErrorProp">Remove Error Prop</rux-button>
             </div>
+            <select id="changeType">
+                <option>text</option>
+                <option>password</option>
+                <option>date</option>
+                <option>time</option>
+            </select>
         </section>
         <script>
             const helpSlotButton = document.getElementById('addHelpSlot')
@@ -71,7 +77,14 @@
             const removeErrorPropButton = document.getElementById(
                 'removeErrorProp'
             )
+            const select = document.getElementById('changeType')
             const input = document.getElementById('test-this')
+
+            /**Change input type**/
+            window.addEventListener('change', (e) => {
+                if (e.target !== select) return
+                input.setAttribute('type', e.target.value)
+            })
 
             /**add/remove slots**/
 

--- a/packages/web-components/src/components/rux-input/test/input.spec.ts
+++ b/packages/web-components/src/components/rux-input/test/input.spec.ts
@@ -251,6 +251,19 @@ test.describe('Input with form', () => {
         //Assert
         await expect(ruxInputIcon).toBeVisible()
     })
+    test('removes rux-icon if type is no longer password', async ({ page }) => {
+        //Arrange
+        const ruxInputComponent = page.locator('#ruxInput4').first()
+        const ruxInputIcon = ruxInputComponent.locator('rux-icon')
+
+        //Assert
+        await expect(ruxInputIcon).toBeVisible()
+
+        await ruxInputComponent.evaluate(
+            (e) => ((e as HTMLRuxInputElement).type = 'text')
+        )
+        await expect(ruxInputIcon).not.toBeVisible()
+    })
     test('changes icon when icon is clicked', async ({ page }) => {
         //Arrange
         const ruxInputComponent = page.locator('#ruxInput4').first()


### PR DESCRIPTION
## Brief Description

When you programatically change run-ionput's type from 'password' to anything else, the show/hide password toggle would remain on the input.

This PR fixes that.

## JIRA Link

[ASTRO-6230](https://rocketcom.atlassian.net/browse/ASTRO-6230)

## Related Issue

## General Notes

## Motivation and Context

Probably a small use case, but it will make it work properly on our playground.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
