### PR TITLE
fix(gsb) adjust paddings so that focus states on the left/right can be visible

### DIFF
--- a/.changeset/quiet-readers-flow.md
+++ b/.changeset/quiet-readers-flow.md
@@ -1,0 +1,11 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-angular": patch
+"astro-react": patch
+"astro-vue": patch
+"@astrouxds/react": patch
+---
+
+fix(GSB) switch padding on host and header container for focus state

--- a/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.scss
+++ b/packages/web-components/src/components/rux-global-status-bar/rux-global-status-bar.scss
@@ -11,7 +11,7 @@
     width: -webkit-fill-available;
     width: -moz-available;
     width: stretch;
-    padding: 0 var(--spacing-6);
+    padding: 0 calc(var(--spacing-6) - var(--spacing-1)); // to account for padding to child so that focus can show
     box-sizing: border-box;
     background-color: var(--gsb-color-background);
     -webkit-user-select: none;
@@ -73,8 +73,9 @@
 }
 
 header {
-    overflow: hidden;
     display: flex;
+    overflow: hidden;
+    padding: 0 var(--spacing-1); // so focus does not get cut off by overflow: hidden
     height: 100%;
     width: 100%;
     align-items: center;


### PR DESCRIPTION
## Brief Description

I moved some of the padding from `host` to the inner `<header>` container so that when a menu or other focusable item appears in the left or right slot, the focus state won't get cut off by the `overflow:hidden` on `<header>` moving overflow:hidden to host wasn't an option because it would then hide any slotted menus.

## JIRA Link

[ASTRO-6766](https://rocketcom.atlassian.net/browse/ASTRO-6766)

## Related Issue

## General Notes
I ran VRTs and it looks like my change doesn't affect the layout in any way. :)

## Motivation and Context

The GSB will cut off focus state of anything slotted in the right-slot or left-slot. The right slot is FOR menus which should always have a focus state.. so it doesn't make sense to have the developer need to tweak this every time in order to get the focus display right.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
