### PR TITLE
Add theme toggle to component stories

### DIFF
--- a/packages/web-components/.storybook/preview.js
+++ b/packages/web-components/.storybook/preview.js
@@ -50,30 +50,6 @@ export const parameters = {
     a11y: {
         element: '#root',
     },
-    globalTypes: {
-      theme: {
-        description: 'Global theme for components',
-        toolbar: {
-          // The label to show for this toolbar item
-          title: 'Theme',
-          icon: 'circlehollow',
-          // Array of plain string values or MenuItem shape (see below)
-          items: ['light', 'dark'],
-          // Change title based on selected value
-          dynamicTitle: true,
-        },
-      },
-    },
-    initialGlobals: {
-      theme: 'dark',
-    },
-    themes: {
-        default: 'Dark Theme',
-        list: [
-            { name: 'Light Theme', class: 'light-theme', color: '#eceff4' },
-            { name: 'Dark Theme', class: 'dark-theme', color: '#192635' },
-        ],
-    },
     readme: {
         codeTheme: 'duotone-sea',
         theme: {
@@ -109,4 +85,32 @@ export const parameters = {
         },
     },
 }
-export const tags = ['autodocs'];
+
+export const tags = ['autodocs']
+
+export const globalTypes = {
+    theme: {
+        name: 'Theme',
+        description: 'Global theme for components',
+        defaultValue: 'dark',
+        toolbar: {
+            icon: 'circlehollow',
+            items: [
+                { value: 'light', icon: 'sun', title: 'Light Theme' },
+                { value: 'dark', icon: 'moon', title: 'Dark Theme' },
+            ],
+            showName: true,
+        },
+    },
+}
+
+// Add a decorator to apply the theme class
+export const decorators = [
+    (Story, context) => {
+        // Apply the selected theme class
+        const theme = context.globals.theme
+        document.body.className =
+            theme === 'light' ? 'light-theme' : 'dark-theme'
+        return Story()
+    },
+]


### PR DESCRIPTION
## Brief Description

The theme switcher for light and dark theme has not been available for some time.

## JIRA Link

https://rocketcom.atlassian.net/jira/software/projects/AP/boards/119?assignee=712020%3A6a79a1e3-7381-4656-9516-c09792ad18be%2C60e2c268bd7f5d006886d1bf%2C712020%3A58e256f4-325a-4523-ae75-89831b3bbeab&selectedIssue=AP-447

## Related Issue

## General Notes

I think this was lost in the last major rev of StoryBook. It was only setup code that needed an adjustment.

## Motivation and Context

We want StoryBook users to be able to see the light-theme version of components

## Issues and Limitations

## Types of changes

- [x] Bug fix

