### PR TITLE
fix(button): icon-only borderless bug

### DIFF
--- a/.changeset/slow-schools-grow.md
+++ b/.changeset/slow-schools-grow.md
@@ -1,0 +1,11 @@
+---
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"@astrouxds/angular": patch
+"astro-angular": patch
+"astro-react": patch
+"astro-vue": patch
+"@astrouxds/react": patch
+---
+
+Fixed button bug when clicking and dragging over an icon-only, borderless button

--- a/packages/web-components/src/components/rux-button/rux-button.scss
+++ b/packages/web-components/src/components/rux-button/rux-button.scss
@@ -116,6 +116,7 @@
             ::slotted(rux-icon) {
                 color: var(--color-background-interactive-default);
             }
+            background: none;
         }
         rux-icon,
         ::slotted(rux-icon) {


### PR DESCRIPTION
## Brief Description

Fixes an issue where clicking and dragging an icon-only, borderless button would show the background. 

## JIRA Link

https://rocketcom.atlassian.net/browse/DIW-138

## Related Issue
https://github.com/RocketCommunicationsInc/astro/issues/1320
## General Notes

## Motivation and Context

Fixes style bug.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
