### PR TITLE
Mj.tab style

### DIFF
--- a/.changeset/healthy-spies-train.md
+++ b/.changeset/healthy-spies-train.md
@@ -1,0 +1,11 @@
+---
+"@astrouxds/angular": minor
+"@astrouxds/astro-web-components": minor
+"angular-workspace": minor
+"astro-angular": minor
+"astro-react": minor
+"astro-vue": minor
+"@astrouxds/react": minor
+---
+
+Add compact property to rux-tabs

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -19983,6 +19983,10 @@ export namespace Components {
     }
     interface RuxTabs {
         /**
+          * Changes the style of the tabs and decreases their overall size
+         */
+        "compact": boolean;
+        /**
           * If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses.
          */
         "small"?: boolean;
@@ -55627,6 +55631,10 @@ declare namespace LocalJSX {
         "selected"?: boolean;
     }
     interface RuxTabs {
+        /**
+          * Changes the style of the tabs and decreases their overall size
+         */
+        "compact"?: boolean;
         /**
           * Fires whenever a new tab is selected, and emits the selected tab on the event.detail.
          */

--- a/packages/web-components/src/components/rux-container/rux-container.scss
+++ b/packages/web-components/src/components/rux-container/rux-container.scss
@@ -87,6 +87,9 @@
     background: var(--color-background-surface-header);
     padding: 0 var(--spacing-4) calc(var(--spacing-1) + 2px) var(--spacing-4); //0 16px 6px 16px
 }
+.rux-container__tab-bar-compact {
+    padding: 0;
+}
 
 .rux-container__toolbar {
     background: var(--color-background-surface-header);

--- a/packages/web-components/src/components/rux-container/rux-container.tsx
+++ b/packages/web-components/src/components/rux-container/rux-container.tsx
@@ -1,4 +1,5 @@
-import { State, Component, Host, h, Element } from '@stencil/core'
+import { Component, Element, Host, State, h } from '@stencil/core'
+
 import { hasSlot } from '../../utils/utils'
 
 /**
@@ -23,6 +24,8 @@ import { hasSlot } from '../../utils/utils'
 export class RuxContainer {
     @Element() el!: HTMLRuxContainerElement
 
+    private hasCompactTabs: boolean = false
+
     @State() activeSlots = {
         header: false,
         'tab-bar': false,
@@ -39,6 +42,13 @@ export class RuxContainer {
     ) {
         const show = hasSlot(this.el, slotName)
         this.activeSlots = { ...this.activeSlots, [slotName]: show }
+        console.log(this.activeSlots, 'active slots')
+        if (this.activeSlots['tab-bar']) {
+            const tabs = this.el.querySelector('rux-tabs')
+            if (tabs?.hasAttribute('compact')) {
+                this.hasCompactTabs = true
+            }
+        }
     }
     render() {
         return (
@@ -62,6 +72,8 @@ export class RuxContainer {
                         class={{
                             'rux-container__tab-bar': true,
                             hidden: !this.activeSlots['tab-bar'],
+                            'rux-container__tab-bar-compact': this
+                                .hasCompactTabs,
                         }}
                         part="tab-bar"
                     >

--- a/packages/web-components/src/components/rux-tabs/readme.md
+++ b/packages/web-components/src/components/rux-tabs/readme.md
@@ -103,9 +103,10 @@ Astro UXDS Tab (child) properties are passed as simple attributes on the individ
 
 ## Properties
 
-| Property | Attribute | Description                                                                                      | Type                   | Default     |
-| -------- | --------- | ------------------------------------------------------------------------------------------------ | ---------------------- | ----------- |
-| `small`  | `small`   | If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses. | `boolean \| undefined` | `undefined` |
+| Property  | Attribute | Description                                                                                      | Type                   | Default     |
+| --------- | --------- | ------------------------------------------------------------------------------------------------ | ---------------------- | ----------- |
+| `compact` | `compact` | Changes the style of the tabs and decreases their overall size                                   | `boolean`              | `false`     |
+| `small`   | `small`   | If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses. | `boolean \| undefined` | `undefined` |
 
 
 ## Events

--- a/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
+++ b/packages/web-components/src/components/rux-tabs/rux-tab/rux-tab.scss
@@ -23,6 +23,36 @@
     }
 }
 
+:host([compact]) {
+    .rux-tab {
+        height: 36px;
+        border: 1px solid transparent;
+        // margin-top: 8px;
+        font-weight: 400;
+        font-size: 16px;
+        line-height: 24px;
+        min-height: 28px;
+        padding: 0 16px;
+        &:hover {
+            background-color: var(--color-background-interactive-muted);
+            color: white;
+            border-radius: 3px 3px 0 0;
+        }
+    }
+    .rux-tab--small {
+        height: 28px;
+    }
+    .rux-tab--selected {
+        background-color: var(--color-background-surface-default);
+        border: 1px solid var(--color-background-interactive-muted);
+        border-bottom: 1px solid var(--color-background-surface-default);
+        border-radius: 3px 3px 0 0;
+        &:hover {
+            color: var(--color-text-interactive-hover);
+            background-color: var(--color-background-interactive-muted);
+        }
+    }
+}
 :host([hidden]) {
     display: none;
 }

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.scss
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.scss
@@ -18,3 +18,10 @@
 :host([hidden]) {
     display: none;
 }
+:host([compact]) {
+    align-items: end;
+    // background-color: var(--color-background-base-header);
+    box-shadow: inset 0px -1px var(--color-background-interactive-muted);
+    padding: 0 16px;
+    gap: 4px;
+}

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
@@ -1,15 +1,16 @@
 /* eslint react/jsx-no-bind: 0 */ // --> OFF
+
 import {
     Component,
-    Host,
-    h,
-    State,
-    Prop,
     Element,
-    Listen,
     Event,
     EventEmitter,
+    Host,
+    Listen,
+    Prop,
+    State,
     Watch,
+    h,
 } from '@stencil/core'
 
 /**
@@ -35,6 +36,8 @@ export class RuxTabs {
      * If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses.
      */
     @Prop() small?: boolean
+
+    @Prop() compact: boolean = false
 
     // This allows us to hear the selected prop change on tab.
     // Once we hear it, we need to update the related panels visibilty accordingly.
@@ -88,6 +91,15 @@ export class RuxTabs {
         }
     }
 
+    @Watch('compact')
+    handleCompact() {
+        if (this._tabs) {
+            this._tabs.forEach((tab: HTMLRuxTabElement) =>
+                tab.setAttribute('compact', '')
+            )
+        }
+    }
+
     @Listen('keydown')
     onKeydown(e: any) {
         // Get all tabs inside of the tab group and then
@@ -128,6 +140,11 @@ export class RuxTabs {
 
     connectedCallback() {
         this._addTabs()
+        if (this._tabs && this.compact) {
+            this._tabs.forEach((tab: HTMLRuxTabElement) =>
+                tab.setAttribute('compact', '')
+            )
+        }
     }
 
     componentWillUpdate() {

--- a/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
+++ b/packages/web-components/src/components/rux-tabs/rux-tabs.tsx
@@ -37,6 +37,9 @@ export class RuxTabs {
      */
     @Prop() small?: boolean
 
+    /**
+     * Changes the style of the tabs and decreases their overall size
+     */
     @Prop() compact: boolean = false
 
     // This allows us to hear the selected prop change on tab.

--- a/packages/web-components/src/stories/tabs.mdx
+++ b/packages/web-components/src/stories/tabs.mdx
@@ -63,6 +63,12 @@ The small property may be passed as a simple attribute on the Astro UXDS Tabs co
 
 <Canvas of={TabsStories.Small} />
 
+## Compact
+
+The compact property changes the style of rux-tabs to provide a different look and more space.
+
+<Canvas of={TabsStories.Compact} />
+
 ## Cherry Picking
 
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:

--- a/packages/web-components/src/stories/tabs.stories.js
+++ b/packages/web-components/src/stories/tabs.stories.js
@@ -1,6 +1,6 @@
-import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil';
-import { html } from 'lit-html';
-import { withActions } from '@storybook/addon-actions/decorator';
+import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil'
+import { html } from 'lit-html'
+import { withActions } from '@storybook/addon-actions/decorator'
 
 const Base = (args) => {
     return html`
@@ -79,6 +79,38 @@ const SmallExample = (args) => {
     `
 }
 
+const CompactExample = (args) => {
+    return html`
+        <div style="display: flex; flex-flow: column;">
+            <div
+                style="border: rgba(255,255,255, .25) dashed 1px; margin: 1vw 1vw 0; padding: 2px;"
+            >
+                <rux-tabs
+                    id="tab-set-id-1"
+                    ?small="${args.small}"
+                    ?compact="${args.compact}"
+                >
+                    <rux-tab id="tab-id-1">Tab 1 title</rux-tab>
+                    <rux-tab id="tab-id-2">Tab 2 title</rux-tab>
+                    <rux-tab id="tab-id-3">Tab 3 title</rux-tab>
+                </rux-tabs>
+
+                <rux-tab-panels aria-labelledby="tab-set-id-1">
+                    <rux-tab-panel aria-labelledby="tab-id-1"
+                        >Tab 1 HTML content</rux-tab-panel
+                    >
+                    <rux-tab-panel aria-labelledby="tab-id-2"
+                        >Tab 2 HTML content</rux-tab-panel
+                    >
+                    <rux-tab-panel aria-labelledby="tab-id-3"
+                        >Tab 3 HTML content</rux-tab-panel
+                    >
+                </rux-tab-panels>
+            </div>
+        </div>
+    `
+}
+
 export default {
     title: 'Components/Tabs',
     component: 'rux-tabs',
@@ -104,6 +136,7 @@ export const Default = {
 
     args: {
         small: false,
+        compact: false,
     },
 }
 
@@ -113,5 +146,16 @@ export const Small = {
 
     args: {
         small: true,
+        compact: false,
+    },
+}
+
+export const Compact = {
+    render: CompactExample.bind(),
+    name: 'Compact',
+
+    args: {
+        small: false,
+        compact: true,
     },
 }


### PR DESCRIPTION
## Brief Description

Adds a `compact` prop to `rux-tabs` that allows for the [compact tab styling](https://www.figma.com/design/9gMquz9RpfIfkK4V2HZjic/New-Tab-Bars?node-id=1-328&t=pjTL47o0s5Iw114D-0).

## Motivation and Context

Update tabs to match designs in community file.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [x] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
