### PR TITLE
Km.6762 rux tabs onclick fix

### DIFF
--- a/.changeset/metal-plants-sell.md
+++ b/.changeset/metal-plants-sell.md
@@ -1,0 +1,11 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-angular": patch
+"astro-react": patch
+"astro-vue": patch
+"@astrouxds/react": patch
+---
+
+fix(rux-tabs) adjust error handling for private \_onClick event

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
@@ -155,9 +155,12 @@ export class RuxTabs {
         const target = e.target as HTMLElement
         //get the tab in case complex html is nested inside rux-tab
         const tab = target.closest('rux-tab') as HTMLRuxTabElement
-        this.ruxSelected.emit(tab)
-        if (tab.getAttribute('disabled') === null) {
-            this._setTab(tab)
+        //if user does not click on a tab but instead on rux-tabs, tab will be null
+        if (tab !== null) {
+            this.ruxSelected.emit(tab)
+            if (tab.getAttribute('disabled') === null) {
+                this._setTab(tab)
+            }
         }
     }
 


### PR DESCRIPTION
## Brief Description

Fixed an error in rux-tabs where if a tab was not clicked then it would throw an error.

## JIRA Link

[ASTRO-6762](https://rocketcom.atlassian.net/browse/ASTRO-6762)

## Related Issue

## General Notes

## Motivation and Context

Its not a huge thing, just prevents the tabs from throwing errors in testing.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
