### PR TITLE
fix: exported types for conditional exports

### DIFF
--- a/.changeset/salty-showers-dig.md
+++ b/.changeset/salty-showers-dig.md
@@ -1,0 +1,5 @@
+---
+"root": patch
+---
+
+fix: exported types for conditional exports

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -12,7 +12,10 @@
       "import": "./dist/index.cjs.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./loader": "./loader/index.js",
+    "./loader": {
+      "import": "./loader/index.js",
+      "types": "./loader/index.d.ts"
+    },
     "./dist/astro-web-components/astro-web-components.css": "./dist/astro-web-components/astro-web-components.css",
     "./components": "./dist/types/components.d.ts",
     "./components/*": "./dist/components/*"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -10,7 +10,7 @@
   "exports": {
     ".": {
       "import": "./dist/index.cjs.js",
-      "types": "./dist/types/components.d.ts"
+      "types": "./dist/types/index.d.ts"
     },
     "./loader": "./loader/index.js",
     "./dist/astro-web-components/astro-web-components.css": "./dist/astro-web-components/astro-web-components.css",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astrouxds/astro-web-components",
-  "version": "8.0.1",
+  "version": "8.0.0",
   "description": "Astro Web Components",
   "homepage": "https://astro-components.netlify.app/?path=/story/astro-uxds-welcome-start-here--page",
   "repository": {

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -13,7 +13,7 @@
       "types": "./dist/types/index.d.ts"
     },
     "./loader": {
-      "import": "./loader/index.js",
+      "import": "./loader/index.cjs.js",
       "types": "./loader/index.d.ts"
     },
     "./dist/astro-web-components/astro-web-components.css": "./dist/astro-web-components/astro-web-components.css",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astrouxds/astro-web-components",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Astro Web Components",
   "homepage": "https://astro-components.netlify.app/?path=/story/astro-uxds-welcome-start-here--page",
   "repository": {
@@ -8,7 +8,10 @@
     "url": "https://github.com/RocketCommunicationsInc/astro"
   },
   "exports": {
-    ".": "./dist/index.cjs.js",
+    ".": {
+      "import": "./dist/index.cjs.js",
+      "types": "./dist/types/components.d.ts"
+    },
     "./loader": "./loader/index.js",
     "./dist/astro-web-components/astro-web-components.css": "./dist/astro-web-components/astro-web-components.css",
     "./components": "./dist/types/components.d.ts",


### PR DESCRIPTION
## Brief Description

https://nodejs.org/api/packages.html#conditional-exports the `exports` takes precedence over the top level `types` field - as a result, typescript types are broken in v8 due to the changes in https://github.com/RocketCommunicationsInc/astro/commit/fecfc74198d16b145f42ceb67c5557d2fa10dda8#diff-7298512f791c54d2827facfc8d26ae8a5db2ac960e464e30953ccaab05dd412eR10

## JIRA Link

<!--- Please add JIRA ticket link here. -->

## Related Issue

https://github.com/RocketCommunicationsInc/astro/pull/1500 pretty sure the regression was introduced here

## General Notes

I've tested this locally using `patch-package` but I'm not sure how else to add a test for this

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] This PR adds or removes a Storybook story.
- [ ] I have added tests to cover my changes.
- [ ] Regressions are passing and/or failures are documented
- [ ] Changes have been checked in evergreen browsers
