### PR TITLE
Add `ul` and `li` parts to segmented-button

### DIFF
--- a/.changeset/tough-months-drop.md
+++ b/.changeset/tough-months-drop.md
@@ -1,0 +1,11 @@
+---
+"@astrouxds/angular": patch
+"@astrouxds/astro-web-components": patch
+"angular-workspace": patch
+"astro-angular": patch
+"astro-react": patch
+"astro-vue": patch
+"@astrouxds/react": patch
+---
+
+Add li and ul parts to segmented buttons

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   setup:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     # timeout-minutes: 8
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   setup:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     # timeout-minutes: 8
     steps:
       - uses: actions/checkout@v2

--- a/packages/web-components/src/components/rux-segmented-button/readme.md
+++ b/packages/web-components/src/components/rux-segmented-button/readme.md
@@ -63,9 +63,11 @@ document.addEventListener('change', (e) =>
 
 ## Shadow Parts
 
-| Part      | Description                       |
-| --------- | --------------------------------- |
-| `"label"` | the label of rux-segmented-button |
+| Part      | Description                                            |
+| --------- | ------------------------------------------------------ |
+| `"label"` | the label of rux-segmented-button                      |
+| `"li"`    | the list item element of the rux-segmented-button      |
+| `"ul"`    | the unordered list element of the rux-segmented-button |
 
 
 ----------------------------------------------

--- a/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
+++ b/packages/web-components/src/components/rux-segmented-button/rux-segmented-button.tsx
@@ -1,19 +1,22 @@
 import {
+    Component,
+    Element,
     Event,
-    Watch,
     EventEmitter,
     Prop,
-    Element,
-    Component,
+    Watch,
     h,
 } from '@stencil/core'
+
 import { SegmentedButton } from './rux-segmented-button.model'
 
 // Used to give each segmented button element a unique name, which allows for proper tabbing.
 let name = 0
 
 /**
- * @part label - the label of rux-segmented-button
+ * @part ul - The unordered list element of the rux-segmented-button
+ * @part li - The list item element of the rux-segmented-button
+ * @part label - The label of rux-segmented-button
  */
 @Component({
     tag: 'rux-segmented-button',
@@ -139,9 +142,10 @@ export class RuxSegmentedButton {
                     'rux-segmented-button--small': this.size === 'small',
                     'rux-segmented-button--large': this.size === 'large',
                 }}
+                part="ul"
             >
                 {this.data.map((item) => (
-                    <li class="rux-segmented-button__segment">
+                    <li class="rux-segmented-button__segment" part="li">
                         <input
                             type="radio"
                             name={this.segBtnName}


### PR DESCRIPTION
## Brief Description

This PR adds CSS shadow parts to the `<ul>` and `<li>` elements of `<rux-segmented-button>`. 
This was added due to it being difficult to have the `<rux-segmented-button>` fill it's parents width, as you couldn't set the width on the `<ul>` or `<li>` elements in the shadow-dom.

NOTE: this PR updates the ubuntu version used by github actions to 22.04. 20.04 was deprecated, and 24.04 doesn't work with playwright's dependencies yet. 

## JIRA Link

## Related Issue

## General Notes

Raised by @dgwiltjer when he was trying to make segmented-button fit the width of its parent container. There is a work around, but it involves semi-complex CSS using container queries - adding parts makes this easier and covers more use cases. 

## Motivation and Context

Allows for more control over the size of the button portions of segmented button. 

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
