### PR TITLE
fix(timeline): playhead no longer throws error when undefined

### DIFF
--- a/packages/web-components/src/components/rux-timeline/rux-timeline.tsx
+++ b/packages/web-components/src/components/rux-timeline/rux-timeline.tsx
@@ -211,15 +211,17 @@ export class RuxTimeline {
      * Give it a time, get where it should be positioned visually (in pixels)
      */
     private _calculatePlayheadFromTime(time: any) {
-        if (
-            new Date(time) < new Date(this.start) ||
-            new Date(time) > new Date(this.end)
-        ) {
-            throw new RangeError(
-                `Playhead date must be between ${new Date(
-                    this.start
-                ).toISOString()} - ${new Date(this.end).toISOString()}`
-            )
+        if (time) {
+            if (
+                new Date(time) < new Date(this.start) ||
+                new Date(time) > new Date(this.end)
+            ) {
+                throw new RangeError(
+                    `Playhead date must be between ${new Date(
+                        this.start
+                    ).toISOString()} - ${new Date(this.end).toISOString()}`
+                )
+            }
         }
 
         let newTime = Math.abs(

--- a/packages/web-components/src/components/rux-timeline/rux-timeline.tsx
+++ b/packages/web-components/src/components/rux-timeline/rux-timeline.tsx
@@ -216,7 +216,7 @@ export class RuxTimeline {
                 new Date(time) < new Date(this.start) ||
                 new Date(time) > new Date(this.end)
             ) {
-                throw new RangeError(
+                console.warn(
                     `Playhead date must be between ${new Date(
                         this.start
                     ).toISOString()} - ${new Date(this.end).toISOString()}`


### PR DESCRIPTION
## Brief Description

Timeline was throwing a playhead range error even when setting the playhead to `undefined`. 
This adds a check before throwing the error to ensure that the playhead is assigned an actual date that could be incorrect. 

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/1284
## General Notes

## Motivation and Context

Removes a console error that shouldn't be thrown. 

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
