### PR TITLE
feat(timeline): deprecate ruler slot

### DIFF
--- a/.changeset/fuzzy-carrots-watch.md
+++ b/.changeset/fuzzy-carrots-watch.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": minor
+"angular-workspace": minor
+"@astrouxds/angular": minor
+"@astrouxds/react": minor
+---
+
+Timeline - Deprecated "ruler" slot. Ruler is now automatically detected. To migrate, delete any code that contains `slot="ruler"` in your Timeline.

--- a/packages/web-components/src/components/rux-timeline/rux-timeline.tsx
+++ b/packages/web-components/src/components/rux-timeline/rux-timeline.tsx
@@ -11,6 +11,8 @@ import { dateRange } from './helpers'
 import { validateTimezone } from './helpers'
 
 /**
+ * @slot (default) - The Timeline's content
+ * @slot ruler [DEPRECATED] - The Timeline's ruler track
  * @part playhead - The timeline's playhead
  * @part time-region-container - The container for time regions. Use this part to set a maximum height and enable vertical scrolling.
  */
@@ -287,9 +289,30 @@ export class RuxTimeline {
                 el.start = this.start
                 el.end = this.end
                 el.timezone = this.timezone
+
+                const rulers = [...el.children].filter(
+                    (el) => el.tagName.toLowerCase() === 'rux-ruler'
+                ) as HTMLRuxRulerElement[]
+
+                rulers.forEach((rulerEl) => {
+                    validateTimezone(this.timezone).then(() => {
+                        rulerEl.timezone = this.timezone
+                    })
+
+                    rulerEl.start = this.start
+                    rulerEl.end = this.end
+                    rulerEl.interval = this.interval
+                })
             })
         }
 
+        /**
+         * @TODO Ruler slot is deprecated. Remove all of this code someday.
+         * The "ruler" slot didnt offer any value, was verbose, and prevented you
+         * from being able to use multiple rulers or control the placement of the ruler (top/bottom).
+         * We can't remove this code yet because the RuxRuler that is marked as the "ruler" slot won't
+         * show up in the assignedElements of the (default) slot.
+         */
         const rulerSlot = this.rulerContainer?.querySelector(
             'slot'
         ) as HTMLSlotElement

--- a/packages/web-components/src/components/rux-timeline/test/basic/index.html
+++ b/packages/web-components/src/components/rux-timeline/test/basic/index.html
@@ -65,7 +65,7 @@
                     Event 3.1
                 </rux-time-region>
             </rux-track>
-            <rux-track slot="ruler">
+            <rux-track>
                 <rux-ruler></rux-ruler>
             </rux-track>
         </rux-timeline>

--- a/packages/web-components/src/components/rux-timeline/test/index.html
+++ b/packages/web-components/src/components/rux-timeline/test/index.html
@@ -52,7 +52,7 @@
                         >Existing Event</rux-time-region
                     >
                 </rux-track>
-                <rux-track slot="ruler">
+                <rux-track>
                     <rux-ruler></rux-ruler>
                 </rux-track>
             </rux-timeline>

--- a/packages/web-components/src/components/rux-timeline/test/played/index.html
+++ b/packages/web-components/src/components/rux-timeline/test/played/index.html
@@ -66,7 +66,7 @@
                     Event 3.1
                 </rux-time-region>
             </rux-track>
-            <rux-track slot="ruler">
+            <rux-track>
                 <rux-ruler></rux-ruler>
             </rux-track>
         </rux-timeline>

--- a/packages/web-components/src/components/rux-timeline/test/playground.html
+++ b/packages/web-components/src/components/rux-timeline/test/playground.html
@@ -44,7 +44,7 @@
                 <rux-track id="region3">
                     <div slot="label">Region 3</div>
                 </rux-track>
-                <rux-track slot="ruler">
+                <rux-track>
                     <rux-ruler></rux-ruler>
                 </rux-track>
             </rux-timeline>

--- a/packages/web-components/src/components/rux-timeline/test/timeline.spec.ts
+++ b/packages/web-components/src/components/rux-timeline/test/timeline.spec.ts
@@ -10,7 +10,7 @@ test.describe('Timeline DST', () => {
                 end="2023-03-15T00:00:00.000Z" 
                 interval="day" 
             >
-                <rux-track slot="ruler">
+                <rux-track>
                     <rux-ruler></rux-ruler>
                 </rux-track>
             </rux-timeline>  
@@ -53,7 +53,7 @@ test.describe('Timeline', () => {
                         >Existing Event</rux-time-region
                     >
                 </rux-track>
-                <rux-track slot="ruler">
+                <rux-track>
                     <rux-ruler></rux-ruler>
                 </rux-track>
             </rux-timeline>

--- a/packages/web-components/src/stories/timeline.stories.mdx
+++ b/packages/web-components/src/stories/timeline.stories.mdx
@@ -273,7 +273,7 @@ export const Default = (args) => {
                         Event 7.1
                     </rux-time-region>
                 </rux-track>
-                <rux-track slot="ruler">
+                <rux-track>
                     <rux-ruler></rux-ruler>
                 </rux-track>
             </rux-timeline>
@@ -354,15 +354,7 @@ To add any number of Time Regions, you can simply add them as children to any Tr
 </rux-track>
 ```
 
-### Enabling the Ruler
 
-To enable the bottom ruler, make use of the `ruler` slot by passing in a `rux-ruler` within a `rux-track`:
-
-```
-<rux-track slot="ruler">
-  <rux-ruler></rux-ruler>
-</rux-track>
-```
 
 ### Enabling Vertical Scrolling
 
@@ -427,7 +419,7 @@ export const VerticalScroll = (args) => {
                         Event 7.1
                     </rux-time-region>
                 </rux-track>
-                <rux-track slot="ruler">
+                <rux-track>
                     <rux-ruler></rux-ruler>
                 </rux-track>
             </rux-timeline>
@@ -489,9 +481,50 @@ If a Time Region's start and end date falls outside of the range of the Timeline
 
 **Ruler** is responsible for displaying the intervals of time across the timeline grid.
 
+### Enabling the Ruler
+
+To enable the ruler, use the `rux-ruler` component inside a `rux-track`.
+
 ```
-    <rux-ruler></rux-ruler>
+<rux-track>
+  <rux-ruler></rux-ruler>
+</rux-track>
 ```
+
+The ruler will be positioned based on the location of it's track in the DOM. For example, if you 
+wanted the ruler to be placed at the top of your timeline instead of the bottom, have your first Track contain the Ruler.
+
+export const TopRuler = (args) => {
+    return html`
+        <style>
+            rux-timeline::part(time-region-container) {
+                height: 223px;
+            }
+        </style>
+        <div style="width: 950px; margin: auto">
+            <rux-timeline start="2021-02-01T00:00:00Z" end="2021-02-03T00:00:00Z" interval="hour" zoom="2">
+                <rux-track>
+                    <rux-ruler></rux-ruler>
+                </rux-track>
+                <rux-track>
+                    <div slot="label">Region 1</div>
+                    <rux-time-region start="2021-02-01T01:00:00Z" end="2021-02-01T02:00:00Z" status="serious">
+                        Event 1.2
+                    </rux-time-region>
+                </rux-track>
+                
+            </rux-timeline>
+        </div>
+    `
+}
+
+<Canvas>
+    <Story
+        name="Top Ruler"
+    >
+        {TopRuler.bind()}
+    </Story>
+</Canvas>
 
 ## Sub Tracks
 
@@ -588,7 +621,7 @@ export const WithPlayedIndicator = (args) => {
                         Event 7.1
                     </rux-time-region>
                 </rux-track>
-                <rux-track slot="ruler">
+                <rux-track>
                     <rux-ruler></rux-ruler>
                 </rux-track>
             </rux-timeline>


### PR DESCRIPTION
## Brief Description

Deprecated `ruler` slot. Now you can have rulers at the top or bottom, middle, both, whatever you desire.

## Motivation and Context

Long requested feature, also dependency for additional features

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
