### PR TITLE
set up weekly checks for npm and GitHub actions - ignore patch level for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm" # TypeScript, JavaScript, and other Node.js dependencies
+    directory: "/" # Location of the package manifests
+    schedule:
+      interval: "weekly" # Run once a week
+    ignore:
+      - dependency-name: "*" # All dependencies
+        update-types: ["version-update:semver-patch"] # Ignore patch updates
+  - package-ecosystem: "github-actions" # GitHub Actions dependencies
+    directory: "/" # Location of the GitHub Actions workflows
+    schedule:
+      interval: "weekly" # Run once a week


### PR DESCRIPTION
## Brief Description

I didn't find the controls I was expecting through the GitHub GUI so this file sets up weekly dependabot runs for NPM and GitHub Actions

## JIRA Link

I'm off script here 

## Related Issue

Follow up to this card:
https://rocketcom.atlassian.net/browse/AP-354

## General Notes

If someone else has better knowledge of dependabot and knows it is working like we want this can be closed. 

## Motivation and Context

A dependabot.yml file is self documenting so any developer can sort out what to expect from dependabot without high level access to the repository

## Issues and Limitations

## Types of changes

- [ ] Developer feature

