### PR TITLE
docs(popup) storybook fix

### DIFF
--- a/packages/web-components/src/stories/popup.stories.mdx
+++ b/packages/web-components/src/stories/popup.stories.mdx
@@ -32,7 +32,7 @@ A Pop Up provides users with a quick way to access common actions for a highligh
 export const Default = (args) => {
     return html`
 <div style="display: flex; width: 100%; justify-content: center; margin-top: 10%;">
-    <rux-pop-up open=${args.open}>
+    <rux-pop-up open=${args.open} placement=${args.placement} ?close-on-select=${args.closeOnSelect} ?disable-auto-update="${args.disableAutoUpdate} ?enable-animation-frame="${args.enableAnimationFrame}">
         <rux-icon icon="apps" slot="trigger"></rux-icon>
         <rux-menu>
             <rux-menu-item href="#">Menu Item 1</rux-menu-item>
@@ -49,7 +49,8 @@ export const Default = (args) => {
         args={{
             open: true,
             placement: 'auto',
-            closeOnSelect: false
+            closeOnSelect: false,
+            disableAutoUpdate: false
         }}
         name="Default"
     >


### PR DESCRIPTION
## Brief Description

Noticed that the `placement` prop wasn't hooked up in storybook so I made a quick fix. I thought the problem was the same as tooltip but it appears not to be the case.

## JIRA Link

No ticket, noticed this on accident when checking out a different PR.

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
