### PR TITLE
replace unpkg with jsdeliver in quick start instructions

### DIFF
--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -13,7 +13,6 @@ To get up and running quickly, Astro web components are available via a CDN. Add
 <link
     rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
-   
 />
 <script
     type="module"

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -12,11 +12,12 @@ To get up and running quickly, Astro web components are available via a CDN. Add
 />
 <link
     rel="stylesheet"
-    href="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
+      href="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
+   
 />
 <script
     type="module"
-    src="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
+    src="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
 ></script>
 ```
 

--- a/packages/web-components/src/stories/astro-uxds/StartHere.mdx
+++ b/packages/web-components/src/stories/astro-uxds/StartHere.mdx
@@ -21,11 +21,11 @@ Add the following to your `<head>` in any html file:
 />
 <link
     rel="stylesheet"
-    href="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
+    href="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
 />
 <script
     type="module"
-    src="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
+    src="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
 ></script>
 ```
 


### PR DESCRIPTION
## Brief Description

The `unpkg` tool is no longer working as expected so we are replacing it with `jsdelivr`

## JIRA Link

https://rocketcom.atlassian.net/browse/AP-400?linkSource=email

## Related Issue

## General Notes

I created an "astro-playground" on my personal git hub. For some reason I could not push to a new repository created under the Rocket account.

https://github.com/brothhammer/astro-playground

If you pull that repo you can run with the "Liver Server" plugin for VS code by right clicking in the file and selecting run with Live Server.
![image](https://github.com/user-attachments/assets/f4faf19a-36f0-4b39-a60b-cccd58b6001c)

After we merge this we need to properly deploy StoryBook. The instructions for that can be found in Confluence here
https://rocketcom.atlassian.net/wiki/spaces/AS11/pages/3740565534/Astro+Deployment+Instructions

## Motivation and Context

We do not want customers getting frustrated trying to follow the Quick Start instructions.

## Issues and Limitations

## Types of changes

- [ ] Non working instructions for quick start

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
