### PR TITLE
fix(textarea) move height to :host

### DIFF
--- a/.changeset/popular-ties-sleep.md
+++ b/.changeset/popular-ties-sleep.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+fix(rux-textarea) fixs the rows prop to get it working

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -1,7 +1,8 @@
 @use '../../common/functional-components/FormFieldMessage/form-field-message.scss';
 
 :host {
-    display: block;
+    display: flex;
+    flex-direction: column;
 }
 
 .hidden,
@@ -80,7 +81,8 @@ textarea {
     line-height: var(--font-control-body-1-line-height);
     color: var(--color-text-primary);
     background-color: var(--color-background-base-default);
-    height: var(--spacing-16); //64
+    min-height: var(--spacing-16); //64
+    flex-grow: 1;
     width: 100%;
     padding: var(--spacing-2);
     margin: var(--spacing-0);
@@ -97,10 +99,10 @@ textarea {
     }
     &--small {
         padding: var(--spacing-1) var(--spacing-2); //4px 8px
-        height: var(--spacing-14); //56px
+        min-height: var(--spacing-14); //56px
     }
     &--large {
-        height: calc(var(--spacing-16) + var(--spacing-2)); //72px
+        min-height: calc(var(--spacing-16) + var(--spacing-2)); //72px
         padding: var(--spacing-3) var(--spacing-2); //12px 8px
     }
 
@@ -129,6 +131,7 @@ textarea {
     display: flex;
     flex-direction: column;
     color: var(--color-text-primary);
+    flex-grow: 1;
 }
 
 .rux-textarea-label {

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.scss
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.scss
@@ -1,8 +1,7 @@
 @use '../../common/functional-components/FormFieldMessage/form-field-message.scss';
 
 :host {
-    display: flex;
-    flex-direction: column;
+    display: block;
 }
 
 .hidden,
@@ -82,7 +81,6 @@ textarea {
     color: var(--color-text-primary);
     background-color: var(--color-background-base-default);
     min-height: var(--spacing-16); //64
-    flex-grow: 1;
     width: 100%;
     padding: var(--spacing-2);
     margin: var(--spacing-0);
@@ -131,7 +129,6 @@ textarea {
     display: flex;
     flex-direction: column;
     color: var(--color-text-primary);
-    flex-grow: 1;
 }
 
 .rux-textarea-label {

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -19,5 +19,51 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body></body>
+    <body>
+        <style>
+            rux-textarea {
+                height: 300px;
+                min-width: 50%;
+                margin: 2rem auto;
+            }
+        </style>
+
+        <form id="form">
+            <rux-textarea
+                id="textarea1"
+                name="test1"
+                value="TextArea Test 1"
+            ></rux-textarea>
+            <br />
+            <rux-textarea
+                id="textarea1"
+                name="test1"
+                value="TextArea Test 1"
+                size="small"
+            ></rux-textarea>
+            <br />
+            <rux-textarea
+                id="textarea1"
+                name="test1"
+                value="TextArea Test 1"
+                size="large"
+            ></rux-textarea>
+            <br />
+            <rux-textarea
+                id="textarea1"
+                name="test1"
+                value="TextArea Test 1"
+                label="This is the label"
+                error-text="this is error!"
+                rows="10"
+            ></rux-textarea>
+            <br />
+            <rux-textarea
+                id="disTextArea"
+                name="disTextArea"
+                value="Disabled"
+                disabled
+            ></rux-textarea>
+        </form>
+    </body>
 </html>

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -19,51 +19,5 @@
         <link rel="stylesheet" href="/build/astro-web-components.css" />
     </head>
 
-    <body>
-        <style>
-            rux-textarea {
-                height: 300px;
-                min-width: 50%;
-                margin: 2rem auto;
-            }
-        </style>
-
-        <form id="form">
-            <rux-textarea
-                id="textarea1"
-                name="test1"
-                value="TextArea Test 1"
-            ></rux-textarea>
-            <br />
-            <rux-textarea
-                id="textarea1"
-                name="test1"
-                value="TextArea Test 1"
-                size="small"
-            ></rux-textarea>
-            <br />
-            <rux-textarea
-                id="textarea1"
-                name="test1"
-                value="TextArea Test 1"
-                size="large"
-            ></rux-textarea>
-            <br />
-            <rux-textarea
-                id="textarea1"
-                name="test1"
-                value="TextArea Test 1"
-                label="This is the label"
-                error-text="this is error!"
-                rows="10"
-            ></rux-textarea>
-            <br />
-            <rux-textarea
-                id="disTextArea"
-                name="disTextArea"
-                value="Disabled"
-                disabled
-            ></rux-textarea>
-        </form>
-    </body>
+    <body></body>
 </html>


### PR DESCRIPTION
## Brief Description

~Testing moving height to host.~
Adjusted this fix to set height on textarea to min-height so that rows="X" will work again.

## JIRA Link

[ASTRO-5903](https://rocketcom.atlassian.net/browse/ASTRO-5903)

## Related Issue

## General Notes

## Motivation and Context

Width can be set on rux-textarea but height can't.
Decided to fix this by fixing the rows prop. it wasn't properly working because height was set on textarea instead of min-height.

## Issues and Limitations

So the problem with setting height this way is that there is more than one element in rux-textarea to contend with. Label sits on top and help/error sits on bottom. It's not a problem if you don't want the textarea to be resizable but if you DO then the height doesn't act as you would expect. setting min-height would.. but is that the less confusing option?

Carbon uses rows to set height. if you set height to their web component it does the same as ours currently does.
Shoelace works like carbons and ours
Calcite wraps text area with anything that needs to go outside the textarea space, skirting the issue.

So instead of making height settable on rux-textarea I adjusted this and fixes a bug with `rows` instead

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
