### PR TITLE
test: add testName option

### DIFF
--- a/packages/web-components/tests/utils/_astro-fixtures.ts
+++ b/packages/web-components/tests/utils/_astro-fixtures.ts
@@ -8,14 +8,16 @@ import { Page } from "@playwright/test";
 export type TestOptions = {
     theme: 'dark' | 'light';
     component: string
+    testName: string
     astroVRTPage: Page
   };
 
 export const test = base.extend<TestOptions>({
     theme: ['dark', { option: true }],
     component: ['rux-foo', { option: true }],
-    astroVRTPage: async ({ theme, component, page }, use) => {
-        await page.goto(`/src/components/${component}/test/basic/index.html`)
+    testName: ['basic', { option: true}],
+    astroVRTPage: async ({ theme, component, testName, page }, use) => {
+        await page.goto(`/src/components/${component}/test/${testName}/index.html`)
         // Set up the fixture.
         if (theme === 'light') {
                 await page.evaluate(() => {


### PR DESCRIPTION
## Brief Description

adds a lil optional `testName` option to our test config that you can pass in like: 
```
    test.use({ component: 'rux-select', testName: 'inline' })
```
so now we can break up our chonky VRT tests into smaller directories. right now, everything is under "basic" but I wanted to create a new directory for inline select

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
