### PR TITLE
fix(rux-segmented-button)

### DIFF
--- a/.changeset/plenty-items-breathe.md
+++ b/.changeset/plenty-items-breathe.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+fix(rux-segmented-button) fixed an issue where segmented buttons could not be tabbed between when next to each other

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
@@ -127,6 +127,10 @@ export class RuxSegmentedButton {
         target.closest('li')?.classList.remove('--focused')
     }
 
+    //this random number is appended to <input name="" in order to give each segmented button group a unique name
+    //this allows users to tab between button groups that are adjacent to each other
+    private random = Math.floor(Math.random() * 100000)
+
     render() {
         return (
             <ul
@@ -140,7 +144,7 @@ export class RuxSegmentedButton {
                     <li class="rux-segmented-button__segment">
                         <input
                             type="radio"
-                            name="rux-group"
+                            name={'rux-group' + this.random.toString()}
                             id={this._slugify(item.label)}
                             value={item.label}
                             checked={this._isSelected(item.label)}

--- a/packages/web-components/src/components/rux-segmented-button/test/segmented-button.spec.ts
+++ b/packages/web-components/src/components/rux-segmented-button/test/segmented-button.spec.ts
@@ -137,10 +137,10 @@ test.describe('Segmented-button', () => {
         const segButton2Segment = segmentedButton.locator('li').nth(1)
         const segButton1Input = segButton1Segment.locator('input')
         const segButton2Input = segButton2Segment.locator('input')
-        
+
         // Imperatively set second segment as selected
         await segmentedButton.evaluate((e) => {
-            (e as HTMLRuxSegmentedButtonElement).selected = 'Second segment'
+            ;(e as HTMLRuxSegmentedButtonElement).selected = 'Second segment'
         })
 
         //make sure it changed
@@ -148,10 +148,10 @@ test.describe('Segmented-button', () => {
             (e) => (e as HTMLInputElement).checked === true
         )
         expect(secondChecked).toBe(true)
-                
+
         // Imperatively set first segment as selected
         await segmentedButton.evaluate((e) => {
-            (e as HTMLRuxSegmentedButtonElement).selected = 'First segment'
+            ;(e as HTMLRuxSegmentedButtonElement).selected = 'First segment'
         })
         //and make sure it gets checked
         const firstChecked = await segButton1Input.evaluate(
@@ -159,9 +159,47 @@ test.describe('Segmented-button', () => {
         )
         expect(firstChecked).toBe(true)
     })
+    test('adjacent segmented buttons can be tabbed between', async ({
+        page,
+    }) => {
+        const template = `
+      <div style="padding: 2.5% 5%">
+      <button></button>
+          <rux-segmented-button id="one"></rux-segmented-button>
+          <rux-segmented-button id="two"></rux-segmented-button>
+      </div>
+      `
+        await page.setContent(template)
+        await page.addScriptTag({
+            content: `
+          const segmented1 = document.querySelector('#one')
+          const segmented2 = document.querySelector('#two')
+          const data = [
+              { label: 'First segment' },
+              { label: 'Second segment' },
+              { label: 'Third segment' },
+          ]
+          segmented1.data = data
+          segmented2.data = data
+
+      `,
+        })
+        const button = await page.locator('button')
+        const el1 = await page.locator('#one')
+        const el2 = await page.locator('#two')
+        await button.focus()
+        await page.keyboard.press('Tab')
+        await expect(el1.locator('li').first()).toHaveClass(
+            'rux-segmented-button__segment --focused'
+        )
+        await page.keyboard.press('Tab')
+        await expect(el2.locator('li').first()).toHaveClass(
+            'rux-segmented-button__segment --focused'
+        )
+    })
 })
 /*
-    Need to test: 
+    Need to test:
     -has props data, size, disabled
     - change event
 */


### PR DESCRIPTION
## Brief Description

`rux-segmented-button` is radio group under the hood. Because all of the segmented button groups were named the same thing, there were issues tabbing between them. This fix adds 5 random numbers to the name of the underlying inputs so that when two button sets are next to each other, you can tab between them as expected.

## JIRA Link

[ASTRO-5270](https://rocketcom.atlassian.net/browse/ASTRO-5270)

## Related Issue

## General Notes

## Motivation and Context

This isn't a huge gamebreaking issue.. especially since segmented buttons are suggested only to be used in certain situations. But keyboard controls not functioning as one would expect can be hugely annoying so its worth shoring up anyways.

## Issues and Limitations

Random numbers are generally not a great idea but in this specific instance I think its alright since no one can access the 'name' property on input anyway.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
