### PR TITLE
feat(selcet): reflect value on select

### DIFF
--- a/packages/web-components/src/components/rux-select/rux-select.tsx
+++ b/packages/web-components/src/components/rux-select/rux-select.tsx
@@ -84,7 +84,7 @@ export class RuxSelect implements FormFieldInterface {
     /**
      * The value of the selected option. If multiple is true, this is an array.
      */
-    @Prop({ mutable: true }) value?: string | string[]
+    @Prop({ mutable: true, reflect: true }) value?: string | string[]
 
     /**
      * The help or explanation text
@@ -149,6 +149,7 @@ export class RuxSelect implements FormFieldInterface {
     connectedCallback() {
         this._handleSlotChange = this._handleSlotChange.bind(this)
         this._handleLabelSlotChange = this._handleLabelSlotChange.bind(this)
+        this._initValue()
     }
 
     componentWillLoad() {
@@ -277,6 +278,12 @@ export class RuxSelect implements FormFieldInterface {
             })
         }
         return Promise.resolve()
+    }
+
+    private _initValue() {
+        if (this.value) return
+        const options = this.el.querySelectorAll('rux-option')
+        this.value = options[0].value
     }
 
     private _onChange(e: Event) {

--- a/packages/web-components/src/components/rux-select/test/select.spec.ts
+++ b/packages/web-components/src/components/rux-select/test/select.spec.ts
@@ -83,7 +83,7 @@ test.describe('Select', () => {
                 <rux-option-group label="Group">
                     <rux-option value="flash" label="Flash"></rux-option>
                 </rux-option-group>
-            </rux-select> 
+            </rux-select>
         `
         await page.setContent(template)
 
@@ -152,6 +152,11 @@ test.describe('Select in a form', () => {
                 <rux-option value="blue" label="Blue"></rux-option>
                 <rux-option value="green" label="Green"></rux-option>
             </rux-select>
+            <rux-select id="allValues" label="Best Thing?" name="bestThing">
+            <rux-option label="Red" value="red"></rux-option>
+            <rux-option value="blue" label="Blue"></rux-option>
+            <rux-option value="green" label="Green"></rux-option>
+        </rux-select>
             <rux-select disabled id="disabledSelect" label="Best Thing?" name="disabled" value="red">
                 <rux-option label="Select an option" value=""></rux-option>
                 <rux-option label="Red" value="red"></rux-option>
@@ -189,6 +194,12 @@ test.describe('Select in a form', () => {
     test('it should defalut to the option with no value', async ({ page }) => {
         const el = await page.locator('#ruxSelect')
         await expect(el.locator('select')).toHaveValue('')
+    })
+    test('it should default to the first option if an option with no value is not present', async ({
+        page,
+    }) => {
+        const el = await page.locator('#allValues')
+        await expect(el.locator('select')).toHaveValue('red')
     })
     // Single Select in a form
     test('it should submit the correct value in a form', async ({ page }) => {


### PR DESCRIPTION
## Brief Description

This PR adds a reflect to the value prop of rux-select, as well as an initValue function that runs on connected callback. 
This function selects a the first 'rux-option' as the value if a value is not already defined. 

I ran into an issue using FormData in a vanilla setting where select menu wouldn't have a value if you didn't interact with it. This could mean that form submissions could be incorrect if the dev used a select menu without a 'select an option...' option.

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
