### PR TITLE
feat(rux-textarea) add readonly attribute

### DIFF
--- a/.changeset/mean-melons-float.md
+++ b/.changeset/mean-melons-float.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": minor
+"angular-workspace": minor
+"@astrouxds/angular": minor
+"@astrouxds/react": minor
+---
+
+feat(rux-textarea) add readonly attribute

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -19956,7 +19956,7 @@ export namespace Components {
     }
     interface RuxTextarea {
         /**
-          * Disables the button via HTML disabled attribute. Button takes on a distinct visual state. Cursor uses the not-allowed system replacement and all keyboard and mouse events are ignored.
+          * Sets the input as disabled
          */
         "disabled": boolean;
         /**
@@ -19992,7 +19992,11 @@ export namespace Components {
          */
         "placeholder"?: string;
         /**
-          * Sets the input as disabled
+          * The textareas readonly attribute
+         */
+        "readonly": boolean;
+        /**
+          * Sets the input as required
          */
         "required": boolean;
         /**
@@ -55550,7 +55554,7 @@ declare namespace LocalJSX {
     }
     interface RuxTextarea {
         /**
-          * Disables the button via HTML disabled attribute. Button takes on a distinct visual state. Cursor uses the not-allowed system replacement and all keyboard and mouse events are ignored.
+          * Sets the input as disabled
          */
         "disabled"?: boolean;
         /**
@@ -55598,7 +55602,11 @@ declare namespace LocalJSX {
          */
         "placeholder"?: string;
         /**
-          * Sets the input as disabled
+          * The textareas readonly attribute
+         */
+        "readonly"?: boolean;
+        /**
+          * Sets the input as required
          */
         "required"?: boolean;
         /**

--- a/packages/web-components/src/components/rux-textarea/rux-textarea.tsx
+++ b/packages/web-components/src/components/rux-textarea/rux-textarea.tsx
@@ -88,14 +88,19 @@ export class RuxTextarea implements FormFieldInterface {
     @Prop() rows?: number
 
     /**
-     * Disables the button via HTML disabled attribute. Button takes on a distinct visual state. Cursor uses the not-allowed system replacement and all keyboard and mouse events are ignored.
+     * Sets the input as disabled
      */
     @Prop({ reflect: true }) disabled = false
 
     /**
-     * Sets the input as disabled
+     * Sets the input as required
      */
     @Prop() required: boolean = false
+
+    /**
+     * The textareas readonly attribute
+     */
+    @Prop() readonly = false
 
     /**
      * Styles the input element size between small, medium and large. The default styling is medium.
@@ -213,6 +218,7 @@ export class RuxTextarea implements FormFieldInterface {
                         aria-invalid={this.invalid ? 'true' : 'false'}
                         placeholder={this.placeholder}
                         required={this.required}
+                        readonly={this.readonly}
                         minlength={this.minLength}
                         maxlength={this.maxLength}
                         value={this.value}


### PR DESCRIPTION
## Brief Description

Added readonly attribute to rux-textarea in a way that mimics rux-input

## JIRA Link

[ASTRO-6600](https://rocketcom.atlassian.net/browse/ASTRO-6600)

## Related Issue

## General Notes

## Motivation and Context

I've run into some dev instances in the TTC/GRM apps where it would have been nice to have readonly available.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
