### PR TITLE
docs(card): add missing footer slot to docs

### DIFF
--- a/.changeset/swift-pans-chew.md
+++ b/.changeset/swift-pans-chew.md
@@ -1,0 +1,11 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-angular": patch
+"astro-react": patch
+"astro-vue": patch
+"@astrouxds/react": patch
+---
+
+Added missing footer slot documentation to storybook

--- a/packages/web-components/src/components/rux-card/readme.md
+++ b/packages/web-components/src/components/rux-card/readme.md
@@ -10,6 +10,7 @@
 | Slot          | Description        |
 | ------------- | ------------------ |
 | `"(default)"` | The card's content |
+| `"footer"`    | The cards footer   |
 | `"header"`    | The card's header  |
 
 

--- a/packages/web-components/src/components/rux-card/rux-card.tsx
+++ b/packages/web-components/src/components/rux-card/rux-card.tsx
@@ -1,8 +1,10 @@
-import { State, Element, Component, Host, h } from '@stencil/core'
+import { Component, Element, Host, State, h } from '@stencil/core'
+
 import { hasSlot } from '../../utils/utils'
 /**
  * @slot (default) - The card's content
  * @slot header - The card's header
+ * @slot footer - The cards footer
  * @part container - The card's outtermost container
  * @part header - The card's outside header element
  * @part body - The card's outside body element


### PR DESCRIPTION
## Brief Description

Card was missing it's footer slot documentation on Storybook. 

## JIRA Link

https://rocketcom.atlassian.net/jira/software/projects/DIW/boards/95

## Related Issue

## General Notes

## Motivation and Context

Better, more accurate docs. 

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
