### PR TITLE
fix(timeline): fixed issue with Nov DST

### DIFF
--- a/.changeset/funny-hotels-hear.md
+++ b/.changeset/funny-hotels-hear.md
@@ -1,0 +1,8 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"@astrouxds/react": patch
+---
+
+Fixed an issue where timeline would display events incorrectly when the events spanned over daylight savings time

--- a/packages/web-components/src/components/rux-timeline/helpers.ts
+++ b/packages/web-components/src/components/rux-timeline/helpers.ts
@@ -29,9 +29,6 @@ function agnosticAddDays(date: Date, amount: number) {
 
     const dstDiff = originalTZO - endTZO
 
-    dstDiff >= 0
-        ? console.log(addMinutes(endDate, dstDiff), 'dstDiff addMin')
-        : console.log(subMinutes(endDate, Math.abs(dstDiff)), 'dstDiff subMin')
     return dstDiff >= 0
         ? addMinutes(endDate, dstDiff)
         : subMinutes(endDate, Math.abs(dstDiff))

--- a/packages/web-components/src/components/rux-timeline/helpers.ts
+++ b/packages/web-components/src/components/rux-timeline/helpers.ts
@@ -4,7 +4,6 @@ import {
     addDays,
     addMinutes,
     subMinutes,
-    differenceInDays,
 } from 'date-fns'
 import { formatInTimeZone } from 'date-fns-tz'
 
@@ -23,12 +22,16 @@ export async function validateTimezone(timezone: string) {
 // https://github.com/date-fns/date-fns/issues/571
 
 function agnosticAddDays(date: Date, amount: number) {
+    console.log('run aAD')
     const originalTZO = date.getTimezoneOffset()
     const endDate = addDays(date, amount)
     const endTZO = endDate.getTimezoneOffset()
 
     const dstDiff = originalTZO - endTZO
 
+    dstDiff >= 0
+        ? console.log(addMinutes(endDate, dstDiff), 'dstDiff addMin')
+        : console.log(subMinutes(endDate, Math.abs(dstDiff)), 'dstDiff subMin')
     return dstDiff >= 0
         ? addMinutes(endDate, dstDiff)
         : subMinutes(endDate, Math.abs(dstDiff))
@@ -50,7 +53,9 @@ export function dateRange(
     }
 
     if (interval === 'day') {
-        const days = differenceInDays(endDate, startDate)
+        //differenceInHours used here to avoid DST issues
+        //https://github.com/date-fns/date-fns/blob/main/src/differenceInDays/index.ts#L17C2-L17C2
+        const days = Math.floor(differenceInHours(endDate, startDate) / 24) | 0
 
         const output = [...Array(days).keys()].map((i) => {
             const time = agnosticAddDays(startDate, i)
@@ -64,6 +69,7 @@ export function dateRange(
 
     if (interval === 'hour') {
         let days = differenceInHours(endDate, startDate)
+
         days = days / intervalValue
 
         const output = [...Array(days).keys()].map((i) => {

--- a/packages/web-components/src/components/rux-timeline/helpers.ts
+++ b/packages/web-components/src/components/rux-timeline/helpers.ts
@@ -22,7 +22,6 @@ export async function validateTimezone(timezone: string) {
 // https://github.com/date-fns/date-fns/issues/571
 
 function agnosticAddDays(date: Date, amount: number) {
-    console.log('run aAD')
     const originalTZO = date.getTimezoneOffset()
     const endDate = addDays(date, amount)
     const endTZO = endDate.getTimezoneOffset()

--- a/packages/web-components/src/components/rux-timeline/test/timeline.spec.ts
+++ b/packages/web-components/src/components/rux-timeline/test/timeline.spec.ts
@@ -2,18 +2,18 @@ import { test, expect } from '../../../../tests/utils/_astro-fixtures'
 // import { test } from "stencil-playwright";
 // import { expect } from "@playwright/test";
 test.describe('Timeline DST', () => {
-    test('it should handle DST in UTC', async ({ page }) => {
+    test('it should handle DST start in UTC', async ({ page }) => {
         const template = `
-            <rux-timeline 
-                timezone="UTC" 
-                start="2023-03-11T00:00:00.000Z" 
-                end="2023-03-15T00:00:00.000Z" 
-                interval="day" 
+            <rux-timeline
+                timezone="UTC"
+                start="2023-03-11T00:00:00.000Z"
+                end="2023-03-15T00:00:00.000Z"
+                interval="day"
             >
                 <rux-track slot="ruler">
                     <rux-ruler></rux-ruler>
                 </rux-track>
-            </rux-timeline>  
+            </rux-timeline>
         `
         await page.setContent(template)
         const rulerEl = await page.locator('rux-ruler')
@@ -27,6 +27,32 @@ test.describe('Timeline DST', () => {
             }
         })
         expect(days).toEqual(['03/11', '03/12', '03/13', '03/14'])
+    })
+    test('it should handle DST end in UTC', async ({ page }) => {
+        const template = `
+          <rux-timeline
+              timezone="UTC"
+              start="2023-11-04T00:00:00.000Z"
+              end="2023-11-08T00:00:00.000Z"
+              interval="day"
+          >
+              <rux-track slot="ruler">
+                  <rux-ruler></rux-ruler>
+              </rux-track>
+          </rux-timeline>
+      `
+        await page.setContent(template)
+        const rulerEl = await page.locator('rux-ruler')
+
+        const days = await rulerEl.evaluate((el) => {
+            const rulerSpans = el.shadowRoot?.querySelectorAll('span')
+            if (rulerSpans) {
+                return [...rulerSpans].map((e) => e.innerHTML)
+            } else {
+                return []
+            }
+        })
+        expect(days).toEqual(['11/04', '11/05', '11/06', '11/07'])
     })
 })
 test.describe('Timeline', () => {


### PR DESCRIPTION
## Brief Description

Fixes an issue where a range spanning over Nov 5th would cause issues on how the timeline displayed. 

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

https://github.com/RocketCommunicationsInc/astro/issues/1258
https://github.com/RocketCommunicationsInc/astro/issues/1101

## General Notes

Solution was pulled from https://github.com/date-fns/date-fns/blob/main/src/differenceInDays/index.ts#L17C2-L17C2

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
