### PR TITLE
Mj.timeline playhead interval change

### DIFF
--- a/.changeset/beige-bats-kiss.md
+++ b/.changeset/beige-bats-kiss.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+---
+
+Fixed an issue where timeline's playhead wouldn't update correctly when changing the interval.

--- a/packages/web-components/src/components/rux-timeline/rux-timeline.tsx
+++ b/packages/web-components/src/components/rux-timeline/rux-timeline.tsx
@@ -84,6 +84,7 @@ export class RuxTimeline {
     @Watch('timezone')
     handleChange() {
         this._updateRegions()
+        this.syncPlayhead()
     }
 
     connectedCallback() {


### PR DESCRIPTION
## Brief Description

Fixes a bug where the playhead on timeline wouldn't update accordingly when interval was changed. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-6872

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/1238
## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
