### PR TITLE
docs(tooltip): removed center variants

### DIFF
--- a/packages/web-components/src/stories/tooltip.stories.mdx
+++ b/packages/web-components/src/stories/tooltip.stories.mdx
@@ -43,7 +43,7 @@ export const Default = (args) => {
         args={{
             open: true,
             message: 'Tooltip',
-            placement: 'top-center',
+            placement: 'top',
             delay: 800,
             strategy: 'absolute',
             offset: 8,
@@ -89,15 +89,6 @@ export const Placements = (args) => {
     </div>
     <div style="padding: 30px 10px 30px 30px;">
         <rux-tooltip
-            placement="top-center"
-            message="Tooltip"
-            open
-        >
-            <rux-button>Top Center</rux-button>
-        </rux-tooltip>
-    </div>
-    <div style="padding: 30px 10px 30px 30px;">
-        <rux-tooltip
             placement="top-end"
             message="Tooltip"
             open
@@ -123,15 +114,6 @@ export const Placements = (args) => {
             open
         >
             <rux-button>Bottom Start</rux-button>
-        </rux-tooltip>
-    </div>
-    <div style="padding: 30px 10px 30px 10px;">
-        <rux-tooltip
-            placement="bottom-center"
-            message="Tooltip"
-            open
-        >
-            <rux-button>Bottom Center</rux-button>
         </rux-tooltip>
     </div>
     <div style="padding: 30px 10px 30px 10px;">
@@ -165,15 +147,6 @@ export const Placements = (args) => {
     </div>
     <div style="padding: 30px 30px 30px 0px;">
         <rux-tooltip
-            placement="right-center"
-            message="Tooltip"
-            open
-        >
-            <rux-button>Right Center</rux-button>
-        </rux-tooltip>
-    </div>
-    <div style="padding: 30px 30px 30px 0px;">
-        <rux-tooltip
             placement="right-end"
             message="Tooltip"
             open
@@ -199,15 +172,6 @@ export const Placements = (args) => {
             open
         >
             <rux-button>Left Start</rux-button>
-        </rux-tooltip>
-    </div>
-    <div style="padding: 30px;">
-        <rux-tooltip
-            placement="left-center"
-            message="Tooltip"
-            open
-        >
-            <rux-button>Left Center</rux-button>
         </rux-tooltip>
     </div>
     <div style="padding: 30px;">


### PR DESCRIPTION
## Brief Description

Removes the tooltip placement 'center' variants from SB. This includes 
- top center
- bottom center
- right center
- left center 
These placements don't exist anymore. Instead they are just 'top', 'bottom', ect. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-6725

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
