### PR TITLE
fix(push-button): remove default label

### DIFF
--- a/.changeset/five-ladybugs-smell.md
+++ b/.changeset/five-ladybugs-smell.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+---
+
+Fix (push button) - The label prop no longer defaults to 'Push Button'

--- a/packages/web-components/src/components/rux-push-button/rux-push-button.tsx
+++ b/packages/web-components/src/components/rux-push-button/rux-push-button.tsx
@@ -50,7 +50,7 @@ export class RuxPushButton {
     /**
      * The label of the push button.
      */
-    @Prop() label: string = 'Push Button'
+    @Prop() label: string = ''
     /**
      * The name of the push button.
      */


### PR DESCRIPTION
## Brief Description

Removes the default label text 'Push Button'

## JIRA Link

ASTRO-3925

## Issues and Limitations

We also probably want to deprecate and remove the `label` prop altogether in favor of slots in the future. 

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
