### PR TITLE
fix(rux-log) bring row height into alignment with figma

### DIFF
--- a/.changeset/moody-needles-fix.md
+++ b/.changeset/moody-needles-fix.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": minor
+---
+
+fix(rux-log) adjust height of rows to 32px

--- a/packages/web-components/src/components/rux-log/rux-log.scss
+++ b/packages/web-components/src/components/rux-log/rux-log.scss
@@ -45,9 +45,7 @@ rux-table-header-cell {
 }
 
 rux-table-cell {
-    height: calc(
-        var(--spacing-8) - var(--spacing-050) - 1px
-    ); //30 size - border
+    height: calc(var(--spacing-8) - 1px); //32 size - border
 }
 
 .rux-log__notification {


### PR DESCRIPTION
## Brief Description

Changed the row-height in run-log to be --spacing-8 - 1px (32px - bottom border) so that it would be aligned with figma design and our 4px design grid.

## JIRA Link

[ASTRO-6157](https://rocketcom.atlassian.net/browse/ASTRO-6157)

## Related Issue

## General Notes

## Motivation and Context

Figma designs updated because rux-log was not previously following our 4px grid system as rows were only 30px tall.

## Issues and Limitations

I marked this as a minor change since it changes some dimensions but it may just be patch. Up to you Mark. :)

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
