### PR TITLE
docs: add missing timeline changeset

### DIFF
--- a/.changeset/neat-tips-hear.md
+++ b/.changeset/neat-tips-hear.md
@@ -1,0 +1,8 @@
+---
+"angular-workspace": minor
+"@astrouxds/angular": minor
+"@astrouxds/react": minor
+"@astrouxds/astro-web-components": minor
+---
+
+Adds `has-playhead-indicator` prop to timeline which visually marks past time as played in each track


### PR DESCRIPTION
## Brief Description

Adds a changest for the timeline playhead indicator prop. 

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
