### PR TITLE
include -story suffix

### DIFF
--- a/packages/web-components/src/stories/popup.mdx
+++ b/packages/web-components/src/stories/popup.mdx
@@ -11,7 +11,7 @@ A Pop Up provides users with a quick way to access common actions for a highligh
 
 * [Astro UXDS: Pop Up](http://www.astrouxds.com/library/pop-up)
 
-<Canvas of={PopupStories.Default} />
+<Canvas of={PopupStories.DefaultStory} />
 
 ## API
 

--- a/packages/web-components/src/stories/popup.stories.js
+++ b/packages/web-components/src/stories/popup.stories.js
@@ -1,6 +1,6 @@
-import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
-import { html } from 'lit-html';
-import { withActions } from '@storybook/addon-actions/decorator';
+import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil'
+import { html } from 'lit-html'
+import { withActions } from '@storybook/addon-actions/decorator'
 
 const Base = (args) => {
     return html`
@@ -89,7 +89,7 @@ export default {
     decorators: [withActions],
 }
 
-export const Default = {
+export const DefaultStory = {
     render: Base.bind(),
 
     args: {


### PR DESCRIPTION
## Brief Description

The default pop up story is not being rendered on the AstorUXDS site.

## JIRA Link

(https://rocketcom.atlassian.net/jira/software/projects/AP/boards/119?assignee=712020%3A6a79a1e3-7381-4656-9516-c09792ad18be%2C60e2c268bd7f5d006886d1bf&selectedIssue=AP-489)

## Related Issue

## General Notes

This could also be fixed in the AstroUXDS repo by removing the -story suffix. I think it is better to update here to keep the expected -story suffix. Looking at the breadcrumb story set up which works you would expect the Pop Up to work as well. **Files of interest for comparison `breadcrumb.mdx` and `breadcrumb.stories.js`**

- The -story suffix is added by Storybook for MDX Canvas references.
- If the CSF export is named `DefaultStory`, the ID matches what MDX expects.
- If the CSF export is named `Default`, Storybook is inconsistent in its mapping and inclusion of the `-story` suffix
- Breadcrumb happens to work because Storybook is mapped `Default` to `DefaultStory`
- Pop Up did not work until renaming the export to `DefautlStory`, which matched what MDX expected

If we are going to expect a `-story` suffix we should use `DefaultStory` to not rely on the internals of StoryBook to add the suffix for us since it appears unreliable. 

## How to Test

From the `asto-web-components` directory run `npm run start.storybook`

Then visit
http://localhost:6006/?path=/story/components-pop-up--default-story

Once this is merged and StoryBook is re-deployed the IFrame here 
https://www.astrouxds.com/patterns/pop-up-menu/
Should work

## Motivation and Context

Bug Fix

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers -> Chrome, Safari, Fire Fox
