### PR TITLE
refactor(dialog): remove button group under the hood

### DIFF
--- a/packages/web-components/src/components/rux-dialog/rux-dialog.scss
+++ b/packages/web-components/src/components/rux-dialog/rux-dialog.scss
@@ -18,10 +18,12 @@
     display: none;
 }
 
-rux-button-group {
-    margin-top: auto;
+.rux-button-group {
     margin-left: auto;
-    align-self: flex-end;
+}
+
+.rux-button-group rux-button:first-of-type {
+    margin-right: var(--spacing-2);
 }
 
 .rux-dialog {

--- a/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
+++ b/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
@@ -262,7 +262,7 @@ export class RuxDialog {
                                     ></slot>
                                 ) : (
                                     <Fragment>
-                                        <rux-button-group h-align="right">
+                                        <div class="rux-button-group">
                                             <rux-button
                                                 secondary={
                                                     confirmText.length > 0
@@ -285,7 +285,7 @@ export class RuxDialog {
                                             >
                                                 {confirmText}
                                             </rux-button>
-                                        </rux-button-group>
+                                        </div>
                                         <slot
                                             name="footer"
                                             onSlotchange={

--- a/packages/web-components/src/components/rux-dialog/test/basic/index.html
+++ b/packages/web-components/src/components/rux-dialog/test/basic/index.html
@@ -74,6 +74,14 @@
                 top: 900px;
                 left: 1000px;
             }
+            .rux-button-group {
+                display: flex;
+                align-items: center;
+                justify-content: flex-end;
+            }
+            .rux-button-group rux-button:first-of-type {
+                margin-right: var(--spacing-2);
+            }
         </style>
         <section>
             <rux-dialog
@@ -87,10 +95,10 @@
                     <rux-input placeholder="input time"></rux-input>
                 </div>
                 <div slot="footer">
-                    <rux-button-group h-align="right">
+                    <div class="rux-button-group">
                         <rux-button secondary>Slot Cancel</rux-button>
                         <rux-button id="slotconfirm">Slot Confirm</rux-button>
-                    </rux-button-group>
+                    </div>
                 </div>
             </rux-dialog>
         </section>
@@ -185,10 +193,10 @@
                 message="Prop Message"
             >
                 <div slot="footer">
-                    <rux-button-group h-align="right">
+                    <div class="rux-button-group">
                         <rux-button secondary>Slotted Deny</rux-button>
                         <rux-button>Slotted Confirm</rux-button>
-                    </rux-button-group>
+                    </div>
                 </div>
             </rux-dialog>
         </section>
@@ -202,20 +210,20 @@
             <rux-dialog id="slot-footer-header" message="Prop Message" open>
                 <span slot="header">Slot Header</span>
                 <div slot="footer">
-                    <rux-button-group h-align="right">
+                    <div class="rux-button-group">
                         <rux-button secondary>Slotted Deny</rux-button>
                         <rux-button>Slotted Confirm</rux-button>
-                    </rux-button-group>
+                    </div>
                 </div>
             </rux-dialog>
             <!-- slotted message and footer -->
             <rux-dialog id="slot-msg-footer" header="Prop Header" open>
                 <div>Slot Message</div>
                 <div slot="footer">
-                    <rux-button-group h-align="right">
+                    <div class="rux-button-group">
                         <rux-button secondary>Slotted Deny</rux-button>
                         <rux-button>Slotted Confirm</rux-button>
-                    </rux-button-group>
+                    </div>
                 </div>
             </rux-dialog>
         </section>

--- a/packages/web-components/src/stories/dialog.stories.mdx
+++ b/packages/web-components/src/stories/dialog.stories.mdx
@@ -70,10 +70,10 @@ export const WithSlots = (args) => {
     </div>
     <div slot="footer" style="display: flex; justify-content: space-between; align-items: center;">
         <a href="astrouxds.com">Link</a>
-        <rux-button-group h-align="right">
-            <rux-button secondary>Cancel</rux-button>
+        <div style="display: flex; align-items: center; margin-left: auto;">
+            <rux-button secondary style="margin-right: var(--spacing-2);">Cancel</rux-button>
             <rux-button>Confirm</rux-button>
-        </rux-button-group>
+        </div>
     </div>
 </rux-dialog>
 </div>
@@ -180,8 +180,6 @@ If you're already utilizing a build system that supports tree shaking and want t
 ```js
 import { RuxDialog } from '@astrouxds/astro-web-components/dist/components/rux-dialog.js'
 import { RuxButton } from '@astrouxds/astro-web-components/dist/components/rux-button.js'
-import { RuxButtonGroup } from '@astrouxds/astro-web-components/dist/components/rux-button-group.js'
 customElements.define('rux-dialog', RuxDialog)
 customElements.define('rux-button', RuxButton)
-customElements.define('rux-button-group', RuxButtonGroup)
 ```


### PR DESCRIPTION
## Brief Description

deprecated button group but dialog is still using it under the hood. this PR removes rux-button-group from rux-dialog 

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
