### PR TITLE
fix(progress): respect max when value increases

### DIFF
--- a/packages/web-components/src/components/rux-progress/rux-progress.tsx
+++ b/packages/web-components/src/components/rux-progress/rux-progress.tsx
@@ -13,11 +13,11 @@ export class RuxProgress {
     /**
      * Current progress value between 0 and 100 (or the max, if defined below).
      */
-    @Prop() value?: number = 0
+    @Prop({ mutable: true }) value?: number = 0
     /**
      * For progress bars where progress bars have a maximum value greater or less than 100
      */
-    @Prop({ mutable: true }) max: number = 100
+    @Prop() max: number = 100
     /**
      * Hides the progress label
      */
@@ -51,11 +51,8 @@ export class RuxProgress {
     }
     private _checkValueNotOverMax(max: number, value: number) {
         if (max && max < value) {
-            max = value
-            this.max = max
-            console.warn(
-                'The given max for <rux-progress> was less than the given value. Max has been changed to equal value in the meantime. Please be sure max and value are correct on the <rux-progress> component.'
-            )
+            value = max
+            this.value = max
         }
     }
 

--- a/packages/web-components/src/components/rux-progress/test/progress.spec.ts
+++ b/packages/web-components/src/components/rux-progress/test/progress.spec.ts
@@ -29,7 +29,7 @@ test.describe('Progress', () => {
 
         await expect(progressString).toContainText('0%')
     })
-    test('it changes max to equal value if given value is greater than given max', async ({
+    test('it changes value to equal max if given value is greater than given max', async ({
         page,
     }) => {
         const template = `
@@ -42,7 +42,8 @@ test.describe('Progress', () => {
         await page.setContent(template)
         const progress = await page.locator('.rux-progress').first()
 
-        await expect(progress).toHaveAttribute('max', '150')
+        await expect(progress).toHaveAttribute('max', '100')
+        await expect(progress).toHaveAttribute('value', '100')
     })
     test('it does not modify max if max is greater than given value', async ({
         page,
@@ -107,6 +108,6 @@ test.describe('Progress', () => {
     })
 })
 /*
-    Need to test: 
+    Need to test:
     -has props value, hide-label
 */


### PR DESCRIPTION
## Brief Description

Changes progress to respect max instead of changing max to equal value when value gets beyond max. 
This seems to be legacy functionality and isn't justified anymore. Was brought up in the demo day and was declared a bug. 
This fix swaps the (backwards) functionality of max changing to equal value with value instead changing to equal max if value is being incremented past the max prop. 

Updates a test.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-6244

## Related Issue

## General Notes

## Motivation and Context

Noticed by user. Makes progress act as you would expect 

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
