### PR TITLE
Changed rux-select to use box-shadow rather than border

### DIFF
--- a/.changeset/stale-masks-visit.md
+++ b/.changeset/stale-masks-visit.md
@@ -1,0 +1,8 @@
+---
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+"@astrouxds/astro-web-components": patch
+---
+
+select - moved border styles to box-shadow css property to align with other form elements. If you were overriding `border` using CSS shadow parts, this may be a breaking change.

--- a/packages/web-components/src/components/rux-select/rux-select.scss
+++ b/packages/web-components/src/components/rux-select/rux-select.scss
@@ -114,7 +114,8 @@ label {
     -webkit-appearance: none;
     -moz-appearance: none;
     width: 100%;
-    border: 1px solid var(--color-border-interactive-muted);
+    border: 0;
+    box-shadow: var(--color-border-interactive-muted, #2b659b) 0 0 0 1px inset;
     border-radius: var(--radius-base);
     color: var(--color-background-interactive-default);
     font-family: var(--font-control-body-1-font-family);

--- a/packages/web-components/src/components/rux-select/rux-select.scss
+++ b/packages/web-components/src/components/rux-select/rux-select.scss
@@ -115,7 +115,7 @@ label {
     -moz-appearance: none;
     width: 100%;
     border: 0;
-    box-shadow: var(--color-border-interactive-muted, #2b659b) 0 0 0 1px inset;
+    box-shadow: var(--color-border-interactive-muted) 0 0 0 1px inset;
     border-radius: var(--radius-base);
     color: var(--color-background-interactive-default);
     font-family: var(--font-control-body-1-font-family);


### PR DESCRIPTION
## Brief Description

`rux-input` uses box-shadow, not border, which gives it a height of 36px by default. `rux-select` uses the opposite, which gives it a height of 38px by default. This makes aligning a `rux-select` and `rux-input` extremely frustrating.

This PR just changes `rux-select` to be consistent with `rux-input`, making the height the same and alignment trivial.

## Types of changes

- [X] Bug fix
- [ ] New feature
- [X??] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
