### PR TITLE
fix(rux-tabs) fix some keyboard functionality

### DIFF
--- a/.changeset/few-badgers-itch.md
+++ b/.changeset/few-badgers-itch.md
@@ -1,0 +1,11 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-angular": patch
+"astro-react": patch
+"astro-vue": patch
+"@astrouxds/react": patch
+---
+
+fix(rux-tabs) enhanced keyboard functionality with or without tab panels

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
@@ -53,6 +53,7 @@ export class RuxTabs {
             this._panels.forEach((panel) => panel.classList.add('hidden'))
             selectedPanel?.classList.remove('hidden')
         }
+        this._checkSelected()
     }
 
     @Listen('ruxregisterpanels', { target: 'window' })
@@ -129,8 +130,23 @@ export class RuxTabs {
         this._addTabs()
     }
 
+    componentWillUpdate() {
+        this._checkSelected()
+    }
+
     private _addTabs() {
-        this._tabs = Array.from(this.el.querySelectorAll('rux-tab'))
+        this._tabs = Array.from(this.el?.querySelectorAll('rux-tab'))
+    }
+
+    private _checkSelected() {
+        // If no selected tab exists, we need to set an item to tabindex = 0
+        // so that we can still tab into the tabs list
+        const firstTab: HTMLDivElement | null = this._tabs[0].shadowRoot!.querySelector(
+            '[part="container"]'
+        )
+        if (firstTab) {
+            firstTab.tabIndex = !this._tabs.find((tab) => tab.selected) ? 0 : -1
+        }
     }
 
     private _registerPanels(e: CustomEvent) {
@@ -200,7 +216,7 @@ export class RuxTabs {
                 onKeyPress={(e: KeyboardEvent) => this._onPress(e)}
                 role="tablist"
             >
-                <slot></slot>
+                <slot onSlotchange={this._addTabs.bind(this)}></slot>
             </Host>
         )
     }

--- a/packages/web-components/src/components/rux-tabs/test/tabs.spec.ts
+++ b/packages/web-components/src/components/rux-tabs/test/tabs.spec.ts
@@ -555,3 +555,39 @@ test.describe('Tab Keyboard Disabled Navigation', () => {
     Need to test:
 
 */
+
+test.describe('Tabs only Tab Keyboard Navigation', () => {
+    test.beforeEach(async ({ page }) => {
+        const template = `
+          <button id="button">Hi!</button>
+              <rux-tabs id="tab-set-id-1">
+                  <rux-tab id="tab-id-1">Tab 1</rux-tab>
+                  <rux-tab id="tab-id-2">Tab 2</rux-tab>
+                  <rux-tab id="tab-id-3">Tab 3</rux-tab>
+              </rux-tabs>
+      `
+        await page.setContent(template)
+    })
+
+    test('it tabs into the first tab when none are selected', async ({
+        page,
+    }) => {
+        //Arrange
+        const button = await page.locator('#button')
+        const tab1 = await page.locator('#tab-id-1')
+        const tab1Child = tab1.locator('.rux-tab')
+
+        //Act
+        await button.focus()
+        await page.keyboard.press('Tab')
+
+        //Assert
+        await expect(tab1Child).toBeFocused()
+
+        //Act
+        await page.keyboard.press('Enter')
+
+        //Assert
+        await expect(tab1).toHaveAttribute('selected', '')
+    })
+})


### PR DESCRIPTION
## Brief Description

Rux-tabs have been pretty well inextricably linked to rux-tab-panels. So much so that in order to run _addTabs() after the initial connection, rux-tabs needs to hear a 'ruxregisterpanels' event. This is fine, unless you're not using panels. For example, in React it sometimes makes sense to pull in tabs to change certain states but not explicitly set panels.
[example](https://grm-equipment-react-ts.netlify.app)

This PR runs _addTabs on rux-tabs slots change since all addTabs does is look through rux-tabs and put every rux-tab found into an array so that keyboard commands can be run on them.

Secondarily, I've added a function that sets the first tab item to tabindex=0 when no tab is set to 'selected'. this way you can tab back into rux-tabs even when there is no explicitly set rux-tab.


## JIRA Link

[ASTRO-6828](https://rocketcom.atlassian.net/browse/ASTRO-6828)

## Related Issue

## General Notes

## Motivation and Context

I've seen multiple apps and wireframes where tabs are used separately from explicitly called tab panels. The upcoming FDS app is probably going to be another example of this where tabs are in the GSB but we won't necessarily want to render all tabs at once and then swap hidden/visable. That is a strategy but it's not necessarily the one devs reach for.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
