### PR TITLE
Further unpkg for jsdelivr

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@1.6.3/schema.json",
+  "$schema": "https://cdn.jsdelivr.net/npm/@changesets/config@1.6.3/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "linked": [],

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -14,7 +14,7 @@
   "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
-  "unpkg": "dist/astro-web-components/astro-web-components.esm.js",
+  "jsdelivr": "dist/astro-web-components/astro-web-components.esm.js",
   "files": [
     "dist/",
     "loader/"

--- a/packages/web-components/src/components/rux-accordion/test/holster/index.html
+++ b/packages/web-components/src/components/rux-accordion/test/holster/index.html
@@ -23,7 +23,6 @@
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"
         />
-        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
     </head>
     <body>
         <!-- PARTS TESTING -->

--- a/packages/web-components/src/components/rux-breadcrumb/test/basic/index.html
+++ b/packages/web-components/src/components/rux-breadcrumb/test/basic/index.html
@@ -19,11 +19,6 @@
         ></script>
 
         <link rel="stylesheet" href="../../../../../src/global/test.css" />
-
-        <!-- <script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script> -->
     </head>
 
     <body>

--- a/packages/web-components/src/components/rux-breadcrumb/test/holster/index.html
+++ b/packages/web-components/src/components/rux-breadcrumb/test/holster/index.html
@@ -23,10 +23,6 @@
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"
         />
-        <!-- <script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script> -->
     </head>
     <body>
         <!-- PARTS TESTING -->

--- a/packages/web-components/src/components/rux-button/test/holster/index.html
+++ b/packages/web-components/src/components/rux-button/test/holster/index.html
@@ -23,7 +23,6 @@
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"
         />
-        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
     </head>
 
     <body class="dark-theme">

--- a/packages/web-components/src/components/rux-card/test/holster/index.html
+++ b/packages/web-components/src/components/rux-card/test/holster/index.html
@@ -23,10 +23,6 @@
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"
         />
-        <!-- <script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script> -->
     </head>
 
     <body style="background: var(--color-background-surface-default)">

--- a/packages/web-components/src/components/rux-checkbox-group/test/holster/index.html
+++ b/packages/web-components/src/components/rux-checkbox-group/test/holster/index.html
@@ -23,10 +23,6 @@
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"
         />
-        <!-- <script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script> -->
     </head>
     <body>
         <section>

--- a/packages/web-components/src/components/rux-checkbox/test/holster/index.html
+++ b/packages/web-components/src/components/rux-checkbox/test/holster/index.html
@@ -23,10 +23,6 @@
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"
         />
-        <!--<script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script>-->
     </head>
 
     <body class="dark-theme">

--- a/packages/web-components/src/components/rux-classification-marking/test/holster/index.html
+++ b/packages/web-components/src/components/rux-classification-marking/test/holster/index.html
@@ -23,11 +23,6 @@
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"
         />
-
-        <!-- <script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script> -->
     </head>
     <body>
         <!-- <ftl-belt file-id="xn47jC9ZYiOita8mXjmghp">

--- a/packages/web-components/src/components/rux-clock/test/holster/index.html
+++ b/packages/web-components/src/components/rux-clock/test/holster/index.html
@@ -23,10 +23,6 @@
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"
         />
-        <!-- <script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script> -->
     </head>
 
     <body>

--- a/packages/web-components/src/components/rux-container/test/index.html
+++ b/packages/web-components/src/components/rux-container/test/index.html
@@ -19,8 +19,6 @@
         ></script>
         <script nomodule src="/build/astro-web-components.js"></script>
 
-        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
-
         <!-- <link
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"

--- a/packages/web-components/src/components/rux-dialog/test/index.html
+++ b/packages/web-components/src/components/rux-dialog/test/index.html
@@ -19,11 +19,6 @@
         ></script>
         <script nomodule src="/build/astro-web-components.js"></script>
 
-        <!-- <script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script> -->
-
         <!-- <link
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"

--- a/packages/web-components/src/components/rux-global-status-bar/test/index.html
+++ b/packages/web-components/src/components/rux-global-status-bar/test/index.html
@@ -27,10 +27,6 @@
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
         />
-        <!-- <script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script> -->
     </head>
 
     <body>

--- a/packages/web-components/src/components/rux-input/test/index.html
+++ b/packages/web-components/src/components/rux-input/test/index.html
@@ -27,7 +27,6 @@
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"
         />
-        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
     </head>
 
     <body class="dark-theme">

--- a/packages/web-components/src/components/rux-log/test/index.html
+++ b/packages/web-components/src/components/rux-log/test/index.html
@@ -27,10 +27,6 @@
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
         /> -->
-        <!-- <script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script> -->
         <style>
             #filterInput {
                 margin: 2rem;

--- a/packages/web-components/src/components/rux-monitoring-icon/test/index.html
+++ b/packages/web-components/src/components/rux-monitoring-icon/test/index.html
@@ -27,10 +27,6 @@
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
         />
-        <!-- <script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script> -->
     </head>
     <body>
         <rux-monitoring-icon

--- a/packages/web-components/src/components/rux-notification/test/index.html
+++ b/packages/web-components/src/components/rux-notification/test/index.html
@@ -27,7 +27,6 @@
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
         />
-        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
         <style></style>
     </head>
 

--- a/packages/web-components/src/components/rux-pop-up/test/index.html
+++ b/packages/web-components/src/components/rux-pop-up/test/index.html
@@ -27,7 +27,6 @@
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
         />
-        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
     </head>
 
     <body>

--- a/packages/web-components/src/components/rux-progress/test/index.html
+++ b/packages/web-components/src/components/rux-progress/test/index.html
@@ -27,10 +27,6 @@
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
         />
-        <!-- <script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script> -->
     </head>
 
     <body>

--- a/packages/web-components/src/components/rux-push-button/test/index.html
+++ b/packages/web-components/src/components/rux-push-button/test/index.html
@@ -27,7 +27,6 @@
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
         />
-        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
     </head>
     <body class="dark-theme">
         <div style="padding: 10%; display: flex; justify-content: center">

--- a/packages/web-components/src/components/rux-segmented-button/test/index.html
+++ b/packages/web-components/src/components/rux-segmented-button/test/index.html
@@ -23,7 +23,6 @@
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"
         />
-        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
     </head>
 
     <body>

--- a/packages/web-components/src/components/rux-select/test/index.html
+++ b/packages/web-components/src/components/rux-select/test/index.html
@@ -23,10 +23,6 @@
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"
         />
-        <!-- <script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script> -->
         <style>
             body {
                 padding-left: 2rem;

--- a/packages/web-components/src/components/rux-slider/test/index.html
+++ b/packages/web-components/src/components/rux-slider/test/index.html
@@ -27,7 +27,6 @@
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
         />
-        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script>  -->
     </head>
 
     <body class="dark-theme">

--- a/packages/web-components/src/components/rux-status/test/index.html
+++ b/packages/web-components/src/components/rux-status/test/index.html
@@ -26,7 +26,7 @@
 
         <script
             type="module"
-            src="https://cdn.jsdelivr.net/npm.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
+            src="https://cdn.jsdelivr.net/npm/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
         ></script>
     </head>
 

--- a/packages/web-components/src/components/rux-status/test/index.html
+++ b/packages/web-components/src/components/rux-status/test/index.html
@@ -26,7 +26,7 @@
 
         <script
             type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
+            src="https://cdn.jsdelivr.net/npm.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
         ></script>
     </head>
 

--- a/packages/web-components/src/components/rux-table/test/index.html
+++ b/packages/web-components/src/components/rux-table/test/index.html
@@ -27,7 +27,6 @@
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
         />
-        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script>  -->
     </head>
 
     <body class="dark-theme">

--- a/packages/web-components/src/components/rux-textarea/test/index.html
+++ b/packages/web-components/src/components/rux-textarea/test/index.html
@@ -28,10 +28,6 @@
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
         />
-        <!-- <script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script>-->
     </head>
 
     <body class="dark-theme">

--- a/packages/web-components/src/components/rux-timeline/rux-time-region/test/holster/index.html
+++ b/packages/web-components/src/components/rux-timeline/rux-time-region/test/holster/index.html
@@ -23,7 +23,6 @@
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"
         />
-        <!--<script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script>-->
     </head>
 
     <body>

--- a/packages/web-components/src/components/rux-toast-stack/test/basic/index.html
+++ b/packages/web-components/src/components/rux-toast-stack/test/basic/index.html
@@ -27,7 +27,6 @@
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
         />
-        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
         <style>
             rux-card {
                 margin: 0.5rem;

--- a/packages/web-components/src/components/rux-toast-stack/test/index.html
+++ b/packages/web-components/src/components/rux-toast-stack/test/index.html
@@ -27,7 +27,6 @@
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
         />
-        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
         <style>
             rux-card {
                 margin: 0.5rem;

--- a/packages/web-components/src/components/rux-toast/test/basic/index.html
+++ b/packages/web-components/src/components/rux-toast/test/basic/index.html
@@ -27,7 +27,6 @@
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
         />
-        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
         <style>
             rux-card {
                 margin-inline: 0.5rem;

--- a/packages/web-components/src/components/rux-toast/test/index.html
+++ b/packages/web-components/src/components/rux-toast/test/index.html
@@ -27,7 +27,6 @@
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
         />
-        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
         <style>
             rux-card {
                 margin-inline: 0.5rem;

--- a/packages/web-components/src/components/rux-tooltip/test/index.html
+++ b/packages/web-components/src/components/rux-tooltip/test/index.html
@@ -41,7 +41,6 @@
             rel="stylesheet"
             href="../../../../../dist/astro-web-components/astro-web-components.css"
         /> -->
-        <!-- <script type="module" src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"></script> -->
         <link rel="stylesheet" href="../../../../../src/global/test.css" />
         <link
             rel="stylesheet"

--- a/packages/web-components/src/components/rux-tree/test/index.html
+++ b/packages/web-components/src/components/rux-tree/test/index.html
@@ -28,10 +28,6 @@
             rel="stylesheet"
             href="../../../../../src/global/test-reset.css"
         />
-        <!-- <script
-            type="module"
-            src="https://unpkg.com/@rocketmark/figma-testing-library/dist/figma-testing-library/figma-testing-library.esm.js"
-        ></script> -->
     </head>
 
     <body>

--- a/packages/web-components/src/stories/astro-sandboxes/forms/html/index.html
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/html/index.html
@@ -12,11 +12,11 @@
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
+            href="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
         />
         <script
             type="module"
-            src="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
+            src="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
         ></script>
         <style>
             form > div {

--- a/packages/web-components/src/stories/astro-sandboxes/forms/svelte/basic/public/index.html
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/svelte/basic/public/index.html
@@ -12,11 +12,11 @@
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
+            href="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
         />
         <script
             type="module"
-            src="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
+            src="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
         ></script>
     </head>
 

--- a/packages/web-components/src/stories/astro-sandboxes/forms/svelte/validation/public/index.html
+++ b/packages/web-components/src/stories/astro-sandboxes/forms/svelte/validation/public/index.html
@@ -12,11 +12,11 @@
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
+            href="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
         />
         <script
             type="module"
-            src="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
+            src="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
         ></script>
     </head>
 

--- a/packages/web-components/src/stories/astro-sandboxes/sign-in/index.html
+++ b/packages/web-components/src/stories/astro-sandboxes/sign-in/index.html
@@ -13,11 +13,11 @@
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
+            href="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
         />
         <script
             type="module"
-            src="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
+            src="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
         ></script>
         <noscript>
             <style type="text/css">

--- a/packages/web-components/src/stories/astro-sandboxes/themes/ag-grid/index.html
+++ b/packages/web-components/src/stories/astro-sandboxes/themes/ag-grid/index.html
@@ -12,7 +12,7 @@
         />
         <link
             rel="stylesheet"
-            href="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
+            href="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
         />
     </head>
 

--- a/packages/web-components/src/stories/frameworks/javascript.mdx
+++ b/packages/web-components/src/stories/frameworks/javascript.mdx
@@ -20,11 +20,11 @@ Add the following inside your head tag
 />
 <link
     rel="stylesheet"
-    href="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
+    href="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css"
 />
 <script
     type="module"
-    src="https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
+    src="https://cdn.jsdelivr.net/npm/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
 ></script>
 ```
 


### PR DESCRIPTION
## Brief Description

`unpkg` has been unreliable. This PR switches this repo to `jsdelivr`

## JIRA Link

https://rocketcom.atlassian.net/browse/AP-400?linkSource=email

## Related Issue

This is the second PR for this change. The first was done to change the customer facing instructions. 
https://github.com/RocketCommunicationsInc/astro/pull/1378

## General Notes

- removed all commented out instances of `unpkg`
- included screen shots of the script tags loading correctly

## Motivation and Context

We want to be consistent and only rely on one package for ease of maintenance and reliability.

## Issues and Limitations

## Types of changes

- [ ] Maintenance

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
