### PR TITLE
Add sign in modal and overlay to obscure content until Auth0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base = "."
-  publish = "packages/web-components/storybook-static"
+  publish = "packages/web-components/www"
   command = "npm run build.web-comps"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base = "."
   publish = "packages/web-components/storybook-static"
-  command = "npm run build.web-comps && cd packages/web-components && npm run build.storybook"
+  command = "npm run build.web-comps"
 
 [build.environment]
   NODE_VERSION = "18"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,6 @@
 [build]
   base = "."
-  publish = "packages/web-components/www"
-  command = "npm run build.web-comps"
-
+  publish = "packages/web-components/storybook-static"
+  command = "npm run build.web-comps && cd packages/web-components && npm run build.storybook"
 [build.environment]
   NODE_VERSION = "18"

--- a/packages/web-components/.storybook/auth-client.js
+++ b/packages/web-components/.storybook/auth-client.js
@@ -1,0 +1,269 @@
+import { createAuth0Client } from '@auth0/auth0-spa-js'
+
+class Auth0Manager {
+    constructor() {
+        this.auth0 = null
+        this.user = null
+        this.isAuthenticated = false
+        this.isInitialized = false
+        this.clientId = null
+        this.domain = null
+        this.confirmed = false
+        this.listeners = new Set()
+    }
+
+    async init() {
+        if (this.isInitialized) return
+
+        try {
+            const domain =
+                document.querySelector('meta[name="auth0-domain"]')?.content ||
+                process.env.STORYBOOK_AUTH0_DOMAIN ||
+                'your-domain.auth0.com'
+            const clientId =
+                document.querySelector('meta[name="auth0-client-id"]')
+                    ?.content ||
+                process.env.STORYBOOK_AUTH0_CLIENT_ID ||
+                'your-client-id'
+            this.clientId = clientId
+            this.domain = domain
+
+            this.auth0 = await createAuth0Client({
+                domain,
+                clientId,
+                authorizationParams: {
+                    redirect_uri: window.location.origin,
+                    audience: `https://${domain}/api/v2/`,
+                },
+                cacheLocation: 'localstorage',
+                useRefreshTokens: true,
+            })
+
+            this.isAuthenticated = await this.auth0.isAuthenticated()
+
+            if (this.isAuthenticated) {
+                this.user = await this.auth0.getUser()
+            }
+
+            // Try to read ID token claims; only mark "confirmed" when we have a valid id token
+            try {
+                const claims = await this.auth0.getIdTokenClaims()
+                if (claims && claims.exp && typeof claims.exp === 'number') {
+                    this.confirmed = claims.exp * 1000 > Date.now()
+                } else {
+                    this.confirmed = !!claims
+                }
+            } catch (e) {
+                this.confirmed = false
+            }
+
+            this.isInitialized = true
+            this.notifyListeners()
+            this.updateUI()
+        } catch (err) {
+            // Keep console error to help debugging in Storybook
+            // but don't throw so Storybook still renders
+            // eslint-disable-next-line no-console
+            console.error('Storybook Auth0 init error:', err)
+        }
+    }
+
+    async login() {
+        if (!this.auth0) await this.init()
+
+        try {
+            await this.auth0.loginWithPopup()
+            this.isAuthenticated = await this.auth0.isAuthenticated()
+            if (this.isAuthenticated) this.user = await this.auth0.getUser()
+
+            // After popup, attempt to read ID token claims to mark confirmed
+            try {
+                const claims = await this.auth0.getIdTokenClaims()
+                if (claims && claims.exp && typeof claims.exp === 'number') {
+                    this.confirmed = claims.exp * 1000 > Date.now()
+                } else {
+                    this.confirmed = !!claims
+                }
+            } catch (e) {
+                this.confirmed = false
+            }
+
+            this.notifyListeners()
+            this.updateUI()
+        } catch (error) {
+            if (error?.error === 'cancelled') {
+                // user cancelled popup
+            } else {
+                // eslint-disable-next-line no-console
+                console.error('Storybook Auth0 login error:', error)
+            }
+        }
+    }
+
+    async logout(options = {}) {
+        if (!this.auth0) return
+        try {
+            // Default to federated logout (clear IdP SSO) unless explicitly disabled
+            const doFederated = options.federated !== false
+            const logoutParams = {
+                returnTo: options.returnTo || window.location.origin,
+            }
+            if (doFederated) logoutParams.federated = true
+
+            // Clear client-side cache/state first so UI doesn't think we're still logged in
+            try {
+                const ls = window && window.localStorage
+                if (ls) {
+                    const keys = Object.keys(ls)
+                    keys.forEach((k) => {
+                        if (!k) return
+                        const lower = k.toLowerCase()
+                        if (
+                            lower.includes('auth0') ||
+                            lower.includes('spajs') ||
+                            lower.includes('@@auth0spajs@@') ||
+                            (this.clientId && k.includes(this.clientId))
+                        ) {
+                            try {
+                                ls.removeItem(k)
+                            } catch (e) {
+                                /* ignore */
+                            }
+                        }
+                    })
+                }
+            } catch (cleanupErr) {
+                // ignore localStorage cleanup failures
+            }
+
+            // Clear internal state and notify UI immediately
+            this.isAuthenticated = false
+            this.user = null
+            this.confirmed = false
+            this.notifyListeners()
+            this.updateUI()
+
+            // For federated logout, navigate the top-level window to Auth0's logout endpoint
+            if (doFederated && this.domain && this.clientId) {
+                try {
+                    const returnTo = logoutParams.returnTo
+                    const logoutUrl = `https://${
+                        this.domain
+                    }/v2/logout?client_id=${encodeURIComponent(
+                        this.clientId
+                    )}&returnTo=${encodeURIComponent(returnTo)}`
+                    // Try to navigate the top window (prevents nested storybook inside iframe)
+                    if (window.top && window.top !== window) {
+                        window.top.location.href = logoutUrl
+                        return
+                    }
+                } catch (navErr) {
+                    // fallback to SDK logout below
+                }
+            }
+
+            // Fallback: call SDK logout which will redirect inside the current context
+            await this.auth0.logout({ logoutParams })
+        } catch (err) {
+            // eslint-disable-next-line no-console
+            console.error('Storybook Auth0 logout error:', err)
+        }
+    }
+
+    async getUser() {
+        if (!this.isAuthenticated) return null
+        return this.user
+    }
+
+    isLoggedIn() {
+        return this.isAuthenticated
+    }
+
+    subscribe(cb) {
+        this.listeners.add(cb)
+        return () => this.listeners.delete(cb)
+    }
+
+    notifyListeners() {
+        this.listeners.forEach((cb) =>
+            cb({
+                isAuthenticated: this.isAuthenticated,
+                user: this.user,
+                isInitialized: this.isInitialized,
+                confirmed: this.confirmed,
+            })
+        )
+        try {
+            // Inform the Storybook manager (parent window) about auth state so it can lock UI
+            if (window.parent && window.parent !== window) {
+                window.parent.postMessage(
+                    {
+                        type: 'storybook-auth',
+                        payload: {
+                            isAuthenticated: this.isAuthenticated,
+                            confirmed: this.confirmed,
+                        },
+                    },
+                    '*'
+                )
+            }
+        } catch (e) {
+            // ignore
+        }
+    }
+
+    updateUI() {
+        const loginButtons = document.querySelectorAll('[data-auth-login]')
+        const logoutButtons = document.querySelectorAll('[data-auth-logout]')
+        const userInfo = document.querySelectorAll('[data-auth-user]')
+        const protectedContent = document.querySelectorAll(
+            '[data-auth-protected]'
+        )
+        const loginPrompts = document.querySelectorAll(
+            '[data-auth-login-prompt]'
+        )
+
+        loginButtons.forEach((btn) => {
+            btn.style.display = this.isAuthenticated ? 'none' : 'block'
+            if (!this.isAuthenticated)
+                btn.addEventListener('click', () => this.login())
+        })
+
+        logoutButtons.forEach((btn) => {
+            btn.style.display = this.isAuthenticated ? 'block' : 'none'
+            if (this.isAuthenticated)
+                btn.addEventListener('click', () => this.logout())
+        })
+
+        userInfo.forEach((el) => {
+            if (this.isAuthenticated && this.user) {
+                el.textContent = this.user.name || this.user.email || 'User'
+                el.style.display = 'block'
+            } else {
+                el.style.display = 'none'
+            }
+        })
+
+        protectedContent.forEach((el) => {
+            el.style.display = this.isAuthenticated ? 'block' : 'none'
+        })
+
+        loginPrompts.forEach((el) => {
+            el.style.display = this.isAuthenticated ? 'none' : 'block'
+        })
+
+        window.dispatchEvent(
+            new CustomEvent('authStateChanged', {
+                detail: {
+                    isAuthenticated: this.isAuthenticated,
+                    user: this.user,
+                    confirmed: this.confirmed,
+                },
+            })
+        )
+    }
+}
+
+const manager = new Auth0Manager()
+window.storybookAuthManager = manager
+export default manager

--- a/packages/web-components/.storybook/manager-addon-logout/index.js
+++ b/packages/web-components/.storybook/manager-addon-logout/index.js
@@ -1,0 +1,221 @@
+import React, { useEffect } from 'react'
+import { addons, types } from '@storybook/addons'
+
+const ADDON_ID = 'auth-logout-addon'
+const PANEL_ID = `${ADDON_ID}/panel`
+
+function LogoutButton() {
+    useEffect(() => {
+        // no-op; kept for parity if we want to subscribe to channels later
+    }, [])
+
+    function handleClick() {
+        try {
+            const preview =
+                document.getElementById('storybook-preview-iframe') ||
+                document.querySelector('iframe[src*="iframe.html"]')
+            const msg = {
+                type: 'storybook-manager-logout',
+                payload: { federated: true },
+            }
+            if (preview && preview.contentWindow)
+                preview.contentWindow.postMessage(msg, '*')
+            else window.postMessage(msg, '*')
+        } catch (e) {
+            // ignore
+        }
+    }
+
+    return React.createElement(
+        'button',
+        {
+            id: 'sb-manager-logout-react',
+            className: 'sb-manager-logout-btn',
+            onClick: handleClick,
+            style: {
+                display: 'block',
+                width: '100%',
+                boxSizing: 'border-box',
+                margin: '8px 12px',
+            },
+        },
+        'Log out'
+    )
+}
+
+// Register the addon and inject a manager-side logout button into the sidebar
+addons.register(ADDON_ID, () => {
+    // Create a native DOM button and insert it into the Storybook sidebar.
+    // We intentionally avoid relying on the manager toolbar APIs (types.TOOL)
+    // because those place controls in the top toolbar. This code inserts
+    // the button below the search field in the left nav, matching the
+    // project's desired layout and CSS selectors in `manager.css`.
+
+    let observer = null
+
+    function postLogoutMessage() {
+        try {
+            const preview =
+                document.getElementById('storybook-preview-iframe') ||
+                document.querySelector('iframe[src*="iframe.html"]')
+            const msg = {
+                type: 'storybook-manager-logout',
+                payload: { federated: true },
+            }
+            if (preview && preview.contentWindow)
+                preview.contentWindow.postMessage(msg, '*')
+            else window.postMessage(msg, '*')
+        } catch (e) {
+            // ignore
+        }
+    }
+
+    function createSidebarButton() {
+        // Prefer to place immediately after the search field if present
+        const searchEl =
+            document.querySelector('.sidebar-container .search-field') ||
+            document.querySelector('.sidebar-header')
+        // See if a button already exists (from previous runs). If so, we'll reuse/move it.
+        const existingBtn = document.getElementById('sb-manager-logout-dom')
+        const sidebarContainer =
+            document.querySelector('.sidebar-container') ||
+            document.querySelector('nav')
+
+        const btn =
+            existingBtn ||
+            (function () {
+                const n = document.createElement('button')
+                n.id = 'sb-manager-logout-dom'
+                n.className = 'sb-manager-logout-btn'
+                n.textContent = 'Log out'
+                n.style.display = 'block'
+                n.style.width = '100%'
+                n.style.margin = '0'
+                // If the parent uses flex layout, force the button to its own row
+                n.style.flexBasis = '100%'
+                n.style.flexShrink = '0'
+                n.style.alignSelf = 'stretch'
+                n.style.minWidth = '0'
+                n.style.order = '2'
+                n.addEventListener('click', postLogoutMessage)
+                return n
+            })()
+
+        // If an existing button was inside the search wrapper, detach it so we can move it
+        if (existingBtn && existingBtn.parentNode)
+            existingBtn.parentNode.removeChild(existingBtn)
+
+        // If we found a search element, insert after its container so the
+        // logout button sits on its own line (prevents crowding the input).
+        if (searchEl) {
+            // prefer inserting a dedicated wrapper after the search wrapper
+            const searchWrapper = searchEl.parentNode || searchEl
+            try {
+                // Create or reuse a container that will always be a sibling after the search wrapper
+                let container = document.getElementById(
+                    'sb-manager-logout-container'
+                )
+                if (!container) {
+                    container = document.createElement('div')
+                    container.id = 'sb-manager-logout-container'
+                    // styling: ensure block and spacing; leave detailed styling to CSS
+                    container.style.display = 'block'
+                    container.style.width = '100%'
+                    container.style.padding = '6px 12px 12px'
+                }
+
+                // If the container is not the correct sibling, insert it after the wrapper
+                if (searchWrapper && searchWrapper.insertAdjacentElement) {
+                    // If container is already in DOM but not after searchWrapper, move it
+                    if (
+                        container.parentNode &&
+                        container.parentNode !== searchWrapper.parentNode
+                    ) {
+                        container.parentNode.removeChild(container)
+                    }
+                    // Insert container directly after the searchWrapper so it is not nested inside it
+                    if (!searchWrapper.nextSibling)
+                        searchWrapper.parentNode.appendChild(container)
+                    else
+                        searchWrapper.insertAdjacentElement(
+                            'afterend',
+                            container
+                        )
+                }
+
+                // Append or move the button into the container
+                if (btn.parentNode !== container) container.appendChild(btn)
+
+                if (observer) observer.disconnect()
+                return true
+            } catch (e) {
+                // ignore and fallthrough to other strategies
+            }
+        }
+
+        // Otherwise append to the top of the sidebar container
+        if (sidebarContainer) {
+            // try to insert after the header if present
+            const header = sidebarContainer.querySelector('.sidebar-header')
+            if (header && header.parentNode) {
+                if (header.nextSibling)
+                    header.parentNode.insertBefore(btn, header.nextSibling)
+                else header.parentNode.appendChild(btn)
+                if (observer) observer.disconnect()
+                return true
+            }
+
+            // fallback: append to container
+            sidebarContainer.appendChild(btn)
+            if (observer) observer.disconnect()
+            return true
+        }
+
+        return false
+    }
+
+    // Try to create immediately in case sidebar is already rendered
+    if (!createSidebarButton()) {
+        // Observe DOM and attempt to insert when sidebar becomes available
+        observer = new MutationObserver(() => {
+            // Try to create the button if missing, and always ensure placement
+            createSidebarButton()
+            ensurePlacement()
+        })
+        observer.observe(document.documentElement || document.body, {
+            childList: true,
+            subtree: true,
+        })
+    }
+
+    // Ensure the button is placed after the search wrapper, even if other code
+    // re-parented it into the search container. This runs after insertions.
+    function ensurePlacement() {
+        const btn = document.getElementById('sb-manager-logout-dom')
+        if (!btn) return
+
+        const searchEl =
+            document.querySelector('.sidebar-container .search-field') ||
+            document.querySelector('.sidebar-header')
+        if (!searchEl) return
+
+        const searchWrapper = searchEl.parentNode || searchEl
+        const insertionPoint = searchWrapper.parentNode || searchWrapper
+        if (!insertionPoint) return
+
+        // If the button is currently inside the searchWrapper (or its descendants), move it
+        if (searchWrapper.contains(btn)) {
+            try {
+                // detach then insert after the wrapper
+                if (btn.parentNode) btn.parentNode.removeChild(btn)
+                if (searchWrapper.nextSibling)
+                    insertionPoint.insertBefore(btn, searchWrapper.nextSibling)
+                else insertionPoint.appendChild(btn)
+            } catch (e) {
+                // ignore placement errors
+            }
+        }
+    }
+})
+
+export default {}

--- a/packages/web-components/.storybook/manager-head.html
+++ b/packages/web-components/.storybook/manager-head.html
@@ -17,3 +17,24 @@
     href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@100;300;400&family=Roboto:wght@100;300;400;500;700;900&display=swap"
     rel="stylesheet"
 />
+
+<script>
+    // Listen for auth events coming from the preview iframe
+    window.addEventListener('message', (ev) => {
+        try {
+            const msg = ev && ev.data
+            if (!msg || msg.type !== 'storybook-auth') return
+
+            const { isAuthenticated } = msg.payload || {}
+            const root =
+                document.getElementById('storybook-root') || document.body
+            if (!isAuthenticated) {
+                root.classList.add('sb-leftnav-locked')
+            } else {
+                root.classList.remove('sb-leftnav-locked')
+            }
+        } catch (e) {
+            // ignore
+        }
+    })
+</script>

--- a/packages/web-components/.storybook/manager-head.html
+++ b/packages/web-components/.storybook/manager-head.html
@@ -38,3 +38,34 @@
         }
     })
 </script>
+
+<script>
+    // When the manager loads, ask the preview iframe to ensure the auth overlay exists.
+    // This helps in docs view where the preview may not auto-run the same initialization path.
+    function requestPreviewForceOverlay() {
+        try {
+            const previewIframe =
+                document.getElementById('storybook-preview-iframe') ||
+                document.querySelector('iframe[src*="iframe.html"]')
+            if (!previewIframe || !previewIframe.contentWindow) return
+            // Post a one-time message to the preview to ask it to create/force the auth overlay
+            previewIframe.contentWindow.postMessage(
+                { type: 'storybook-manager-force-overlay' },
+                '*'
+            )
+            // Also request auth state if preview can reply
+            previewIframe.contentWindow.postMessage(
+                { type: 'storybook-manager-request-auth-state' },
+                '*'
+            )
+        } catch (err) {
+            // ignore silently
+        }
+    }
+
+    // Try once on load; also try after a short delay in case frames are still initializing
+    window.addEventListener('load', () => {
+        requestPreviewForceOverlay()
+        setTimeout(requestPreviewForceOverlay, 1500)
+    })
+</script>

--- a/packages/web-components/.storybook/manager.css
+++ b/packages/web-components/.storybook/manager.css
@@ -1,222 +1,229 @@
 /* sidebar outer wrapper */
 .sidebar-container .css-d3imve {
-  padding-left: 0;
-  padding-right: 0;
+    padding-left: 0;
+    padding-right: 0;
 }
 
 /* search input */
 .sidebar-container .search-field {
-  margin-inline: 1rem;
+    margin-inline: 1rem;
 }
 
 .sidebar-container .css-y6bzay {
-  appearance: none;
-  height: 28px;
-  padding-left: 28px;
-  padding-right: 28px;
-  border: 1px solid rgba(153 153 153 / 40%);
-  background: transparent;
-  border-radius: 28px;
-  font-size: 12px;
-  font-family: inherit;
-  transition: 150ms;
-  color: white;
+    appearance: none;
+    height: 28px;
+    padding-left: 28px;
+    padding-right: 28px;
+    border: 1px solid rgba(153 153 153 / 40%);
+    background: transparent;
+    border-radius: 28px;
+    font-size: 12px;
+    font-family: inherit;
+    transition: 150ms;
+    color: white;
 }
 
 .sidebar-container .sidebar-item {
-  font-size: 16px;
-  line-height: 20px;
-  padding-top: 3px;
-  padding-bottom: 3px;
-  border-bottom: 1px solid rgba(140 142 145 / 15%);
-  align-items: baseline;
-  font-weight: 500;
+    font-size: 16px;
+    line-height: 20px;
+    padding-top: 3px;
+    padding-bottom: 3px;
+    border-bottom: 1px solid rgba(140 142 145 / 15%);
+    align-items: baseline;
+    font-weight: 500;
 }
 
 .sidebar-item .css-caedy5,
 .sidebar-item .css-154pbrb,
 .sidebar-item button {
-  font-size: 16px;
+    font-size: 16px;
 }
 
 /* component icon */
 .sidebar-item .css-1j7mmb8 {
- color: rgb(77 172 255);
+    color: rgb(77 172 255);
 }
 
 /* drop down caret & active caret */
 .sidebar-container .css-5ba62h,
 .sidebar-container .sidebar-item css-1yuef8z {
-  color: rgb(77 172 255);
-  border-top-width: 5px;
-  border-bottom-width: 5px;
-  border-left-width: 5px;
-  margin-right: 10px;
+    color: rgb(77 172 255);
+    border-top-width: 5px;
+    border-bottom-width: 5px;
+    border-left-width: 5px;
+    margin-right: 10px;
 }
 
 /* folder icon & grid icon */
 .sidebar-container .sidebar-item .css-1res6at,
 .sidebar-container .sidebar-item .css-12curbu {
-  display: none;
+    display: none;
 }
 
 .sidebar-header .css-l8z9zc {
-  transform: scale(1.1);
+    transform: scale(1.1);
 }
 
 .css-1d2iskc > .css-sqdry3 {
-  border: 1px solid rgba(255 255 255 / 12.5%);
+    border: 1px solid rgba(255 255 255 / 12.5%);
 }
 
 /* component list */
 
 /* only the outermost children */
 nav.sidebar-container .css-0 section > a > div {
-  padding-left: 12px;
+    padding-left: 12px;
 }
 
 nav.sidebar-container .css-0 section > a > div > span:first-child {
-  border-left-color: rgb(77 172 255);
-  border-top-width: 5px;
-  border-bottom-width: 5px;
-  border-left-width: 5px;
-  margin-right: 10px;
+    border-left-color: rgb(77 172 255);
+    border-top-width: 5px;
+    border-bottom-width: 5px;
+    border-left-width: 5px;
+    margin-right: 10px;
 }
 
 /* group icons */
 nav.sidebar-container .css-0 section > a > div > svg {
-  display: none;
+    display: none;
 }
 
 /* only the innermost children */
 nav.sidebar-container .css-0 section .css-0 > a > div {
-  padding-left: 18px;
+    padding-left: 18px;
 }
 
 nav.sidebar-container .css-0 section .css-0 > a > div > svg {
-  margin-right: 10px;
+    margin-right: 10px;
 }
 
 nav.sidebar-container .css-0 section .css-0 > a > div > span:last-child {
-  overflow: hidden;
-  text-overflow: ellipsis;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 nav.sidebar-container .css-0 section > div[type='section'] {
-  font-weight: bold;
-  margin: 0;
-  padding: 0 20px 5px;
-  border-bottom: 1px solid rgba(140 142 145 / 15%);
+    font-weight: bold;
+    margin: 0;
+    padding: 0 20px 5px;
+    border-bottom: 1px solid rgba(140 142 145 / 15%);
 }
 
 /* addons panel */
 #storybook-panel-root .css-0 a,
 #storybook-panel-root .css-0 a span {
-  color: rgb(77 172 255);
+    color: rgb(77 172 255);
 }
 
 .storybook-readme-story {
-  padding: 10px;
+    padding: 10px;
 }
 
 .storybook-readme-story p code,
 .storybook-readme-story li code {
-  background: #182635;
-  border-radius: 2px;
+    background: #182635;
+    border-radius: 2px;
 }
 
 .storybook-readme-story code[class*='language-'],
 .storybook-readme-story pre[class*='language-'] {
-  background: #060708;
-  -webkit-font-smoothing: auto;
+    background: #060708;
+    -webkit-font-smoothing: auto;
 }
 
 .storybook-readme-story .token.punctuation {
-  color: #a1acba;
+    color: #a1acba;
 }
 
 .storybook-readme-story code.language-sh,
 .storybook-readme-story code.language-xml,
 .storybook-readme-story code.language-html,
 .storybook-readme-story code.language-js {
-  color: #ccd5e0;
+    color: #ccd5e0;
 }
 
 /* component search input */
 .sidebar-container input[type='search'] {
-  color: white;
+    color: white;
 }
 
 .storybook-readme-story .markdown-body table thead tr {
-  background-color: #141f2c;
+    background-color: #141f2c;
 }
 
 /* theme switcher icon color override */
 .css-c3junj .css-ynalaq {
-  color: white;
-  background: rgb(32 50 70);
+    color: white;
+    background: rgb(32 50 70);
 }
 
 /* scrollbars */
 body {
-  scrollbar-color: var(
-          --color-border-interactive-muted,
-          rgb(43 101 155)
-      )
-      var(--color-background-surface-default, rgb(27 45 62));
+    scrollbar-color: var(--color-border-interactive-muted, rgb(43 101 155))
+        var(--color-background-surface-default, rgb(27 45 62));
 }
 
 ::-webkit-scrollbar {
-  width: 16px;
-  height: 16px;
-  background-color: transparent;
+    width: 16px;
+    height: 16px;
+    background-color: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-  background-color: var(
-      --color-border-interactive-muted,
-      rgb(43 101 155)
-  );
-  border-radius: 8px;
-  border: 3px solid transparent;
-  background-clip: padding-box;
+    background-color: var(--color-border-interactive-muted, rgb(43 101 155));
+    border-radius: 8px;
+    border: 3px solid transparent;
+    background-clip: padding-box;
 }
 
 /* visually "centers" because the dark edge of the shadow gives the illusion this is offset */
 ::-webkit-scrollbar-thumb:vertical {
-  border-left-width: 4px;
+    border-left-width: 4px;
 }
 
 ::-webkit-scrollbar-thumb:horizontal {
-  border-top-width: 4px;
+    border-top-width: 4px;
 }
 
 ::-webkit-scrollbar-thumb:active,
 ::-webkit-scrollbar-thumb:hover {
-  background-color: var(
-      --color-background-interactive-default,
-      rgb(58 129 191)
-  );
+    background-color: var(
+        --color-background-interactive-default,
+        rgb(58 129 191)
+    );
 }
 
 ::-webkit-scrollbar-track,
 ::-webkit-scrollbar-corner {
-  background-color: var(--color-background-surface-default);
+    background-color: var(--color-background-surface-default);
 }
 
 ::-webkit-scrollbar-track:vertical {
-  box-shadow: inset 3px 3px 3px 0 rgba(0 0 0 / 50%);
+    box-shadow: inset 3px 3px 3px 0 rgba(0 0 0 / 50%);
 }
 
 ::-webkit-scrollbar-track:horizontal {
-  box-shadow: inset 1px 3px 3px 0 rgba(0 0 0 / 50%);
+    box-shadow: inset 1px 3px 3px 0 rgba(0 0 0 / 50%);
 }
 
 @media (min-width: 600px) {
-  .css-1nolumm {
-      grid-template-columns: minmax(0, 230px) minmax(100px, 1fr) minmax(
-              0,
-              400px
-          );
-  }
+    .css-1nolumm {
+        grid-template-columns: minmax(0, 230px) minmax(100px, 1fr) minmax(
+                0,
+                400px
+            );
+    }
+}
+
+/* When left nav is locked, dim it and prevent interactions */
+.sb-leftnav-locked .sidebar-container {
+    opacity: 0.35;
+    pointer-events: none;
+    user-select: none;
+}
+
+/* Also visually indicate the header/theme switcher is disabled */
+.sb-leftnav-locked .sidebar-header,
+.sb-leftnav-locked .css-c3junj {
+    opacity: 0.5;
 }

--- a/packages/web-components/.storybook/manager.css
+++ b/packages/web-components/.storybook/manager.css
@@ -227,3 +227,53 @@ body {
 .sb-leftnav-locked .css-c3junj {
     opacity: 0.5;
 }
+
+/* Manager logout button styling: match floating button appearance but place in sidebar */
+.sidebar-container .sb-manager-logout-btn,
+.sidebar-header .sb-manager-logout-btn {
+    display: block !important;
+    margin: 10px 12px 6px;
+    padding: 6px 10px;
+    background: var(--color-background-surface-default, rgb(11 18 32 / 90%));
+    color: var(--color-text-primary, #fff);
+    border: 1px solid rgb(255 255 255 / 8%);
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: 600;
+    text-align: center;
+    width: calc(100% - 24px);
+}
+
+/* If the button retains the floating class, neutralize fixed positioning */
+.sidebar-container .sb-manager-logout-btn.sb-auth-floating-logout {
+    position: static !important;
+    top: auto !important;
+    right: auto !important;
+    z-index: auto !important;
+}
+
+/* Defensive styles to ensure logout sits below the search input */
+#sb-manager-logout-container {
+    display: block !important;
+    width: 100% !important;
+    padding: 6px 12px 12px !important;
+}
+
+#sb-manager-logout-container .sb-manager-logout-btn,
+#sb-manager-logout-dom {
+    display: block !important;
+    width: calc(100% - 24px) !important;
+    margin: 8px 12px 12px !important;
+    box-sizing: border-box !important;
+    flex-basis: 100% !important;
+    flex-shrink: 0 !important;
+    align-self: stretch !important;
+}
+
+/* If Storybook puts the button inside the search wrapper, force it to break to a new row */
+.search-field > #sb-manager-logout-dom,
+.search-field #sb-manager-logout-dom {
+    display: block !important;
+    width: 100% !important;
+    margin-top: 8px !important;
+}

--- a/packages/web-components/.storybook/manager.js
+++ b/packages/web-components/.storybook/manager.js
@@ -1,6 +1,8 @@
 import themes from './theme'
 import { addons } from '@storybook/addons'
 import './manager.css'
+// Register the manager-side logout addon (renders a React button into the manager)
+import './manager-addon-logout'
 
 addons.setConfig({
     panelPosition: 'right',

--- a/packages/web-components/.storybook/preview-head.html
+++ b/packages/web-components/.storybook/preview-head.html
@@ -8,6 +8,9 @@
         }
     })
 </script>
+<!-- Auth0 configuration for Storybook: these can be overridden by Netlify environment or .env files -->
+<meta name="auth0-domain" content="dev-mx6z0sxk8h0nzv2j.us.auth0.com" />
+<meta name="auth0-client-id" content="LDbaXBVku69WyaJTDnNrTCT7P0GlApoZ" />
 <link
     href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@100;300;400&family=Roboto:wght@100;300;400;500;700;900&display=swap"
     rel="stylesheet"

--- a/packages/web-components/.storybook/preview.css
+++ b/packages/web-components/.storybook/preview.css
@@ -1,117 +1,211 @@
 /* stylelint-disable selector-id-pattern */
 .sbdocs.sbdocs-wrapper {
-  background: var(--color-background-base-default);
+    background: var(--color-background-base-default);
 }
 
 .sbdocs .docs-story {
-  background: var(--color-background-surface-default);
+    background: var(--color-background-surface-default);
 }
 
 .sbdocs h1 {
-  font-size: 2.125rem;
-  font-weight: 400;
-  color: var(--color-text-primary);
-  margin-block-start: 0.67em;
-  margin-block-end: 0.67em;
-  margin-inline-start: 0;
-  margin-inline-end: 0;
+    font-size: 2.125rem;
+    font-weight: 400;
+    color: var(--color-text-primary);
+    margin-block-start: 0.67em;
+    margin-block-end: 0.67em;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
 }
 
 .sbdocs h2,
 .sbdocs h3 {
-  color: var(--color-text-primary);
+    color: var(--color-text-primary);
 }
 
-.sbdocs p, .sbdocs.sbdocs-content p {
-  margin: 0 0 1rem;
-  font-size: 17px;
-  color: var(--color-text-primary);
-  font-weight: 300;
-  line-height: 1.6;
+.sbdocs p,
+.sbdocs.sbdocs-content p {
+    margin: 0 0 1rem;
+    font-size: 17px;
+    color: var(--color-text-primary);
+    font-weight: 300;
+    line-height: 1.6;
 }
 
-.sbdocs li, .sbdocs.sbdocs-content li {
-  font-size: 17px;
-  color: var(--color-text-primary);
-  font-weight: 300;
-  line-height: 1.6;
+.sbdocs li,
+.sbdocs.sbdocs-content li {
+    font-size: 17px;
+    color: var(--color-text-primary);
+    font-weight: 300;
+    line-height: 1.6;
 }
 
 .sbdocs.sbdocs-content .docblock-argstable-body a {
-  color: var(--color-background-interactive-default);
-  text-decoration: none;
+    color: var(--color-background-interactive-default);
+    text-decoration: none;
 }
 
 .sbdocs a,
 .sbdocs a p,
-.sbdocs.sbdocs-content a p
- {
-  color: var(--color-background-interactive-default);
-  text-decoration: none;
+.sbdocs.sbdocs-content a p {
+    color: var(--color-background-interactive-default);
+    text-decoration: none;
 }
 
 .sbdocs code {
-  color: var(--color-text-primary);
+    color: var(--color-text-primary);
 }
 
 .sbdocs #story--components-dialog--dialog,
 .sbdocs #story--components-modal--modal {
-  display: block;
-  min-height: 500px;
+    display: block;
+    min-height: 500px;
 }
 
 .sbdocs #story--components-dialog--dialog rux-dialog::part(container),
 .sbdocs #story--components-modal--modal rux-modal::part(wrapper) {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
 }
 
 .sbdocs #story--components-dialog--with-slots,
 .sbdocs #story--components-modal--with-slots {
-  display: block;
-  min-height: 500px;
+    display: block;
+    min-height: 500px;
 }
 
 .sbdocs #story--components-dialog--with-slots rux-dialog::part(container),
 .sbdocs #story--components-modal--with-slots rux-modal::part(wrapper) {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
 }
 
 .sbdocs .banner-text p,
 .sbdocs .banner-text code {
-  color: var(--color-text-inverse);
+    color: var(--color-text-inverse);
 }
 
 .sbdocs .css-15ysoxh .banner-text p {
-  margin-top: 1rem;
+    margin-top: 1rem;
 }
 
 .sbdocs .css-wzniqs {
-  display: flex;
-  align-items: center;
+    display: flex;
+    align-items: center;
 }
 
 .sbdocs .framework {
-  padding: 1rem;
-  text-align: center;
-  border-radius: var(--radius-base);
-  border: 1px solid var(--color-background-interactive-default);
-  cursor: pointer;
+    padding: 1rem;
+    text-align: center;
+    border-radius: var(--radius-base);
+    border: 1px solid var(--color-background-interactive-default);
+    cursor: pointer;
 }
 
-.sbdocs .framework  svg {
-  margin-bottom: 2rem;
-  width: 100px;
-  height: 100px;
+.sbdocs .framework svg {
+    margin-bottom: 2rem;
+    width: 100px;
+    height: 100px;
 }
 
 .sbdocs .framework a p {
-  font-size: 1.5rem;
+    font-size: 1.5rem;
+}
+
+/* Auth overlay to block Storybook preview until login */
+.sb-auth-overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgb(2 6 23 / 85%);
+    z-index: 99999;
+}
+
+.sb-auth-overlay-panel {
+    background: var(--color-background-surface-default, #0b1220);
+    color: var(--color-text-primary, #fff);
+    padding: 2rem;
+    border-radius: 8px;
+    max-width: 420px;
+    width: 90%;
+    text-align: center;
+    box-shadow: 0 8px 30px rgb(0 0 0 / 60%);
+}
+
+.sb-auth-overlay-panel h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1.25rem;
+}
+
+.sb-auth-overlay-info {
+    margin: 0 0 1rem;
+    opacity: 0.9;
+}
+
+.sb-auth-overlay-btn {
+    background: var(--color-background-interactive-default, #4dacff);
+    color: var(--color-text-inverse, #001);
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.sb-auth-overlay-user {
+    margin-top: 1rem;
+    font-size: 0.9rem;
+    opacity: 0.9;
+}
+
+/* When locked, blur and disable interactions on the main content */
+.sb-auth-locked body > *:not(#sb-auth-overlay) {
+    filter: blur(6px) saturate(80%);
+    pointer-events: none;
+    user-select: none;
+}
+
+/* Also ensure the canvas area is non-interactive (covers custom elements) */
+.sb-auth-locked #root,
+.sb-auth-locked #storybook-preview-iframe {
+    pointer-events: none;
+}
+
+/* But the overlay itself must stay interactive */
+#sb-auth-overlay {
+    pointer-events: auto;
+}
+
+/* Federated logout button inside overlay */
+.sb-auth-logout-btn {
+    margin-left: 0.5rem;
+    background: transparent;
+    color: var(--color-background-interactive-default, #4dacff);
+    border: 1px solid rgb(255 255 255 / 8%);
+    padding: 0.4rem 0.6rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+/* Floating logout button visible when signed in */
+.sb-auth-floating-logout {
+    position: fixed;
+    top: 12px;
+    right: 12px;
+    z-index: 100000;
+    background: var(--color-background-surface-default, rgb(11 18 32 / 90%));
+    color: var(--color-text-primary, #fff);
+    border: 1px solid rgb(255 255 255 / 8%);
+    padding: 0.4rem 0.6rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: 600;
 }

--- a/packages/web-components/.storybook/preview.js
+++ b/packages/web-components/.storybook/preview.js
@@ -42,7 +42,8 @@ function ensureAuthOverlay() {
     const newAccountLink = document.createElement('a')
     newAccountLink.className = 'sb-auth-new-account'
     newAccountLink.textContent = 'Create a new account'
-    newAccountLink.href = 'http://localhost:3000/#create-account'
+    newAccountLink.href =
+        'https://deploy-preview-437--astrouxds.netlify.app/#create-account'
     newAccountLink.target = '_blank'
     newAccountLink.rel = 'noopener noreferrer'
     newAccountLink.setAttribute('role', 'link')
@@ -84,22 +85,7 @@ function ensureAuthOverlay() {
     const rootEl = document.body || document.documentElement
     rootEl.appendChild(overlay)
 
-    // Create a floating logout button outside the overlay so it's available when stories are visible
-    const floatingLogout = document.createElement('button')
-    floatingLogout.className = 'sb-auth-floating-logout'
-    floatingLogout.textContent = 'Log out'
-    floatingLogout.style.display = 'none'
-    floatingLogout.addEventListener('click', async () => {
-        try {
-            if (window.storybookAuthManager) {
-                await window.storybookAuthManager.logout({ federated: true })
-            }
-        } catch (e) {
-            // eslint-disable-next-line no-console
-            console.error('Floating logout failed', e)
-        }
-    })
-    rootEl.appendChild(floatingLogout)
+    // Floating logout removed — manager now exposes the logout control in the left nav
 
     // Helper to toggle locked state (blur + disable interactions)
     function setLocked(locked) {
@@ -139,11 +125,9 @@ function ensureAuthOverlay() {
             federatedLogoutBtn.style.display = unlocked
                 ? 'inline-block'
                 : 'none'
-            floatingLogout.style.display = unlocked ? 'inline-block' : 'none'
         } else {
             userSpan.textContent = ''
             federatedLogoutBtn.style.display = 'none'
-            floatingLogout.style.display = 'none'
         }
     })
 
@@ -189,7 +173,6 @@ function ensureAuthOverlay() {
             federatedLogoutBtn.style.display = unlocked
                 ? 'inline-block'
                 : 'none'
-            floatingLogout.style.display = unlocked ? 'inline-block' : 'none'
         })
     }
 

--- a/packages/web-components/.storybook/preview.js
+++ b/packages/web-components/.storybook/preview.js
@@ -9,6 +9,273 @@ import './preview.css'
 import docJson from '../docs.json'
 if (docJson) setStencilDocJson(docJson)
 
+// Initialize Storybook Auth0 manager (non-blocking)
+import './auth-client'
+
+// Create an overlay that blocks the preview until the user is authenticated.
+function ensureAuthOverlay() {
+    if (document.getElementById('sb-auth-overlay')) return
+
+    const overlay = document.createElement('div')
+    overlay.id = 'sb-auth-overlay'
+    overlay.className = 'sb-auth-overlay'
+
+    const panel = document.createElement('div')
+    panel.className = 'sb-auth-overlay-panel'
+
+    const title = document.createElement('h2')
+    title.textContent = 'Please sign in to view storybook'
+
+    const info = document.createElement('p')
+    info.className = 'sb-auth-overlay-info'
+    info.textContent =
+        'Sign in with Auth0 to unlock stories and protected content.'
+
+    const loginBtn = document.createElement('button')
+    loginBtn.className = 'sb-auth-overlay-btn'
+    loginBtn.textContent = 'Sign in'
+    loginBtn.addEventListener('click', async () => {
+        if (window.storybookAuthManager)
+            await window.storybookAuthManager.login()
+    })
+
+    const newAccountLink = document.createElement('a')
+    newAccountLink.className = 'sb-auth-new-account'
+    newAccountLink.textContent = 'Create a new account'
+    newAccountLink.href = 'http://localhost:3000/#create-account'
+    newAccountLink.target = '_blank'
+    newAccountLink.rel = 'noopener noreferrer'
+    newAccountLink.setAttribute('role', 'link')
+    newAccountLink.setAttribute(
+        'aria-label',
+        'Create a new Auth0 account (opens in a new tab)'
+    )
+    newAccountLink.style.display = 'block'
+    newAccountLink.style.marginTop = '12px'
+
+    const userSpan = document.createElement('div')
+    userSpan.className = 'sb-auth-overlay-user'
+
+    // Create a small federated logout button that appears when the user is signed in
+    const federatedLogoutBtn = document.createElement('button')
+    federatedLogoutBtn.className = 'sb-auth-logout-btn'
+    federatedLogoutBtn.textContent = 'Log out (Federated)'
+    federatedLogoutBtn.style.display = 'none'
+    federatedLogoutBtn.addEventListener('click', async () => {
+        try {
+            if (window.storybookAuthManager) {
+                // call federated logout explicitly
+                await window.storybookAuthManager.logout({ federated: true })
+            }
+        } catch (e) {
+            // eslint-disable-next-line no-console
+            console.error('Federated logout failed', e)
+        }
+    })
+
+    panel.appendChild(title)
+    panel.appendChild(info)
+    panel.appendChild(loginBtn)
+    panel.appendChild(newAccountLink)
+    panel.appendChild(userSpan)
+    panel.appendChild(federatedLogoutBtn)
+    overlay.appendChild(panel)
+    // Append to body to make sure it covers Storybook's entire preview area
+    const rootEl = document.body || document.documentElement
+    rootEl.appendChild(overlay)
+
+    // Create a floating logout button outside the overlay so it's available when stories are visible
+    const floatingLogout = document.createElement('button')
+    floatingLogout.className = 'sb-auth-floating-logout'
+    floatingLogout.textContent = 'Log out'
+    floatingLogout.style.display = 'none'
+    floatingLogout.addEventListener('click', async () => {
+        try {
+            if (window.storybookAuthManager) {
+                await window.storybookAuthManager.logout({ federated: true })
+            }
+        } catch (e) {
+            // eslint-disable-next-line no-console
+            console.error('Floating logout failed', e)
+        }
+    })
+    rootEl.appendChild(floatingLogout)
+
+    // Helper to toggle locked state (blur + disable interactions)
+    function setLocked(locked) {
+        if (locked) {
+            overlay.style.display = 'flex'
+            document.documentElement.classList.add('sb-auth-locked')
+        } else {
+            overlay.style.display = 'none'
+            document.documentElement.classList.remove('sb-auth-locked')
+        }
+    }
+
+    // Inform manager (parent) of initial unauthenticated state so it can lock left nav
+    try {
+        if (window.parent && window.parent !== window) {
+            window.parent.postMessage(
+                { type: 'storybook-auth', payload: { isAuthenticated: false } },
+                '*'
+            )
+        }
+    } catch (e) {
+        // ignore
+    }
+
+    // Listen for auth state changes (use "confirmed" when available to ensure ID token exists)
+    window.addEventListener('authStateChanged', (ev) => {
+        const { isAuthenticated, user, confirmed } = ev.detail || {}
+        // Prefer confirmed (ID token present) otherwise fall back to isAuthenticated
+        const unlocked =
+            typeof confirmed === 'boolean' ? confirmed : !!isAuthenticated
+        console.log('auth event:', { isAuthenticated, confirmed, user })
+        setLocked(!unlocked)
+
+        if (user) {
+            userSpan.textContent = `Signed in as ${user.name || user.email}`
+            // show federated logout when confirmed/authenticated
+            federatedLogoutBtn.style.display = unlocked
+                ? 'inline-block'
+                : 'none'
+            floatingLogout.style.display = unlocked ? 'inline-block' : 'none'
+        } else {
+            userSpan.textContent = ''
+            federatedLogoutBtn.style.display = 'none'
+            floatingLogout.style.display = 'none'
+        }
+    })
+
+    // Listen for manager requests (e.g., logout requests) via postMessage
+    window.addEventListener('message', async (ev) => {
+        try {
+            const msg = ev && ev.data
+            if (!msg) return
+            if (msg.type === 'storybook-manager-logout') {
+                const { federated } = msg.payload || {}
+                if (window.storybookAuthManager) {
+                    await window.storybookAuthManager.logout({
+                        federated: !!federated,
+                    })
+                } else {
+                    // if manager not ready, queue action
+                    window.__pendingLogout = { federated: !!federated }
+                }
+            } else if (msg.type === 'storybook-manager-force-overlay') {
+                // request to force the overlay visible for debugging
+                if (typeof window.__forceAuthOverlay === 'function') {
+                    window.__forceAuthOverlay()
+                } else if (typeof ensureAuthOverlay === 'function') {
+                    ensureAuthOverlay()
+                }
+            }
+        } catch (e) {
+            // ignore
+        }
+    })
+
+    // Also subscribe to manager updates when available
+    if (window.storybookAuthManager) {
+        window.storybookAuthManager.subscribe((s) => {
+            const unlocked =
+                typeof s.confirmed === 'boolean'
+                    ? s.confirmed
+                    : !!s.isAuthenticated
+            setLocked(!unlocked)
+            userSpan.textContent = s.user
+                ? `Signed in as ${s.user.name || s.user.email}`
+                : ''
+            federatedLogoutBtn.style.display = unlocked
+                ? 'inline-block'
+                : 'none'
+            floatingLogout.style.display = unlocked ? 'inline-block' : 'none'
+        })
+    }
+
+    // default: locked until auth state says otherwise
+    setLocked(true)
+}
+
+// Create overlay as early as possible so it blocks content while Storybook bundles
+try {
+    // If DOM is ready, create immediately, else on DOMContentLoaded
+    if (
+        document.readyState === 'complete' ||
+        document.readyState === 'interactive'
+    ) {
+        ensureAuthOverlay()
+    } else {
+        window.addEventListener('DOMContentLoaded', ensureAuthOverlay)
+    }
+} catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to create Storybook auth overlay', e)
+}
+
+// Add debug helpers to window for easier troubleshooting
+if (typeof window !== 'undefined') {
+    window.__storybookAuthDebug = function () {
+        // eslint-disable-next-line no-console
+        console.log('storybookAuthManager', window.storybookAuthManager)
+        // eslint-disable-next-line no-console
+        console.log('overlay', document.getElementById('sb-auth-overlay'))
+    }
+
+    // Force-create an overlay for debugging (call from preview iframe console)
+    window.__forceAuthOverlay = function () {
+        try {
+            const existing = document.getElementById('sb-auth-overlay')
+            if (existing) {
+                existing.style.display = 'flex'
+                document.documentElement.classList.add('sb-auth-locked')
+                return existing
+            }
+            // reuse ensureAuthOverlay if available
+            if (typeof ensureAuthOverlay === 'function') {
+                ensureAuthOverlay()
+                const el = document.getElementById('sb-auth-overlay')
+                if (el) {
+                    el.style.display = 'flex'
+                    document.documentElement.classList.add('sb-auth-locked')
+                }
+                return el
+            }
+            return null
+        } catch (e) {
+            // eslint-disable-next-line no-console
+            console.error('forceAuthOverlay failed', e)
+            return null
+        }
+    }
+
+    window.__removeForceAuthOverlay = function () {
+        try {
+            const el = document.getElementById('sb-auth-overlay')
+            if (el) {
+                el.style.display = 'none'
+            }
+            document.documentElement.classList.remove('sb-auth-locked')
+        } catch (e) {
+            // eslint-disable-next-line no-console
+            console.error('removeForceAuthOverlay failed', e)
+        }
+    }
+}
+
+// Respect bypass flag for local dev (set STORYBOOK_AUTH_BYPASS=1 to disable overlay)
+try {
+    const bypass =
+        (process && process.env && process.env.STORYBOOK_AUTH_BYPASS) ||
+        window.__STORYBOOK_AUTH_BYPASS
+    if (bypass === '1' || bypass === 1 || bypass === true) {
+        const overlay = document.getElementById('sb-auth-overlay')
+        if (overlay) overlay.style.display = 'none'
+    }
+} catch (e) {
+    // ignore
+}
+
 export const parameters = {
     options: {
         storySort: {
@@ -111,6 +378,18 @@ export const decorators = [
         const theme = context.globals.theme
         document.body.className =
             theme === 'light' ? 'light-theme' : 'dark-theme'
+        // Ensure auth manager starts up; it's safe to call init repeatedly
+        if (
+            window.storybookAuthManager &&
+            !window.storybookAuthManager.isInitialized
+        ) {
+            // don't await here, let it initialize in the background
+            window.storybookAuthManager.init()
+        }
+
+        // Ensure overlay exists and reflect current auth state
+        ensureAuthOverlay()
+
         return Story()
     },
 ]

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@astrouxds/astro-web-components",
-  "version": "7.26.1",
+  "version": "7.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@astrouxds/astro-web-components",
-      "version": "7.26.1",
+      "version": "7.27.0",
       "license": "MIT",
       "dependencies": {
+        "@auth0/auth0-spa-js": "^2.0.0",
         "@floating-ui/dom": "~1.0.6",
         "@stencil/core": "~3.4.1",
         "date-fns": "~2.21.3",
@@ -102,6 +103,17 @@
     "node_modules/@astrouxds/tokens": {
       "version": "1.14.0",
       "dev": true
+    },
+    "node_modules/@auth0/auth0-spa-js": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.6.0.tgz",
+      "integrity": "sha512-zxqgmXObIv4V8kt6Dz2MU4lWTH72b3RL7Po5C+HDU8zCg5rm5VL/aYXIo407B0uVUIFH44ph0tusMLBoILg7kw==",
+      "license": "MIT",
+      "dependencies": {
+        "browser-tabs-lock": "^1.2.15",
+        "dpop": "^2.1.1",
+        "es-cookie": "~1.3.2"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.22.13",
@@ -4485,6 +4497,16 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/browser-tabs-lock": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.3.0.tgz",
+      "integrity": "sha512-g6nHaobTiT0eMZ7jh16YpD2kcjAp+PInbiVq3M1x6KKaEIVhT4v9oURNIpZLOZ3LQbQ3XYfNhMAb/9hzNLIWrw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": ">=4.17.21"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.23.3",
       "dev": true,
@@ -5631,6 +5653,7 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5842,6 +5865,15 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/dpop": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dpop/-/dpop-2.1.1.tgz",
+      "integrity": "sha512-J0Of2JTiM4h5si0tlbPQ/lkqfZ5wAEVkKYBhkwyyANnPJfWH4VsR5uIkZ+T+OSPIwDYUg1fbd5Mmodd25HjY1w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "dev": true,
@@ -5994,6 +6026,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-cookie": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-cookie/-/es-cookie-1.3.2.tgz",
+      "integrity": "sha512-UTlYYhXGLOy05P/vKVT2Ui7WtC7NiRzGtJyAKKn32g5Gvcjn7KAClLPWlipCtxIus934dFg9o9jXiBL0nP+t9Q==",
+      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.0",
@@ -10309,7 +10347,6 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.truncate": {
@@ -25928,6 +25965,7 @@
       "version": "8.4.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -30715,6 +30753,7 @@
       "version": "8.13.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "~1.0.6",
+    "@auth0/auth0-spa-js": "^2.0.0",
     "@stencil/core": "~3.4.1",
     "date-fns": "~2.21.3",
     "date-fns-tz": "~1.3.7"


### PR DESCRIPTION
## Brief Description

Place the Storybook manager logout control in the left sidebar under the search.

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

- Add manager-side code to render a logout control in the Storybook sidebar instead of the top toolbar.
- Create a dedicated DOM container (#sb-manager-logout-container) and append the logout button (#sb-manager-logout-dom) there.
- Use a MutationObserver and re-placement logic to keep the control correctly positioned across Storybook re-renders.
- Add CSS to force block/full-width layout and spacing so the logout button doesn’t crowd the search input.

## Motivation and Context

We want to get a better idea of who is accessing the Astro components. 

## Issues and Limitations

- Placement relies on current Storybook DOM selectors. If Storybook changes these in future versions, updates will be needed.
- implementation defends against re-renders via MutationObserver, aggressive re-parenting by any other scripts could cause issues.

## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [x] Regressions are passing and/or failures are documented
- [x] Changes have been checked in evergreen browsers
