### PR TITLE
fix(timeline): correcting background color of rux-ruler to a token.

### DIFF
--- a/.changeset/smooth-walls-exist.md
+++ b/.changeset/smooth-walls-exist.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/astro-web-components": patch
+---
+
+Correcting background value of rux-ruler to be a token so it works in light and dark themes.

--- a/packages/web-components/src/components/rux-timeline/rux-ruler/rux-ruler.scss
+++ b/packages/web-components/src/components/rux-timeline/rux-ruler/rux-ruler.scss
@@ -9,7 +9,7 @@
 .ruler-time {
     display: flex;
     padding: var(--spacing-2);
-    background: #2c3d4d;
+    background: var(--color-background-surface-header);
     border-right: 1px solid var(--color-background-surface-default);
 }
 


### PR DESCRIPTION
## Brief Description

This fix is for an [issue raised](https://github.com/RocketCommunicationsInc/astro/issues/1367) where the background of the `rux-ruler` in the `rux-timeline` component is hardcoded instead of linked to a design token, so the UI is less than ideal when swapped to light theme.

## JIRA Link

[AP-334](https://rocketcom.atlassian.net/browse/AP-334)

## Related Issue

## General Notes

## Motivation and Context

Component values need to be linked back to a token in order for light and dark theme to work properly.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
