### PR TITLE
Fix(storybook): Fixing actions logging for components

### DIFF
--- a/.changeset/moody-cars-lie.md
+++ b/.changeset/moody-cars-lie.md
@@ -1,5 +1,0 @@
----
-"@astrouxds/astro-web-components": patch
----
-
-Storybook actions fix.

--- a/.changeset/moody-cars-lie.md
+++ b/.changeset/moody-cars-lie.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+Storybook actions fix.

--- a/packages/web-components/src/stories/accordion-item.stories.js
+++ b/packages/web-components/src/stories/accordion-item.stories.js
@@ -1,5 +1,6 @@
 import { html } from 'lit-html'
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil'
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -33,21 +34,16 @@ const IconSlotted = (args) => {
 export default {
     title: 'Components/Accordion/Accordion Item',
     component: 'rux-accordion-item',
-
-    subcomponents: {
-        RuxAccordion: 'rux-accordion',
-    },
-
     argTypes: extractArgTypes('rux-accordion-item'),
-
     parameters: {
         actions: {
             handles: [
-                'ruxexpanded rux-accordion-item',
-                'ruxcollapsed rux-accordion-item',
+                'ruxexpanded',
+                'ruxcollapsed',
             ],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/accordion.stories.js
+++ b/packages/web-components/src/stories/accordion.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil'
 import { html } from 'lit-html'
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -82,13 +83,10 @@ const TruncateExample = (args) => {
 export default {
     title: 'Components/Accordion',
     component: 'rux-accordion',
-
     subcomponents: {
         RuxAccordionItem: 'rux-accordion-item',
     },
-
     argTypes: extractArgTypes('rux-accordion'),
-
     parameters: {
         actions: {
             handles: [
@@ -97,6 +95,7 @@ export default {
             ],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/breadcrumb-item.stories.js
+++ b/packages/web-components/src/stories/breadcrumb-item.stories.js
@@ -35,11 +35,6 @@ const IconOnly = (args) => {
 export default {
     title: 'Components/Breadcrumb/Breadcrumb Item',
     component: 'rux-breadcrumb-item',
-
-    subcomponents: {
-        RuxBreadcrumb: 'rux-breadcrumb',
-    },
-
     argTypes: extractArgTypes('rux-breadcrumb-item'),
 }
 

--- a/packages/web-components/src/stories/button.stories.js
+++ b/packages/web-components/src/stories/button.stories.js
@@ -250,11 +250,6 @@ const WithAllVariants = () => {
 export default {
     title: 'Components/Button',
     component: 'rux-button',
-
-    subcomponents: {
-        RuxButtonGroup: 'rux-button-group',
-    },
-
     argTypes: extractArgTypes('rux-button'),
 }
 

--- a/packages/web-components/src/stories/checkbox-group.stories.js
+++ b/packages/web-components/src/stories/checkbox-group.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil'
-import { html, render } from 'lit-html'
+import { html } from 'lit-html'
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -54,6 +55,17 @@ export default {
     },
 
     argTypes: extractArgTypes('rux-checkbox-group'),
+    parameters: {
+      actions: {
+          handles: [
+              'ruxchange rux-checkbox',
+              'ruxinput rux-checkbox',
+              'ruxblur rux-checkbox',
+              'ruxfocus rux-checkbox',
+          ],
+      },
+  },
+  decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/checkbox.stories.js
+++ b/packages/web-components/src/stories/checkbox.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
 import { html } from 'lit-html';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -20,20 +21,17 @@ export default {
     title: 'Forms/Checkbox',
     component: 'rux-checkbox',
     argTypes: extractArgTypes('rux-checkbox'),
-
-    subcomponents: {
-        RuxCheckboxGroup: 'rux-checkbox-group',
-    },
-
     parameters: {
         actions: {
             handles: [
                 'ruxchange rux-checkbox',
                 'ruxinput rux-checkbox',
                 'ruxblur rux-checkbox',
+                'ruxfocus rux-checkbox',
             ],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/dialog.stories.js
+++ b/packages/web-components/src/stories/dialog.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil'
 import { html } from 'lit-html'
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -60,11 +61,12 @@ export default {
     parameters: {
         actions: {
             handles: [
-                'ruxdialogclosed rux-dialog',
-                'ruxdialogopened rux-dialog',
+                'ruxdialogclosed',
+                'ruxdialogopened',
             ],
         },
     },
+    decorators: [withActions],
 }
 
 export const Dialog = {

--- a/packages/web-components/src/stories/input.stories.js
+++ b/packages/web-components/src/stories/input.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil'
 import { html } from 'lit-html'
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -304,6 +305,7 @@ export default {
             ],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/menu-item-divider.stories.js
+++ b/packages/web-components/src/stories/menu-item-divider.stories.js
@@ -8,11 +8,6 @@ const Base = (args) => {
 export default {
     title: 'Components/Pop Up/Menu Item Divider',
     component: 'rux-menu-item-divider',
-
-    subcomponents: {
-        RuxPopUp: 'rux-pop-up',
-    },
-
     argTypes: extractArgTypes('rux-menu-item-divider'),
 }
 

--- a/packages/web-components/src/stories/menu-item.stories.js
+++ b/packages/web-components/src/stories/menu-item.stories.js
@@ -18,12 +18,6 @@ const Base = (args) => {
 export default {
     title: 'Components/Pop Up/Menu Item',
     component: 'rux-menu-item',
-
-    subcomponents: {
-        RuxPopUp: 'rux-pop-up',
-        RuxMenu: 'rux-menu',
-    },
-
     argTypes: extractArgTypes('rux-menu-item'),
 }
 

--- a/packages/web-components/src/stories/menu.stories.js
+++ b/packages/web-components/src/stories/menu.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
 import { html } from 'lit-html';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = () => {
     return html`
@@ -16,7 +17,6 @@ export default {
     component: 'rux-menu',
 
     subcomponents: {
-        RuxPopUp: 'rux-pop-up',
         RuxMenuItem: 'rux-menu-item',
         RuxMenuItemDivider: 'rux-menu-item-divider',
     },
@@ -28,6 +28,7 @@ export default {
             handles: ['ruxmenuselected', 'rux-menu'],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/notification.stories.js
+++ b/packages/web-components/src/stories/notification.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil'
 import { html } from 'lit-html'
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -232,6 +233,7 @@ export default {
             handles: ['ruxclosed rux-notification'],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/option-group.mdx
+++ b/packages/web-components/src/stories/option-group.mdx
@@ -1,0 +1,33 @@
+import { Meta, Story, Canvas, Controls } from '@storybook/blocks';
+import * as OptionGroupStories from './option-group.stories';
+
+<Meta of={OptionGroupStories} />
+
+# Option
+
+Option Group belongs to the Select Menu Component
+
+## Guidelines
+
+* [Astro UXDS: Select Menu](https://astrouxds.com/components/select/)
+* [Astro UXDS: Form and Input Validation](https://www.astrouxds.com/ui-components/validation)
+
+<Canvas of={OptionGroupStories.Default} />
+
+## API
+
+<Controls />
+
+## Usage
+
+For Grouping, make sure to use the Astro `<rux-option-group>` component instead of the native `<optgroup>`.
+
+## Cherry Picking
+
+If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
+
+```js
+import { RuxOptionGroup } from '@astrouxds/astro-web-components/dist/components/rux-option-group'
+
+customElements.define('rux-option-group', RuxOptionGroup)
+```

--- a/packages/web-components/src/stories/option-group.stories.js
+++ b/packages/web-components/src/stories/option-group.stories.js
@@ -1,0 +1,39 @@
+import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
+import { html } from 'lit-html';
+
+const Base = (args) => {
+    return html`
+        <div style="width: 200px; margin: 0 auto;">
+          <rux-option-group label="Group one" style="background: transparent">
+              <rux-option value="1.1" label="Option 1.1"></rux-option>
+              <rux-option value="1.2" label="Option 1.2"></rux-option>
+              <rux-option value="1.3" label="Option 1.3"></rux-option>
+              <rux-option value="1.4" label="Option 1.4"></rux-option>
+          </rux-option-group>
+        </div>
+    `
+}
+
+export default {
+    title: 'Forms/Select Menu/Option Group',
+    component: 'rux-option-group',
+    argTypes: extractArgTypes('rux-option-group'),
+}
+
+export const Default = {
+    render: Base.bind(),
+
+    args: {
+        label: 'Group 1',
+    },
+
+    argTypes: {
+        value: {
+            table: {
+                disable: true,
+            },
+        },
+    },
+
+    name: 'Option-Group',
+}

--- a/packages/web-components/src/stories/option.mdx
+++ b/packages/web-components/src/stories/option.mdx
@@ -1,0 +1,41 @@
+import { Meta, Story, Canvas, Controls } from '@storybook/blocks';
+import * as OptionStories from './option.stories';
+
+<Meta of={OptionStories} />
+
+# Option
+
+Option belongs to the Select Menu Component
+
+## Guidelines
+
+* [Astro UXDS: Select Menu](https://astrouxds.com/components/select/)
+* [Astro UXDS: Form and Input Validation](https://www.astrouxds.com/ui-components/validation)
+
+<Canvas of={OptionStories.Default} />
+
+## API
+
+<Controls />
+
+## Usage
+
+> Select **requires** the use of the `<rux-option>` component instead of the native `<option>`. Make sure to set the label using the `label` property instead of a slot like you would with the native `<option>`
+
+### Selecting Options
+
+The `value` property will sync the currently selected option value property
+
+### Grouping
+
+For Grouping, make sure to use the Astro `<rux-option-group>` component instead of the native `<optgroup>`.
+
+## Cherry Picking
+
+If you're already utilizing a build system that supports tree shaking and want to only import this individual component:
+
+```js
+import { RuxOption } from '@astrouxds/astro-web-components/dist/components/rux-option'
+
+customElements.define('rux-option', RuxOption)
+```

--- a/packages/web-components/src/stories/option.stories.js
+++ b/packages/web-components/src/stories/option.stories.js
@@ -1,0 +1,39 @@
+import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
+import { html } from 'lit-html';
+
+const Base = (args) => {
+    return html`
+        <div style="width: 200px; margin: 0 auto;">
+                <rux-option
+                    value=""
+                    selected
+                    label="Select an option"
+                ></rux-option>
+        </div>
+    `
+}
+
+export default {
+    title: 'Forms/Select Menu/Option',
+    component: 'rux-option',
+    argTypes: extractArgTypes('rux-option'),
+}
+
+export const Default = {
+    render: Base.bind(),
+
+    args: {
+        disabled: false,
+        label: 'Option 1',
+    },
+
+    argTypes: {
+        value: {
+            table: {
+                disable: true,
+            },
+        },
+    },
+
+    name: 'Option',
+}

--- a/packages/web-components/src/stories/popup.stories.js
+++ b/packages/web-components/src/stories/popup.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
 import { html } from 'lit-html';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -85,6 +86,7 @@ export default {
             handles: ['ruxpopupopened rux-pop-up', 'ruxpopupclosed rux-pop-up'],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/push-button.stories.js
+++ b/packages/web-components/src/stories/push-button.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
 import { html } from 'lit-html';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -147,6 +148,7 @@ export default {
             handles: ['ruxchange rux-push-button', 'ruxblur rux-push-button'],
         },
     },
+    decorators: [withActions],
 }
 
 export const PushButton = {

--- a/packages/web-components/src/stories/radio-group.stories.js
+++ b/packages/web-components/src/stories/radio-group.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
 import { html } from 'lit-html';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -61,6 +62,7 @@ export default {
             handles: ['ruxchange rux-radio-group'],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/radio.stories.js
+++ b/packages/web-components/src/stories/radio.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
 import { html } from 'lit-html';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -27,9 +28,10 @@ export default {
 
     parameters: {
         actions: {
-            handles: ['ruxchange rux-radio', 'ruxblur rux-radio'],
+            handles: ['ruxblur rux-radio'],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/segmented-button.stories.js
+++ b/packages/web-components/src/stories/segmented-button.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil'
 import { html } from 'lit-html'
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     document.addEventListener('change', (e) => action('change')(e.target))
@@ -25,6 +26,7 @@ export default {
             handles: ['ruxchange rux-segmented-button'],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/select.stories.js
+++ b/packages/web-components/src/stories/select.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
 import { html } from 'lit-html';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -254,6 +255,7 @@ export default {
             handles: ['ruxchange rux-select', 'ruxblur rux-select'],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/slider.stories.js
+++ b/packages/web-components/src/stories/slider.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
 import { html } from 'lit-html';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -86,6 +87,7 @@ export default {
             ],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/switch.stories.js
+++ b/packages/web-components/src/stories/switch.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
 import { html } from 'lit-html';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -29,6 +30,7 @@ export default {
             ],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/tab.stories.js
+++ b/packages/web-components/src/stories/tab.stories.js
@@ -30,11 +30,6 @@ const ActionsExample = (args) => {
 export default {
     title: 'Components/Tabs/Tab',
     component: 'rux-tab',
-
-    subcomponents: {
-        'Rux Tabs': 'rux-tabs',
-    },
-
     argTypes: extractArgTypes('rux-tab'),
 }
 

--- a/packages/web-components/src/stories/tabs.stories.js
+++ b/packages/web-components/src/stories/tabs.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
 import { html } from 'lit-html';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -94,6 +95,7 @@ export default {
             handles: ['ruxselected rux-tabs'],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/textarea.stories.js
+++ b/packages/web-components/src/stories/textarea.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
 import { html } from 'lit-html';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -68,6 +69,7 @@ export default {
             ],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/toast.stories.js
+++ b/packages/web-components/src/stories/toast.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
 import { html } from 'lit-html';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -59,18 +60,13 @@ const AllVariantsExample = () => html`
 export default {
     title: 'Beta/Toast [BETA]',
     component: 'rux-toast',
-
-    subcomponents: {
-        RuxToastStack: 'rux-toast-stack',
-    },
-
     argTypes: extractArgTypes('rux-toast'),
-
     parameters: {
         actions: {
             handles: ['ruxtoastopen rux-toast', 'ruxtoastclosed rux-toast'],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/tooltip.stories.js
+++ b/packages/web-components/src/stories/tooltip.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil'
 import { html } from 'lit-html'
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -115,6 +116,7 @@ export default {
             ],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/tree-node.stories.js
+++ b/packages/web-components/src/stories/tree-node.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil'
 import { html } from 'lit-html'
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = (args) => {
     return html`
@@ -36,6 +37,7 @@ export default {
             handles: ['ruxtreenodeselected rux-tree-node'],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {

--- a/packages/web-components/src/stories/tree.stories.js
+++ b/packages/web-components/src/stories/tree.stories.js
@@ -1,5 +1,6 @@
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil'
 import { html } from 'lit-html'
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const Base = () => {
     const treeData = [
@@ -310,6 +311,7 @@ export default {
             ],
         },
     },
+    decorators: [withActions],
 }
 
 export const Default = {


### PR DESCRIPTION
## Brief Description

This PR fixes an issue in Storybook where actions were not being logged out in the actions panel. After upgrading to Storybook 8, I had missed that the way we have actions configured in each individual story needed an extra decorator to properly catch and log component events.

I also noticed that Storybook did not have actual pages for `rux-option` and `rux-option-group`. These have been added.

## JIRA Link

[AP-330](https://rocketcom.atlassian.net/browse/AP-330)

## Related Issue

## General Notes

## Motivation and Context

Fixes the issue in Storybook where component events were not being logged in the actions panel.

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
