### PR TITLE
Astro-6883 Fix reference error

### DIFF
--- a/.changeset/calm-mugs-fly.md
+++ b/.changeset/calm-mugs-fly.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+fix: rux-pop-up resolve console log error

--- a/packages/web-components/src/components/rux-pop-up/rux-pop-up.tsx
+++ b/packages/web-components/src/components/rux-pop-up/rux-pop-up.tsx
@@ -233,6 +233,8 @@ export class RuxPopUp {
         const triggerEl = this.el.querySelector(
             `[slot='trigger']`
         ) as HTMLElement
+        //if there is no trigger then there is nothing to set
+        if (!triggerEl) return
         triggerEl.hasAttribute('tabindex')
             ? null
             : triggerEl.setAttribute('tabindex', '0')


### PR DESCRIPTION
## Brief Description

This fixes an attribute error in the console log if popup doesn't have a trigger.

## JIRA Link

[6883](https://rocketcom.atlassian.net/jira/software/c/projects/ASTRO/issues/ASTRO-6883)

## Related Issue

## General Notes

## Motivation and Context

I saw an instance in a recent project where the popup was being used without a trigger and one of the functions was causing it to throw an error. I fixed that function.

## Issues and Limitations

There are other errors that are thrown if you try to use popup without a slotted trigger.. but those would take more logic to solve.. might be worth future consideration though as technically you can programmatically show/hide a popup so it doesn't need a trigger for anything other than autopositioning.

I didn't work up a fix for that right now because it would likely be a major change.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
