### PR TITLE
feat(rux-accordion-item) add part to the content wrapper

### DIFF
--- a/.changeset/heavy-horses-jump.md
+++ b/.changeset/heavy-horses-jump.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": minor
+"angular-workspace": minor
+"@astrouxds/angular": minor
+"@astrouxds/react": minor
+---
+
+Accordion Item - Added `content` CSS Shadow Part

--- a/packages/web-components/src/components/rux-accordion/rux-accordion-item/rux-accordion-item.tsx
+++ b/packages/web-components/src/components/rux-accordion/rux-accordion-item/rux-accordion-item.tsx
@@ -21,6 +21,7 @@ import { hasSlot } from '../../../utils/utils'
  * @part label - The label
  * @part prefix - The wrapper for the prefix slot
  * @part indicator - The opened/closed indicator
+ * @part content - The element wrapping the expanded content
  */
 
 @Component({
@@ -128,7 +129,7 @@ export class RuxAccordionItem {
                             </svg>
                         </span>
                     </summary>
-                    <span class="rux-accordion-item--content">
+                    <span part="content" class="rux-accordion-item--content">
                         <slot></slot>
                     </span>
                 </details>


### PR DESCRIPTION
## Brief Description

added part=content to the span that wraps the details slot. It has some padding on it and that can't be manipulated without the part.

## JIRA Link

[Astro-6233](https://rocketcom.atlassian.net/browse/ASTRO-6233)

## Related Issue

## General Notes

## Motivation and Context

Allows people to remove padding from the content slot wrapper if they need to.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
