### PR TITLE
feat(dialog): toggleOpen, openDialog, closeDialog methods

### DIFF
--- a/.changeset/gentle-games-brush.md
+++ b/.changeset/gentle-games-brush.md
@@ -5,4 +5,4 @@
 "@astrouxds/react": minor
 ---
 
-Added `toggleOpen`, `openDialog` and `closeDialog` methods
+Added `toggle`, `show` and `hide` methods

--- a/.changeset/gentle-games-brush.md
+++ b/.changeset/gentle-games-brush.md
@@ -5,4 +5,4 @@
 "@astrouxds/react": minor
 ---
 
-Added a `toggleOpen` public method
+Added `toggleOpen`, `openDialog` and `closeDialog` methods

--- a/.changeset/gentle-games-brush.md
+++ b/.changeset/gentle-games-brush.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": minor
+"angular-workspace": minor
+"@astrouxds/angular": minor
+"@astrouxds/react": minor
+---
+
+Added a `toggleOpen` public method

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astrouxds/astro-web-components",
-  "version": "7.15.2",
+  "version": "7.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@astrouxds/astro-web-components",
-      "version": "7.15.2",
+      "version": "7.16.0",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "~1.0.6",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -252,6 +252,10 @@ export namespace Components {
          */
         "clickToClose": boolean;
         /**
+          * Closes the dialog
+         */
+        "closeDialog": () => Promise<void>;
+        /**
           * Text for confirmation button
          */
         "confirmText": string;
@@ -271,6 +275,13 @@ export namespace Components {
           * Shows and hides dialog
          */
         "open": boolean;
+        /**
+          * Opens the dialog
+         */
+        "openDialog": () => Promise<void>;
+        /**
+          * Toggles the dialog's open prop.
+         */
         "toggleOpen": () => Promise<void>;
     }
     interface RuxGlobalStatusBar {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -252,10 +252,6 @@ export namespace Components {
          */
         "clickToClose": boolean;
         /**
-          * Closes the dialog
-         */
-        "closeDialog": () => Promise<void>;
-        /**
           * Text for confirmation button
          */
         "confirmText": string;
@@ -268,6 +264,10 @@ export namespace Components {
          */
         "header"?: string;
         /**
+          * Closes the dialog
+         */
+        "hide": () => Promise<void>;
+        /**
           * Dialog body message
          */
         "message"?: string;
@@ -278,11 +278,11 @@ export namespace Components {
         /**
           * Opens the dialog
          */
-        "openDialog": () => Promise<void>;
+        "show": () => Promise<void>;
         /**
           * Toggles the dialog's open prop.
          */
-        "toggleOpen": () => Promise<void>;
+        "toggle": () => Promise<void>;
     }
     interface RuxGlobalStatusBar {
         /**

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -271,6 +271,7 @@ export namespace Components {
           * Shows and hides dialog
          */
         "open": boolean;
+        "toggleOpen": () => Promise<void>;
     }
     interface RuxGlobalStatusBar {
         /**

--- a/packages/web-components/src/components/rux-dialog/readme.md
+++ b/packages/web-components/src/components/rux-dialog/readme.md
@@ -78,6 +78,39 @@ Or use slots to render the header, content and footer.
 | `ruxdialogopened` | Event that is fired when dialog opens                                                                                                                                                                                  | `CustomEvent<void>`            |
 
 
+## Methods
+
+### `hide() => Promise<void>`
+
+Closes the dialog
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `show() => Promise<void>`
+
+Opens the dialog
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `toggle() => Promise<void>`
+
+Toggles the dialog's open prop.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
 ## Slots
 
 | Slot          | Description                     |

--- a/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
+++ b/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
@@ -82,7 +82,7 @@ export class RuxDialog {
      * Toggles the dialog's open prop.
      */
     @Method()
-    async toggleOpen() {
+    async toggle() {
         this.open = !this.open
     }
 
@@ -90,7 +90,7 @@ export class RuxDialog {
      * Opens the dialog
      */
     @Method()
-    async openDialog() {
+    async show() {
         this.open = true
     }
 
@@ -98,7 +98,7 @@ export class RuxDialog {
      * Closes the dialog
      */
     @Method()
-    async closeDialog() {
+    async hide() {
         this.open = false
     }
 

--- a/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
+++ b/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
@@ -10,6 +10,7 @@ import {
     Host,
     State,
     Fragment,
+    Method,
 } from '@stencil/core'
 import { hasSlot } from '../../utils/utils'
 
@@ -76,6 +77,11 @@ export class RuxDialog {
         bubbles: true,
     })
     ruxDialogClosed!: EventEmitter<boolean | null>
+
+    @Method()
+    async toggleOpen() {
+        this.open = !this.open
+    }
 
     @Element() element!: HTMLRuxDialogElement
 

--- a/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
+++ b/packages/web-components/src/components/rux-dialog/rux-dialog.tsx
@@ -78,9 +78,28 @@ export class RuxDialog {
     })
     ruxDialogClosed!: EventEmitter<boolean | null>
 
+    /**
+     * Toggles the dialog's open prop.
+     */
     @Method()
     async toggleOpen() {
         this.open = !this.open
+    }
+
+    /**
+     * Opens the dialog
+     */
+    @Method()
+    async openDialog() {
+        this.open = true
+    }
+
+    /**
+     * Closes the dialog
+     */
+    @Method()
+    async closeDialog() {
+        this.open = false
     }
 
     @Element() element!: HTMLRuxDialogElement

--- a/packages/web-components/src/components/rux-dialog/test/dialog.spec.ts
+++ b/packages/web-components/src/components/rux-dialog/test/dialog.spec.ts
@@ -238,7 +238,7 @@ test.describe(
         })
     }
 )
-test.describe('toggleOpen method', () => {
+test.describe('Methods', () => {
     test('toggleOpen method opens a closed dialog', async ({ page }) => {
         const template = `
           <rux-button>Toggle Open</rux-button>
@@ -287,5 +287,54 @@ test.describe('toggleOpen method', () => {
         await expect(dialog).toHaveAttribute('open', '')
         await btn.click()
         await expect(dialog).not.toHaveAttribute('open', '')
+    })
+    test('closeDialog method closes an open dialog', async ({ page }) => {
+        const template = `
+      <rux-dialog open>
+        <div slot="header">Header</div>
+        Body Content
+        <div slot="footer">
+          <rux-button>Close</rux-button>
+        </div>
+      </rux-dialog>`
+        await page.setContent(template)
+        await page.addScriptTag({
+            content: `
+        const dialog = document.querySelector('rux-dialog')
+        const btn = document.querySelector('rux-button')
+        btn.addEventListener('click', () => {
+          dialog.closeDialog()
+        })
+        `,
+        })
+        const dialog = page.locator('rux-dialog')
+        const btn = page.locator('rux-button')
+        await expect(dialog).toHaveAttribute('open', '')
+        await btn.click()
+        await expect(dialog).not.toHaveAttribute('open', '')
+    })
+    test('openDialog method opens a closed dialog', async ({ page }) => {
+        const template = `
+    <rux-dialog>
+      <div slot="header">Header</div>
+      Body Content
+    </rux-dialog>
+    <rux-button>Open</rux-button>
+    `
+        await page.setContent(template)
+        await page.addScriptTag({
+            content: `
+      const dialog = document.querySelector('rux-dialog')
+      const btn = document.querySelector('rux-button')
+      btn.addEventListener('click', () => {
+        dialog.openDialog()
+      })
+      `,
+        })
+        const dialog = page.locator('rux-dialog')
+        const btn = page.locator('rux-button')
+        await expect(dialog).not.toHaveAttribute('open', '')
+        await btn.click()
+        await expect(dialog).toHaveAttribute('open', '')
     })
 })

--- a/packages/web-components/src/components/rux-dialog/test/dialog.spec.ts
+++ b/packages/web-components/src/components/rux-dialog/test/dialog.spec.ts
@@ -239,7 +239,7 @@ test.describe(
     }
 )
 test.describe('Methods', () => {
-    test('toggleOpen method opens a closed dialog', async ({ page }) => {
+    test('toggle method opens a closed dialog', async ({ page }) => {
         const template = `
           <rux-button>Toggle Open</rux-button>
           <rux-dialog>
@@ -253,7 +253,7 @@ test.describe('Methods', () => {
             const dialog = document.querySelector('rux-dialog')
             const btn = document.querySelector('rux-button')
             btn.addEventListener('click', () => {
-              dialog.toggleOpen()
+              dialog.toggle()
             })
             `,
         })
@@ -263,7 +263,7 @@ test.describe('Methods', () => {
         await btn.click()
         await expect(dialog).toHaveAttribute('open', '')
     })
-    test('toggleOpen method closes an open dialog', async ({ page }) => {
+    test('toggle method closes an open dialog', async ({ page }) => {
         const template = `
           <rux-dialog open>
             <div slot="header">Header</div>
@@ -278,7 +278,7 @@ test.describe('Methods', () => {
             const dialog = document.querySelector('rux-dialog')
             const btn = document.querySelector('rux-button')
             btn.addEventListener('click', () => {
-              dialog.toggleOpen()
+              dialog.toggle()
             })
             `,
         })
@@ -288,7 +288,7 @@ test.describe('Methods', () => {
         await btn.click()
         await expect(dialog).not.toHaveAttribute('open', '')
     })
-    test('closeDialog method closes an open dialog', async ({ page }) => {
+    test('hide method closes an open dialog', async ({ page }) => {
         const template = `
       <rux-dialog open>
         <div slot="header">Header</div>
@@ -303,7 +303,7 @@ test.describe('Methods', () => {
         const dialog = document.querySelector('rux-dialog')
         const btn = document.querySelector('rux-button')
         btn.addEventListener('click', () => {
-          dialog.closeDialog()
+          dialog.hide()
         })
         `,
         })
@@ -313,7 +313,7 @@ test.describe('Methods', () => {
         await btn.click()
         await expect(dialog).not.toHaveAttribute('open', '')
     })
-    test('openDialog method opens a closed dialog', async ({ page }) => {
+    test('show method opens a closed dialog', async ({ page }) => {
         const template = `
     <rux-dialog>
       <div slot="header">Header</div>
@@ -327,7 +327,7 @@ test.describe('Methods', () => {
       const dialog = document.querySelector('rux-dialog')
       const btn = document.querySelector('rux-button')
       btn.addEventListener('click', () => {
-        dialog.openDialog()
+        dialog.show()
       })
       `,
         })

--- a/packages/web-components/src/components/rux-dialog/test/dialog.spec.ts
+++ b/packages/web-components/src/components/rux-dialog/test/dialog.spec.ts
@@ -172,7 +172,7 @@ test.describe(
             const openFalse = document.getElementById('false');
             const ctcTrueModal = document.getElementById('ctc-true')
             const ctcFalseModal = document.getElementById('ctc-false')
-    
+
             openTrue.addEventListener('click', () => {
                 ctcTrueModal.open = true
             })
@@ -238,3 +238,54 @@ test.describe(
         })
     }
 )
+test.describe('toggleOpen method', () => {
+    test('toggleOpen method opens a closed dialog', async ({ page }) => {
+        const template = `
+          <rux-button>Toggle Open</rux-button>
+          <rux-dialog>
+            <div slot="header">Header</div>
+            Body Content
+            <div slot="footer">Footer</div>
+          </rux-dialog>`
+        await page.setContent(template)
+        await page.addScriptTag({
+            content: `
+            const dialog = document.querySelector('rux-dialog')
+            const btn = document.querySelector('rux-button')
+            btn.addEventListener('click', () => {
+              dialog.toggleOpen()
+            })
+            `,
+        })
+        const dialog = page.locator('rux-dialog')
+        const btn = page.locator('rux-button')
+        await expect(dialog).not.toHaveAttribute('open', '')
+        await btn.click()
+        await expect(dialog).toHaveAttribute('open', '')
+    })
+    test('toggleOpen method closes an open dialog', async ({ page }) => {
+        const template = `
+          <rux-dialog open>
+            <div slot="header">Header</div>
+            Body Content
+            <div slot="footer">
+              <rux-button>Close</rux-button>
+            </div>
+          </rux-dialog>`
+        await page.setContent(template)
+        await page.addScriptTag({
+            content: `
+            const dialog = document.querySelector('rux-dialog')
+            const btn = document.querySelector('rux-button')
+            btn.addEventListener('click', () => {
+              dialog.toggleOpen()
+            })
+            `,
+        })
+        const dialog = page.locator('rux-dialog')
+        const btn = page.locator('rux-button')
+        await expect(dialog).toHaveAttribute('open', '')
+        await btn.click()
+        await expect(dialog).not.toHaveAttribute('open', '')
+    })
+})


### PR DESCRIPTION
## Brief Description

This adds a public `toggleOpen` method to rux-dialog that makes the dialog easier to open and close. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-6841

## Related Issue

## General Notes

## Motivation and Context

On FDS we were having a problem where the open prop on dialog would get out of sync, and you had to listen to the closed and opened events in order to toggle the open prop correctly, which can be cumbersome and unintuitive. 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
