### PR TITLE
fix(rux-log) search input updates when filter is updated programatically 

### DIFF
--- a/.changeset/kind-crabs-grow.md
+++ b/.changeset/kind-crabs-grow.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+---
+
+fix(rux-log) search input updates when filter is updated programatically

--- a/packages/web-components/src/components/rux-log/rux-log.tsx
+++ b/packages/web-components/src/components/rux-log/rux-log.tsx
@@ -1,5 +1,5 @@
 /* eslint react/jsx-no-bind: 0 */ // --> OFF
-import { Prop, Component, Host, h } from '@stencil/core'
+import { Prop, Component, Host, h, Watch, Element } from '@stencil/core'
 import { LogRow } from './rux-log.model'
 
 /**
@@ -17,6 +17,8 @@ import { LogRow } from './rux-log.model'
     shadow: true,
 })
 export class RuxLog {
+    @Element() el!: HTMLRuxLogElement
+    private inputEl!: HTMLRuxInputElement
     /**
      * An array of objects to display as log
      */
@@ -30,6 +32,13 @@ export class RuxLog {
      * A string to filter the array to return only the children whose `message` property contains a case-insensitive substring match.
      */
     @Prop({ mutable: true, reflect: true }) filter?: string
+
+    @Watch('filter')
+    syncFilter() {
+        if (this.inputEl.value !== this.filter) {
+            this.inputEl.value = this.filter || ''
+        }
+    }
 
     private _setFilter(e: Event) {
         this.filter = (e.target as HTMLInputElement).value
@@ -66,6 +75,9 @@ export class RuxLog {
                                                         class="rux-log__filter"
                                                         type="search"
                                                         placeholder="Search..."
+                                                        ref={(el) =>
+                                                            (this.inputEl = el!)
+                                                        }
                                                         onRuxinput={(event) =>
                                                             this._setFilter(
                                                                 event

--- a/packages/web-components/src/components/rux-log/test/index.html
+++ b/packages/web-components/src/components/rux-log/test/index.html
@@ -18,22 +18,28 @@
             src="../../../../../dist/astro-web-components/astro-web-components.esm.js"
         ></script>
         <script nomodule src="/build/astro-web-components.js"></script>
-        <!-- 
+
         <link
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"
-        /> -->
-        <link
+        />
+        <!-- <link
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
-        />
+        /> -->
         <!-- <script
             type="module"
             src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
         ></script> -->
+        <style>
+            #filterInput {
+                margin: 2rem;
+            }
+        </style>
     </head>
     <body>
         <rux-log id="testing"></rux-log>
+        <rux-input id="filterInput" placeholder="Filter Test" />
         <script>
             const log = document.getElementById('testing')
             const data = [
@@ -96,6 +102,11 @@
             ]
 
             log.data = data
+
+            const filterInput = document.querySelector('#filterInput')
+            filterInput.addEventListener('input', (e) => {
+                log.setAttribute('filter', e.target.value)
+            })
         </script>
 
         <!-- <section>


### PR DESCRIPTION
## Brief Description

Added a watch decorator to filter and had search update when filter changed and the two fall out of sync.

## JIRA Link

[ASTRO-1842](https://rocketcom.atlassian.net/browse/ASTRO-1842)

## Related Issue

## General Notes

Pretty easy fix though I am wondering if I should add an event for the filter change...

## Motivation and Context

Low impact issue but in the case that a dev is trying to filter from external js, the filter string didn't populate into the search input (though the items did still filter properly). This makes sure that the filter and the search stay in sync.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
