### PR TITLE
Km.6882 add keyboard control tooltip

### DIFF
--- a/.changeset/rich-cherries-hunt.md
+++ b/.changeset/rich-cherries-hunt.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+Tooltip - allow pressing escape to close the tooltip

--- a/packages/web-components/src/components/rux-tooltip/rux-tooltip.tsx
+++ b/packages/web-components/src/components/rux-tooltip/rux-tooltip.tsx
@@ -9,6 +9,7 @@ import {
     Watch,
     Method,
     State,
+    Listen,
 } from '@stencil/core'
 import {
     computePosition,
@@ -112,6 +113,17 @@ export class RuxTooltip {
     @Watch('placement')
     handlePlacement() {
         this._startPositioner()
+    }
+
+    @Listen('keydown', { target: 'document' })
+    handleKeypress(e: KeyboardEvent) {
+        if (e.key !== 'Escape') return
+        const hovered = this.trigger.matches(':hover')
+        const focused = this.triggerSlot.contains(document.activeElement)
+        if (!hovered && !focused) return
+        if (this.open) {
+            this.hide()
+        }
     }
 
     /**

--- a/packages/web-components/src/components/rux-tooltip/test/tooltip.spec.ts
+++ b/packages/web-components/src/components/rux-tooltip/test/tooltip.spec.ts
@@ -326,6 +326,7 @@ test.describe('Tooltip', async () => {
 
         //act
         await trigger.focus()
+        await expect(trigger).toBeFocused()
         await page.keyboard.press('Escape')
 
         //assert

--- a/packages/web-components/src/components/rux-tooltip/test/tooltip.spec.ts
+++ b/packages/web-components/src/components/rux-tooltip/test/tooltip.spec.ts
@@ -304,4 +304,32 @@ test.describe('Tooltip', async () => {
         //assert
         await expect(ruxTooltip).toHaveAttribute('open', '')
     })
+
+    test('on esc tooltip closes', async ({ page }) => {
+        const template = `
+              <rux-tooltip message="This is the tooltip" open>
+                <rux-button id="trigger">Trigger</rux-button>
+              </rux-tooltip>
+              `
+        await page.setContent(template)
+
+        //arrange
+        const trigger = page.locator('#trigger')
+        const ruxtooltip = page.locator('rux-tooltip')
+        await expect(ruxtooltip).toHaveAttribute('open', '')
+
+        //act
+        await page.keyboard.press('Escape')
+
+        //assert
+        await expect(ruxtooltip).toHaveAttribute('open', '')
+
+        //act
+        await trigger.focus()
+        await page.keyboard.press('Escape')
+
+        //assert
+        const open = await ruxtooltip.getAttribute('open')
+        expect(open).toBeNull()
+    })
 })


### PR DESCRIPTION
## Brief Description

Added an escape key listener that will close a tooltip if the tooltip trigger is either hovered or focused. If it is neither the escape key won't act on it.

## JIRA Link

[ASTRO-6882](https://rocketcom.atlassian.net/browse/ASTRO-6882)

## Related Issue

## General Notes

## Motivation and Context

Cory (from Shoelace) mentioned that tooltips should have ability to close without moving the mouse or unfocusing. Seemed like a good idea.

## Issues and Limitations

Make sure this is the functionality we want. I could remove the if statements in the listener and have all tooltips close whenever escape is pressed. That would also be valid. This is just more specific.

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [x] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
