### PR TITLE
Docs: Remove Controlled references from Classification Storybook page (eventual breaking change)

### DIFF
--- a/packages/web-components/src/stories/classification-marking.mdx
+++ b/packages/web-components/src/stories/classification-marking.mdx
@@ -9,8 +9,6 @@ Classification and Control Markings are required for digital products created fo
 
 For the most up-to-date policies, see the [ISOO Training Aids](https://www.archives.gov/isoo/training/training-aids) for classification marking policies and the [CUI Registry](https://www.archives.gov/cui) for control marking policies. In addition to these requirements, each government agency may have their own rules to use for Classification and Control Markings.
 
-> NOTE: 'CUI' and 'Controlled' markings are semantically the same. It is up to your organization's preference to decide which one to use.
-
 ## Guidelines
 
 * [Astro UXDS: Classification Markings](https://astrouxds.com/components/classification-markings/)
@@ -32,7 +30,6 @@ import { Classification } from '@astrouxds/astro-web-components'
 ```
  type Classification =
     | 'cui'
-    | 'controlled'
     | 'confidential'
     | 'secret'
     | 'top-secret'
@@ -61,8 +58,6 @@ When using the Classification Marking component as a wrapper with slotted childr
 ### All Tag Variants
 
 By default Classification Markings are rendered in banner format. Applying the `tag` property attribute sets the marking type. The `tag` attribute property defines the Classification Marking as a Tag.
-
-> NOTE: The 'Controlled' marking will always display as 'CUI' when using the Tag property.
 
 <Canvas of={ClassificationMarkingStories.AllTagVariants} />
 


### PR DESCRIPTION
We need to remove the Controlled option from the classification markings since that option was removed by the government in a December 2024 update. Starting the process off by removing it from the documentation portion of Storybook to practice my Storybook editing.

## Brief Description

Begin the removal of Controlled classification marking options from Astro since it is no longer allowed by the government. Other tickets/PRs will be for removing Controlled from the WWW files and from the components.

## JIRA Link

https://rocketcom.atlassian.net/browse/AP-557

## Related Issue

## General Notes

## Motivation and Context

The government made an update to classification marking guidance in December 2024 that removes the option of Controlled for CUI markings.

## Issues and Limitations

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
