### PR TITLE
fix: toggle source maps in stencil config

### DIFF
--- a/packages/web-components/stencil.config.ts
+++ b/packages/web-components/stencil.config.ts
@@ -35,6 +35,7 @@ const tokens = Object.assign({}, reference, system, component, oneOffs)
 export const config: Config = {
     namespace: 'astro-web-components',
     globalStyle: 'src/global/global.scss',
+    sourceMap: false,
     outputTargets: [
         reactOutputTarget({
             componentCorePackage: '@astrouxds/astro-web-components',


### PR DESCRIPTION
## Brief Description

Source maps were turned on by accident. This turns them off again. 
## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
